### PR TITLE
Fix AbciQuery to support error response.

### DIFF
--- a/tendermint/src/rpc/endpoint/abci_query.rs
+++ b/tendermint/src/rpc/endpoint/abci_query.rs
@@ -58,9 +58,11 @@ impl rpc::Response for Response {}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AbciQuery {
     /// Response code
+    #[serde(default)]
     pub code: Code,
 
     /// Log value
+    #[serde(default)]
     pub log: Log,
 
     /// Info value
@@ -69,24 +71,40 @@ pub struct AbciQuery {
     /// Index
     #[serde(
         serialize_with = "serializers::serialize_i64",
-        deserialize_with = "serializers::parse_i64"
+        deserialize_with = "serializers::parse_i64",
+        default
     )]
     pub index: i64,
 
     /// Key
     // TODO(tarcieri): parse to Vec<u8>?
-    pub key: String,
+    pub key: Option<String>,
 
     /// Value
     // TODO(tarcieri): parse to Vec<u8>?
-    pub value: String,
+    pub value: Option<String>,
 
     /// Proof (if requested)
     pub proof: Option<Proof>,
 
     /// Block height
-    pub height: block::Height,
+    #[serde(default, deserialize_with = "serializers::parse_height_option")]
+    pub height: Option<block::Height>,
 
     /// Codespace
     pub codespace: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn parse_query_responses() {
+        let error_rsp = r#"{"response": {"code": 1, "log": "account lookup failed: account not found", "info": "", "index": "0", "key": null, "value": null, "proof": null, "height": "0", "codespace": ""}}"#;
+        let success_rsp = r#"{"response": {"value": "some value"}}"#;
+        serde_json::from_str::<Response>(error_rsp).expect("parse error response");
+        serde_json::from_str::<Response>(success_rsp).expect("parse success response");
+    }
 }

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -1,5 +1,6 @@
 //! Serde serializers
 
+use crate::block;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::time::Duration;
 
@@ -60,4 +61,16 @@ where
     S: Serializer,
 {
     format!("{}", duration.as_nanos()).serialize(serializer)
+}
+
+/// Parse `Height` from json, `None` if value is invalid.
+pub(crate) fn parse_height_option<'de, D>(
+    deserializer: D,
+) -> Result<Option<block::Height>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(String::deserialize(deserializer)?
+        .parse::<block::Height>()
+        .ok())
 }

--- a/tendermint/tests/rpc.rs
+++ b/tendermint/tests/rpc.rs
@@ -29,7 +29,7 @@ mod endpoints {
             .unwrap()
             .response;
 
-        assert_eq!(response.height.value(), 1);
+        assert_eq!(response.height.map_or(0, |height| height.value()), 1);
     }
 
     #[test]


### PR DESCRIPTION
For example:

`{"response": {"code": 1, "log": "account lookup failed: account not found", "info": "", "index": "0", "key": null, "value": null, "proof": null, "height  ": "0", "codespace": ""}}`