### PR TITLE
Fix build on master

### DIFF
--- a/light-node/Cargo.toml
+++ b/light-node/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 gumdrop = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
-tendermint = { version = "0.12.0-rc0", path = "../tendermint" }
+tendermint = { version = "0.13.0-dev", path = "../tendermint" }
 async-trait = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 abscissa_tokio = "0.5"


### PR DESCRIPTION
We forgot to bump the version of tendermint in the light-node crate. 
Closes #224 

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
