### PR TITLE
Update `signatory` requirement to v0.19

### DIFF
--- a/light-node/Cargo.toml
+++ b/light-node/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 gumdrop = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
-tendermint = { version = "0.12.0-rc0", path = "../tendermint" }
+tendermint = { version = "0.13.0-dev", path = "../tendermint" }
 async-trait = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 abscissa_tokio = "0.5"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -45,9 +45,9 @@ prost-amino-derive = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 sha2 = { version = "0.8", default-features = false }
-signatory = { version = "0.18", features = ["ed25519", "ecdsa"] }
-signatory-dalek = "0.18"
-signatory-secp256k1 = "0.18"
+signatory = { version = "0.19", features = ["ed25519", "ecdsa"] }
+signatory-dalek = "0.19"
+signatory-secp256k1 = "0.19"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tai64 = { version = "3", features = ["chrono"] }


### PR DESCRIPTION
This release of `signatory` uses the v1.0 releases of the `ed25519` and `signature` crates. Release announcement for those here:

https://www.reddit.com/r/rust/comments/g4w8by/ann_rustcrypto_signature_v10_and_ed25519_v10/

It also eliminates the needless dependencies on the `p256` and `p384` crates, which `tendermint-rs` doesn't use (it only uses the `k256` crate for the secp256k1 curve definition).