### PR TITLE
Update secp address hash

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -55,6 +55,7 @@ thiserror = "1"
 toml = { version = "0.5" }
 uuid = { version = "0.8", default-features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
+ripemd160 = "0.8.0"
 
 [dev-dependencies]
 serde_json = "1"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -55,7 +55,7 @@ thiserror = "1"
 toml = { version = "0.5" }
 uuid = { version = "0.8", default-features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
-ripemd160 = "0.8.0"
+ripemd160 = "0.8"
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

I just manually created a test vector since I couldn't use the go tendermint vector (I didn't look into what the extra address bytes were there and assumed that's handled somewhere else here)

Want me to add this in CHANGES.md?

Edit: Everything passes on stable and nightly toolchain locally, and I can't see why CI failed for some reason

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGES.md
