### PR TITLE
Release/v0.13.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
-## Pending [0.13.0] (dev)
+## [0.13.0] (2020-04-20)
+
+Dependencies:
+
+- Update `signatory` requirement to v0.19 ([#227])
+
+[0.13.0]: https://github.com/informalsystems/tendermint-rs/pull/228
+[#227]: https://github.com/informalsystems/tendermint-rs/pull/227
 
 ## [0.12.0] (2020-04-17)
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.13.0-dev" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.13.0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/interchainio/tendermint-rs/tree/master/tendermint"

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -15,7 +15,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.13.0-dev"
+    html_root_url = "https://docs.rs/tendermint/0.13.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
Dependencies:

- Update `signatory` requirement to v0.19 ([#227])

[0.13.0]: https://github.com/informalsystems/tendermint-rs/pull/228
[#227]: https://github.com/informalsystems/tendermint-rs/pull/227