### PR TITLE
Fix block_id of nil vote

### DIFF
--- a/tendermint/src/lite_impl/signed_header.rs
+++ b/tendermint/src/lite_impl/signed_header.rs
@@ -98,6 +98,7 @@ fn non_absent_votes(commit: &block::Commit) -> Vec<vote::Vote> {
         let extracted_validator_address;
         let extracted_timestamp;
         let extracted_signature;
+        let block_id;
         match commit_sig {
             CommitSig::BlockIDFlagAbsent { .. } => continue,
             CommitSig::BlockIDFlagCommit {
@@ -108,6 +109,7 @@ fn non_absent_votes(commit: &block::Commit) -> Vec<vote::Vote> {
                 extracted_validator_address = validator_address;
                 extracted_timestamp = timestamp;
                 extracted_signature = signature;
+                block_id = Some(commit.block_id.clone());
             }
             CommitSig::BlockIDFlagNil {
                 validator_address,
@@ -117,13 +119,14 @@ fn non_absent_votes(commit: &block::Commit) -> Vec<vote::Vote> {
                 extracted_validator_address = validator_address;
                 extracted_timestamp = timestamp;
                 extracted_signature = signature;
+                block_id = None;
             }
         }
         votes.push(vote::Vote {
             vote_type: vote::Type::Precommit,
             height: commit.height,
             round: commit.round,
-            block_id: Option::from(commit.block_id.clone()),
+            block_id,
             timestamp: *extracted_timestamp,
             validator_address: *extracted_validator_address,
             validator_index: u64::try_from(i)

--- a/tendermint/tests/lite.rs
+++ b/tendermint/tests/lite.rs
@@ -237,7 +237,7 @@ fn run_single_step_tests(dir: &str) {
             .any(|failing_case| fp_str.ends_with(failing_case))
         {
             println!("Skipping JSON test: {}", fp_str);
-            return;
+            continue;
         }
         println!(
             "Running light client against 'single-step' test-file:\n {}",


### PR DESCRIPTION
The block_id of nil vote should be `None`, otherwise, the signature verify fails.