### PR TITLE
Fix serializer and deserializer not symmetric

### DIFF
--- a/tendermint/src/block.rs
+++ b/tendermint/src/block.rs
@@ -59,15 +59,18 @@ where
         pub signatures: Option<CommitSigs>,
     }
 
-    let commit = TmpCommit::deserialize(deserializer)?;
-    if commit.block_id.is_none() || commit.signatures.is_none() {
-        Ok(None)
+    if let Some(commit) = <Option<TmpCommit>>::deserialize(deserializer)? {
+        if let Some(block_id) = commit.block_id {
+            Ok(Some(Commit {
+                height: commit.height,
+                round: commit.round,
+                block_id,
+                signatures: commit.signatures.unwrap_or_else(|| CommitSigs::new(vec![])),
+            }))
+        } else {
+            Ok(None)
+        }
     } else {
-        Ok(Some(Commit {
-            height: commit.height,
-            round: commit.round,
-            block_id: commit.block_id.unwrap(),
-            signatures: commit.signatures.unwrap(),
-        }))
+        Ok(None)
     }
 }

--- a/tendermint/tests/lite.rs
+++ b/tendermint/tests/lite.rs
@@ -214,7 +214,8 @@ fn run_test_cases(cases: TestCases) {
 }
 
 fn check_symmetric_encoding<T: Serialize + for<'a> Deserialize<'a>>(value: &T) {
-    serde_json::from_str::<T>(&serde_json::to_string(value).unwrap()).expect("encoded can be decode again");
+    serde_json::from_str::<T>(&serde_json::to_string(value).unwrap())
+        .expect("encoded can be decode again");
 }
 
 // Link to the commit where the happy_path.json was created:

--- a/tendermint/tests/lite.rs
+++ b/tendermint/tests/lite.rs
@@ -1,7 +1,6 @@
 use anomaly::fail;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::{fs, path::PathBuf};
@@ -167,6 +166,7 @@ fn run_test_cases(cases: TestCases) {
         let trusted_next_vals = tc.initial.clone().next_validator_set;
         let mut latest_trusted =
             Trusted::new(tc.initial.signed_header.clone().into(), trusted_next_vals);
+        check_symmetric_encoding(&latest_trusted);
 
         let expects_err = match &tc.expected_output {
             Some(eo) => eo.eq("error"),
@@ -203,6 +203,7 @@ fn run_test_cases(cases: TestCases) {
                     assert!(!expects_err);
 
                     latest_trusted = new_state.clone();
+                    check_symmetric_encoding(&latest_trusted);
                 }
                 Err(_) => {
                     assert!(expects_err);
@@ -210,6 +211,10 @@ fn run_test_cases(cases: TestCases) {
             }
         }
     }
+}
+
+fn check_symmetric_encoding<T: Serialize + for<'a> Deserialize<'a>>(value: &T) {
+    serde_json::from_str::<T>(&serde_json::to_string(value).unwrap()).expect("encoded can be decode again");
 }
 
 // Link to the commit where the happy_path.json was created:

--- a/tendermint/tests/rpc.rs
+++ b/tendermint/tests/rpc.rs
@@ -59,6 +59,12 @@ mod endpoints {
             endpoint::block::Response::from_string(&read_json_fixture("block_with_evidences"))
                 .unwrap();
 
+        // test the symmetricity
+        serde_json::from_str::<endpoint::block::Response>(
+            &serde_json::to_string(&response).unwrap(),
+        )
+        .expect("encoded can be decode again");
+
         let tendermint::Block { evidence, .. } = response.block;
         let evidence = evidence.iter().next().unwrap();
         match evidence {
@@ -88,6 +94,12 @@ mod endpoints {
         let response =
             endpoint::block::Response::from_string(&read_json_fixture("first_block")).unwrap();
 
+        // test the symmetricity
+        serde_json::from_str::<endpoint::block::Response>(
+            &serde_json::to_string(&response).unwrap(),
+        )
+        .expect("encoded can be decode again");
+
         let tendermint::Block {
             header,
             data,
@@ -109,6 +121,7 @@ mod endpoints {
         let response =
             endpoint::block_results::Response::from_string(&read_json_fixture("block_results"))
                 .unwrap();
+
         assert_eq!(response.height.value(), 1814);
 
         let validator_updates = response.validator_updates;


### PR DESCRIPTION
These deserializers intents to parse some empty data as `None`, because golang version of tendermint would encode these empty values as some default values.
But since the serializers would encode `None` as `null`, which makes them not symmetric.
So the solution is make these deserializers also support decoding `null` as `None`.