### PR TITLE
Temporary JSON test fixes

### DIFF
--- a/tendermint/tests/support/lite/single_step_sequential/commit_tests.json
+++ b/tendermint/tests/support/lite/single_step_sequential/commit_tests.json
@@ -1337,8 +1337,8 @@
                 {
                   "block_id_flag": 1,
                   "validator_address": "01F527D77D3FFCC4FCFF2DDC2952EEA5414F2A33",
-                  "timestamp": "2019-11-02T15:04:15Z",
-                  "signature": "+RfrcWlUSRm70Q68sVhXzChztdLHu50T3DLTYPQXTG4YQdCaK89Uer6tsSAdUe3gNx3TbKL0sXN6QNWyUBWHDg=="
+                  "timestamp": null,
+                  "signature": null
                 },
                 {
                   "block_id_flag": 2,
@@ -1599,8 +1599,8 @@
               "signatures": [
                 {
                   "block_id_flag": 1,
-                  "validator_address": "",
-                  "timestamp": "0001-01-01T00:00:00Z",
+                  "validator_address": "01F527D77D3FFCC4FCFF2DDC2952EEA5414F2A33",
+                  "timestamp": null,
                   "signature": null
                 },
                 {

--- a/tendermint/tests/support/lite/single_step_skipping/commit_tests.json
+++ b/tendermint/tests/support/lite/single_step_skipping/commit_tests.json
@@ -147,8 +147,8 @@
                 {
                   "block_id_flag": 1,
                   "validator_address": "01F527D77D3FFCC4FCFF2DDC2952EEA5414F2A33",
-                  "timestamp": "2019-11-02T15:04:20Z",
-                  "signature": "cynkKHMj7Q+4HpeSMntB0XgpvEciMKgYb/twD0/QEl7aotW2gXrCxCFMgw1ph5KvVEWRRrjSGC7IJTrHV9y2DQ=="
+                  "timestamp": null,
+                  "signature": null
                 },
                 {
                   "block_id_flag": 2,
@@ -409,8 +409,8 @@
               "signatures": [
                 {
                   "block_id_flag": 1,
-                  "validator_address": "",
-                  "timestamp": "0001-01-01T00:00:00Z",
+                  "validator_address": "01F527D77D3FFCC4FCFF2DDC2952EEA5414F2A33",
+                  "timestamp": null,
                   "signature": null
                 },
                 {


### PR DESCRIPTION

I have only made quick fixes to the failing commit tests because `timestamp` serialization needs to be fixed on the Go side. For now, I've changed it to `null` so that it parses. 

Also, there is a confusion whether `validator_address` is optional or not for an absent CommitSig ([comment](https://github.com/informalsystems/tendermint-rs/pull/248#discussion_r419794099))
* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
