### PR TITLE
Serialization refactor step 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Serialization:
 - [#248] Refactor serializers library to use modules and give a nicer annotation to structs.
+-        Implemented deserialization of null value for Vec<u8>
 
 ## [0.13.0] (2020-04-20)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Pending
+
+Serialization:
+- [#248] Refactor serializers library to use modules and give a nicer annotation to structs.
+
 ## [0.13.0] (2020-04-20)
 
 Dependencies:

--- a/tendermint/src/abci/proof.rs
+++ b/tendermint/src/abci/proof.rs
@@ -19,18 +19,10 @@ pub struct ProofOp {
     #[serde(alias = "type")]
     pub field_type: String,
     /// Key of the ProofOp
-    #[serde(
-        default,
-        serialize_with = "serializers::serialize_base64",
-        deserialize_with = "serializers::parse_base64"
-    )]
+    #[serde(default, with = "serializers::bytes::base64string")]
     pub key: Vec<u8>,
     /// Actual data
-    #[serde(
-        default,
-        serialize_with = "serializers::serialize_base64",
-        deserialize_with = "serializers::parse_base64"
-    )]
+    #[serde(default, with = "serializers::bytes::base64string")]
     pub data: Vec<u8>,
 }
 

--- a/tendermint/src/block.rs
+++ b/tendermint/src/block.rs
@@ -49,10 +49,7 @@ where
     #[derive(Deserialize)]
     struct TmpCommit {
         pub height: Height,
-        #[serde(
-            serialize_with = "serializers::serialize_u64",
-            deserialize_with = "serializers::parse_u64"
-        )]
+        #[serde(with = "serializers::primitives::string")]
         pub round: u64,
         #[serde(deserialize_with = "serializers::parse_non_empty_block_id")]
         pub block_id: Option<Id>,

--- a/tendermint/src/block/commit.rs
+++ b/tendermint/src/block/commit.rs
@@ -17,10 +17,7 @@ pub struct Commit {
     pub height: Height,
 
     /// Round
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub round: u64,
 
     /// Block ID

--- a/tendermint/src/block/header.rs
+++ b/tendermint/src/block/header.rs
@@ -45,10 +45,7 @@ pub struct Header {
     pub consensus_hash: Hash,
 
     /// State after txs from the previous block
-    #[serde(
-        serialize_with = "serializers::serialize_hex",
-        deserialize_with = "serializers::parse_hex"
-    )]
+    #[serde(with = "serializers::bytes::hexstring")]
     pub app_hash: Vec<u8>,
 
     /// Root hash of all results from the txs from the previous block
@@ -70,17 +67,11 @@ pub struct Header {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct Version {
     /// Block version
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub block: u64,
 
     /// App version
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub app: u64,
 }
 

--- a/tendermint/src/block/parts.rs
+++ b/tendermint/src/block/parts.rs
@@ -10,10 +10,7 @@ use {
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Header {
     /// Number of parts in this block
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub total: u64,
 
     /// Hash of the parts set header,

--- a/tendermint/src/block/size.rs
+++ b/tendermint/src/block/size.rs
@@ -9,16 +9,10 @@ use {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Size {
     /// Maximum number of bytes in a block
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub max_bytes: u64,
 
     /// Maximum amount of gas which can be spent on a block
-    #[serde(
-        serialize_with = "serializers::serialize_i64",
-        deserialize_with = "serializers::parse_i64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub max_gas: i64,
 }

--- a/tendermint/src/channel.rs
+++ b/tendermint/src/channel.rs
@@ -15,35 +15,19 @@ pub struct Channel {
     pub id: Id,
 
     /// Capacity of the send queue
-    #[serde(
-        rename = "SendQueueCapacity",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "SendQueueCapacity", with = "serializers::primitives::string")]
     pub send_queue_capacity: u64,
 
     /// Size of the send queue
-    #[serde(
-        rename = "SendQueueSize",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "SendQueueSize", with = "serializers::primitives::string")]
     pub send_queue_size: u64,
 
     /// Priority value
-    #[serde(
-        rename = "Priority",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "Priority", with = "serializers::primitives::string")]
     pub priority: u64,
 
     /// Amount of data recently sent
-    #[serde(
-        rename = "RecentlySent",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "RecentlySent", with = "serializers::primitives::string")]
     pub recently_sent: u64,
 }
 

--- a/tendermint/src/consensus/state.rs
+++ b/tendermint/src/consensus/state.rs
@@ -18,10 +18,7 @@ pub struct State {
     pub height: block::Height,
 
     /// Current consensus round
-    #[serde(
-        serialize_with = "serializers::serialize_i64",
-        deserialize_with = "serializers::parse_i64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub round: i64,
 
     /// Current consensus step

--- a/tendermint/src/evidence.rs
+++ b/tendermint/src/evidence.rs
@@ -70,10 +70,7 @@ impl AsRef<[Evidence]> for Data {
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct Params {
     /// Maximum allowed age for evidence to be collected
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub max_age_num_blocks: u64,
 
     /// Max age duration
@@ -84,13 +81,7 @@ pub struct Params {
 /// essentially, to keep the usages look cleaner
 /// i.e. you can avoid using serde annotations everywhere
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct Duration(
-    #[serde(
-        serialize_with = "serializers::serialize_duration",
-        deserialize_with = "serializers::parse_duration"
-    )]
-    std::time::Duration,
-);
+pub struct Duration(#[serde(with = "serializers::timeduration::string")] std::time::Duration);
 
 impl From<Duration> for std::time::Duration {
     fn from(d: Duration) -> std::time::Duration {

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -39,7 +39,7 @@ pub mod node;
 pub mod private_key;
 pub mod public_key;
 pub mod rpc;
-mod serializers;
+pub mod serializers;
 pub mod signature;
 pub mod time;
 mod timeout;

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -90,15 +90,9 @@ pub trait TrustThreshold: Copy + Clone + Debug + Serialize + DeserializeOwned {
 /// [`TrustThreshold`] which can be passed into all relevant methods.
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TrustThresholdFraction {
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     numerator: u64,
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     denominator: u64,
 }
 

--- a/tendermint/src/node/info.rs
+++ b/tendermint/src/node/info.rs
@@ -36,24 +36,15 @@ pub struct Info {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProtocolVersionInfo {
     /// P2P protocol version
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub p2p: u64,
 
     /// Block version
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub block: u64,
 
     /// App version
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub app: u64,
 }
 

--- a/tendermint/src/rpc/endpoint/abci_info.rs
+++ b/tendermint/src/rpc/endpoint/abci_info.rs
@@ -36,10 +36,7 @@ pub struct AbciInfo {
     pub version: String,
 
     /// App version
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub app_version: u64,
 
     /// Last block height

--- a/tendermint/src/rpc/endpoint/abci_query.rs
+++ b/tendermint/src/rpc/endpoint/abci_query.rs
@@ -14,10 +14,7 @@ pub struct Request {
     path: Option<Path>,
 
     /// Data to query
-    #[serde(
-        serialize_with = "serializers::serialize_hex",
-        deserialize_with = "serializers::parse_hex"
-    )]
+    #[serde(with = "serializers::bytes::hexstring")]
     data: Vec<u8>,
 
     /// Block height
@@ -75,18 +72,11 @@ pub struct AbciQuery {
     pub info: String,
 
     /// Index
-    #[serde(
-        serialize_with = "serializers::serialize_i64",
-        deserialize_with = "serializers::parse_i64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub index: i64,
 
     /// Key
-    #[serde(
-        default,
-        serialize_with = "serializers::serialize_base64",
-        deserialize_with = "serializers::parse_base64"
-    )]
+    #[serde(default, with = "serializers::bytes::base64string")]
     pub key: Vec<u8>,
 
     /// Value (might be explicit null)

--- a/tendermint/src/rpc/endpoint/abci_query.rs
+++ b/tendermint/src/rpc/endpoint/abci_query.rs
@@ -79,13 +79,9 @@ pub struct AbciQuery {
     #[serde(default, with = "serializers::bytes::base64string")]
     pub key: Vec<u8>,
 
-    /// Value (might be explicit null)
-    #[serde(
-        default,
-        serialize_with = "serializers::serialize_option_base64",
-        deserialize_with = "serializers::parse_option_base64"
-    )]
-    pub value: Option<Vec<u8>>,
+    /// Value
+    #[serde(default, with = "serializers::bytes::base64string")]
+    pub value: Vec<u8>,
 
     /// Proof (might be explicit null)
     pub proof: Option<Proof>,

--- a/tendermint/src/rpc/endpoint/net_info.rs
+++ b/tendermint/src/rpc/endpoint/net_info.rs
@@ -30,10 +30,7 @@ pub struct Response {
     pub listeners: Vec<Listener>,
 
     /// Number of connected peers
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub n_peers: u64,
 
     /// Peer information
@@ -72,11 +69,7 @@ pub struct PeerInfo {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConnectionStatus {
     /// Duration of this connection
-    #[serde(
-        rename = "Duration",
-        serialize_with = "serializers::serialize_duration",
-        deserialize_with = "serializers::parse_duration"
-    )]
+    #[serde(rename = "Duration", with = "serializers::timeduration::string")]
     pub duration: Duration,
 
     /// Send monitor
@@ -104,83 +97,43 @@ pub struct Monitor {
     pub start: Time,
 
     /// Duration of this monitor
-    #[serde(
-        rename = "Duration",
-        serialize_with = "serializers::serialize_duration",
-        deserialize_with = "serializers::parse_duration"
-    )]
+    #[serde(rename = "Duration", with = "serializers::timeduration::string")]
     pub duration: Duration,
 
     /// Idle duration for this monitor
-    #[serde(
-        rename = "Idle",
-        serialize_with = "serializers::serialize_duration",
-        deserialize_with = "serializers::parse_duration"
-    )]
+    #[serde(rename = "Idle", with = "serializers::timeduration::string")]
     pub idle: Duration,
 
     /// Bytes
-    #[serde(
-        rename = "Bytes",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "Bytes", with = "serializers::primitives::string")]
     bytes: u64,
 
     /// Samples
-    #[serde(
-        rename = "Samples",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "Samples", with = "serializers::primitives::string")]
     samples: u64,
 
     /// Instant rate
-    #[serde(
-        rename = "InstRate",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "InstRate", with = "serializers::primitives::string")]
     inst_rate: u64,
 
     /// Current rate
-    #[serde(
-        rename = "CurRate",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "CurRate", with = "serializers::primitives::string")]
     cur_rate: u64,
 
     /// Average rate
-    #[serde(
-        rename = "AvgRate",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "AvgRate", with = "serializers::primitives::string")]
     avg_rate: u64,
 
     /// Peak rate
-    #[serde(
-        rename = "PeakRate",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "PeakRate", with = "serializers::primitives::string")]
     peak_rate: u64,
 
     /// Bytes remaining
-    #[serde(
-        rename = "BytesRem",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "BytesRem", with = "serializers::primitives::string")]
     bytes_rem: u64,
 
     /// Time remaining
-    #[serde(
-        rename = "TimeRem",
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(rename = "TimeRem", with = "serializers::primitives::string")]
     time_rem: u64,
 
     /// Progress

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -5,6 +5,10 @@
 //! All serializers are presented in a serializers::<Rust_type_name>::<JSON_representation_name> format.
 //!
 //! This example shows how to serialize Vec<u8> into different types of strings:
+//! ```
+//! use serde::{Serialize, Deserialize};
+//! use tendermint::serializers;
+//!
 //! #[derive(Serialize, Deserialize)]
 //! struct ByteTypes {
 //!
@@ -18,6 +22,7 @@
 //!     bytes: Vec<u8>,
 //!
 //! }
+//! ```
 //!
 //! Available serializers:
 //! i64                  <-> string:               #[serde(with="serializers::primitives::string")]

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -23,7 +23,6 @@
 //!
 //! }
 //! ```
-//! Note: null values will be deserialized into vec![].
 //!
 //! Available serializers:
 //! i64                  <-> string:               #[serde(with="serializers::primitives::string")]
@@ -33,8 +32,9 @@
 //! Vec<u8>              <-> Base64String:         #[serde(with="serializers::bytes::base64string")]
 //! Vec<u8>              <-> String:               #[serde(with="serializers::bytes::string")]
 //!
-//! Any type that has the "FromStr" trait can be serialized into a string with serializers::primitives::string.
-//!
+//! Notes:
+//! * Any type that has the "FromStr" trait can be serialized into a string with serializers::primitives::string.
+//! * serializers::bytes::* deserializes a null value into an empty vec![].
 
 use crate::account::{Id, LENGTH};
 use crate::{block, Hash, Signature};

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -1,70 +1,193 @@
 //! Serde serializers
+//!
+//! Serializers and deserializers for a transparent developer experience.
+//!
+//! All serializers are presented in a serializers::<Rust_type_name>::<JSON_representation_name> format.
+//!
+//! This example shows how to serialize Vec<u8> into different types of strings:
+//! #[derive(Serialize, Deserialize)]
+//! struct ByteTypes {
+//!
+//!     #[serde(with="serializers::bytes::hexstring")]
+//!     hexbytes: Vec<u8>,
+//!
+//!     #[serde(with="serializers::bytes::base64string")]
+//!     base64bytes: Vec<u8>,
+//!
+//!     #[serde(with="serializers::bytes::string")]
+//!     bytes: Vec<u8>,
+//!
+//! }
+//!
+//! Available serializers:
+//! i64                  <-> string:               #[serde(with="serializers::primitives::string")]
+//! u64                  <-> string:               #[serde(with="serializers::primitives::string")]
+//! std::time::Dureation <-> nanoseconds as string #[serde(with="serializers::timeduration::string")]
+//! Vec<u8>              <-> HexString:            #[serde(with="serializers::bytes::hexstring")]
+//! Vec<u8>              <-> Base64String:         #[serde(with="serializers::bytes::base64string")]
+//! Vec<u8>              <-> String:               #[serde(with="serializers::bytes::string")]
+//!
+//! Any type that has the "FromStr" trait can be serialized into a string with serializers::primitives::string.
+//!
 
 use crate::account::{Id, LENGTH};
 use crate::{block, Hash, Signature};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
-use std::time::Duration;
-use subtle_encoding::{base64, hex};
 
-/// Parse `i64` from a JSON string
-pub(crate) fn parse_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    String::deserialize(deserializer)?
-        .parse::<i64>()
-        .map_err(|e| D::Error::custom(format!("{}", e)))
+/// Serialize/deserialize primitive types (i64, u64, etc)
+pub mod primitives {
+
+    /// Serialize into string, deserialize from string
+    pub mod string {
+        use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+
+        /// Deserialize string into T
+        pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+        where
+            D: Deserializer<'de>,
+            T: std::str::FromStr,
+            <T as std::str::FromStr>::Err: std::fmt::Display,
+        {
+            String::deserialize(deserializer)?
+                .parse::<T>()
+                .map_err(|e| D::Error::custom(format!("{}", e)))
+        }
+
+        /// Serialize from T into string
+        pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+            T: std::fmt::Display,
+        {
+            format!("{}", value).serialize(serializer)
+        }
+    }
 }
 
-/// Serialize `i64` as a JSON string
-#[allow(clippy::trivially_copy_pass_by_ref)]
-pub(crate) fn serialize_i64<S>(value: &i64, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    format!("{}", value).serialize(serializer)
+/// Serialize/deserialize std::time::Duration type
+pub mod timeduration {
+
+    /// Serialize into string, deserialize from string
+    pub mod string {
+        use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+        use std::time::Duration;
+
+        /// Deserialize string into Duration
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let value = String::deserialize(deserializer)?
+                .parse::<u64>()
+                .map_err(|e| D::Error::custom(format!("{}", e)))?;
+
+            Ok(Duration::from_nanos(value))
+        }
+
+        /// Serialize from Duration into string
+        pub fn serialize<S>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            format!("{}", value.as_nanos()).serialize(serializer)
+        }
+    }
 }
 
-/// Parse `u64` from a JSON string
-pub(crate) fn parse_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    String::deserialize(deserializer)?
-        .parse::<u64>()
-        .map_err(|e| D::Error::custom(format!("{}", e)))
+/// Serialize/deserialize bytes (Vec<u8>) type
+pub mod bytes {
+
+    /// Serialize into hexstring, deserialize from hexstring
+    pub mod hexstring {
+        use serde::{
+            de::Error as deError, ser::Error as serError, Deserialize, Deserializer, Serializer,
+        };
+        use subtle_encoding::hex;
+
+        /// Deserialize hexstring into Vec<u8>
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let string = String::deserialize(deserializer)?;
+
+            hex::decode_upper(&string)
+                .or_else(|_| hex::decode(&string))
+                .map_err(deError::custom)
+        }
+
+        /// Serialize from T into hexstring
+        pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+            T: AsRef<[u8]>,
+        {
+            let hex_bytes = hex::encode(value.as_ref());
+            let hex_string = String::from_utf8(hex_bytes).map_err(serError::custom)?;
+            serializer.serialize_str(&hex_string)
+        }
+    }
+
+    /// Serialize into base64string, deserialize from base64string
+    pub mod base64string {
+        use serde::{
+            de::Error as deError, ser::Error as serError, Deserialize, Deserializer, Serializer,
+        };
+        use subtle_encoding::base64;
+
+        /// Deserialize base64string into Vec<u8>
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let string = String::deserialize(deserializer)?;
+
+            base64::decode(&string).map_err(deError::custom)
+        }
+
+        /// Serialize from T into base64string
+        pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+            T: AsRef<[u8]>,
+        {
+            let base64_bytes = base64::encode(value.as_ref());
+            let base64_string = String::from_utf8(base64_bytes).map_err(serError::custom)?;
+            serializer.serialize_str(&base64_string)
+        }
+    }
+
+    /// Serialize into string, deserialize from string
+    pub mod string {
+        use serde::{
+            de::Error as _, ser::Error as serError, Deserialize, Deserializer, Serializer,
+        };
+
+        /// Deserialize string into Vec<u8>
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            String::deserialize(deserializer)
+                .map(|m| m.as_bytes().to_vec())
+                .map_err(|e| D::Error::custom(format!("{}", e)))
+        }
+
+        /// Serialize from T into string
+        pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+            T: AsRef<[u8]>,
+        {
+            let string = String::from_utf8(value.as_ref().to_vec()).map_err(serError::custom)?;
+            serializer.serialize_str(&string)
+        }
+    }
 }
 
-/// Serialize `u64` as a JSON string
-#[allow(clippy::trivially_copy_pass_by_ref)]
-pub(crate) fn serialize_u64<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    format!("{}", value).serialize(serializer)
-}
-
-/// Parse `Duration` from a JSON string containing a nanosecond count
-pub(crate) fn parse_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // TODO(tarcieri): handle 64-bit overflow?
-    let nanos = String::deserialize(deserializer)?
-        .parse::<u64>()
-        .map_err(|e| D::Error::custom(format!("{}", e)))?;
-
-    Ok(Duration::from_nanos(nanos))
-}
-
-/// Serialize `Duration` as a JSON string containing a nanosecond count
-pub(crate) fn serialize_duration<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    format!("{}", duration.as_nanos()).serialize(serializer)
-}
+// Todo: Refactor the "Option"-based serializers below.
+//  Most of them are not needed if the structs are defined well (with enums).
 
 pub(crate) fn parse_non_empty_hash<'de, D>(deserializer: D) -> Result<Option<Hash>, D::Error>
 where
@@ -79,49 +202,6 @@ where
     }
 }
 
-pub(crate) fn serialize_hex<S, T>(bytes: T, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: AsRef<[u8]>,
-{
-    use serde::ser::Error;
-    let hex_bytes = hex::encode(bytes.as_ref());
-    let hex_string = String::from_utf8(hex_bytes).map_err(Error::custom)?;
-    serializer.serialize_str(&hex_string)
-}
-
-// decode upper or lowercase hex
-pub(crate) fn parse_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use serde::de::Error;
-    let string = String::deserialize(deserializer)?;
-    hex::decode_upper(&string)
-        .or_else(|_| hex::decode(&string))
-        .map_err(Error::custom)
-}
-
-pub(crate) fn serialize_base64<S, T>(bytes: T, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: AsRef<[u8]>,
-{
-    use serde::ser::Error;
-    let base64_bytes = base64::encode(bytes.as_ref());
-    let base64_string = String::from_utf8(base64_bytes).map_err(Error::custom)?;
-    serializer.serialize_str(&base64_string)
-}
-
-pub(crate) fn parse_base64<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use serde::de::Error;
-    let string = String::deserialize(deserializer)?;
-    base64::decode(&string).map_err(Error::custom)
-}
-
 #[allow(dead_code)]
 pub(crate) fn serialize_option_base64<S>(
     maybe_bytes: &Option<Vec<u8>>,
@@ -131,7 +211,7 @@ where
     S: Serializer,
 {
     #[derive(Serialize)]
-    struct Wrapper<'a>(#[serde(serialize_with = "serialize_base64")] &'a Vec<u8>);
+    struct Wrapper<'a>(#[serde(with = "bytes::base64string")] &'a Vec<u8>);
 
     match maybe_bytes {
         Some(bytes) => Wrapper(bytes).serialize(serializer),
@@ -145,7 +225,7 @@ where
     D: Deserializer<'de>,
 {
     #[derive(Deserialize)]
-    struct Wrapper(#[serde(deserialize_with = "parse_base64")] Vec<u8>);
+    struct Wrapper(#[serde(with = "bytes::base64string")] Vec<u8>);
 
     let v = Option::deserialize(deserializer)?;
     Ok(v.map(|Wrapper(a)| a))
@@ -160,7 +240,7 @@ where
 {
     #[derive(Deserialize)]
     struct Parts {
-        #[serde(deserialize_with = "parse_u64")]
+        #[serde(with = "primitives::string")]
         total: u64,
         hash: String,
     }

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -25,10 +25,7 @@ pub struct Vote {
     pub height: block::Height,
 
     /// Round
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub round: u64,
 
     /// Block ID
@@ -42,10 +39,7 @@ pub struct Vote {
     pub validator_address: account::Id,
 
     /// Validator index
-    #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
-    )]
+    #[serde(with = "serializers::primitives::string")]
     pub validator_index: u64,
 
     /// Signature

--- a/tendermint/tests/integration.rs
+++ b/tendermint/tests/integration.rs
@@ -34,7 +34,7 @@ mod rpc {
     async fn abci_info() {
         let abci_info = localhost_rpc_client().abci_info().await.unwrap();
 
-        assert_eq!(&abci_info.version, "0.16.2");
+        assert_eq!(&abci_info.version, "0.17.0");
         assert_eq!(abci_info.app_version, 1u64);
         // the kvstore app's reply will contain "{\"size\":0}" as data right from the start
         assert_eq!(&abci_info.data, "{\"size\":0}");
@@ -58,7 +58,7 @@ mod rpc {
         assert_eq!(abci_query.index, 0);
         assert_eq!(&abci_query.key, &Vec::<u8>::new());
         assert!(&abci_query.key.is_empty());
-        assert!(abci_query.value.is_none());
+        assert_eq!(abci_query.value, Vec::<u8>::new());
         assert!(abci_query.proof.is_none());
         assert!(abci_query.height.value() > 0);
         assert_eq!(abci_query.codespace, String::new());

--- a/tendermint/tests/serialization.rs
+++ b/tendermint/tests/serialization.rs
@@ -118,3 +118,36 @@ fn deserialize_vec_from_string() {
     assert_eq!(result.mybase64bytes, "MyString decoded.".as_bytes());
     assert_eq!(result.stringifiedbytes, "hello".as_bytes());
 }
+
+#[test]
+fn serialize_emptyvec_into_emptystring() {
+    let outgoing = BytesTests {
+        myhexbytes: vec![],
+        mybase64bytes: vec![],
+        stringifiedbytes: vec![],
+    };
+
+    let result: String = serde_json::to_string(&outgoing).unwrap();
+
+    assert_eq!(
+        result,
+        r#"{"myhexbytes":"","mybase64bytes":"","stringifiedbytes":""}"#
+    );
+}
+
+#[test]
+fn deserialize_emptyvec_from_null() {
+    let incoming = r#"
+    {
+      "myhexbytes": null,
+      "mybase64bytes": null,
+      "stringifiedbytes": null
+    }
+    "#;
+
+    let result: BytesTests = serde_json::from_str(&incoming).unwrap();
+
+    assert_eq!(result.myhexbytes, Vec::<u8>::new());
+    assert_eq!(result.mybase64bytes, Vec::<u8>::new());
+    assert_eq!(result.stringifiedbytes, Vec::<u8>::new());
+}

--- a/tendermint/tests/serialization.rs
+++ b/tendermint/tests/serialization.rs
@@ -1,0 +1,120 @@
+//! Serialization tests
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tendermint::serializers;
+
+#[derive(Serialize, Deserialize)]
+struct IntegerTests {
+    #[serde(with = "serializers::primitives::string")]
+    unsigned: u64,
+
+    #[serde(with = "serializers::primitives::string")]
+    signed: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DurationTests {
+    #[serde(with = "serializers::timeduration::string")]
+    duration: Duration,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BytesTests {
+    #[serde(with = "serializers::bytes::hexstring")]
+    myhexbytes: Vec<u8>,
+
+    #[serde(with = "serializers::bytes::base64string")]
+    mybase64bytes: Vec<u8>,
+
+    #[serde(with = "serializers::bytes::string")]
+    stringifiedbytes: Vec<u8>,
+}
+
+#[test]
+fn serialize_integer_into_string() {
+    let outgoing = IntegerTests {
+        unsigned: 9007199254740995,
+        signed: -9007199254740997,
+    };
+
+    let result: String = serde_json::to_string(&outgoing).unwrap();
+
+    assert_eq!(
+        result,
+        r#"{"unsigned":"9007199254740995","signed":"-9007199254740997"}"#
+    );
+}
+
+#[test]
+fn deserialize_integer_from_string() {
+    let incoming = r#"
+    {
+      "unsigned": "9007199254740992",
+      "signed": "-9007199254740994"
+    }
+    "#;
+
+    let result: IntegerTests = serde_json::from_str(&incoming).unwrap();
+
+    assert_eq!(result.unsigned, 9007199254740992);
+    assert_eq!(result.signed, -9007199254740994);
+}
+
+#[test]
+fn serialize_duration_into_string() {
+    let outgoing = DurationTests {
+        duration: Duration::from_secs(5),
+    };
+
+    let result: String = serde_json::to_string(&outgoing).unwrap();
+
+    assert_eq!(result, r#"{"duration":"5000000000"}"#);
+}
+
+#[test]
+fn deserialize_duration_from_string() {
+    let incoming = r#"
+    {
+      "duration": "15000000001"
+    }
+    "#;
+
+    let result: DurationTests = serde_json::from_str(&incoming).unwrap();
+
+    assert_eq!(result.duration.as_secs(), 15);
+    assert_eq!(result.duration.as_nanos(), 15000000001);
+}
+
+#[test]
+fn serialize_vec_into_string() {
+    let outgoing = BytesTests {
+        myhexbytes: vec![00, 255, 32],
+        mybase64bytes: "MyString encoded.".as_bytes().to_vec(),
+        stringifiedbytes: vec![65, 66, 67],
+    };
+
+    let result: String = serde_json::to_string(&outgoing).unwrap();
+
+    assert_eq!(
+        result,
+        r#"{"myhexbytes":"00ff20","mybase64bytes":"TXlTdHJpbmcgZW5jb2RlZC4=","stringifiedbytes":"ABC"}"#
+    );
+}
+
+#[test]
+fn deserialize_vec_from_string() {
+    let incoming = r#"
+    {
+      "myhexbytes": "412042FF00",
+      "mybase64bytes": "TXlTdHJpbmcgZGVjb2RlZC4=",
+      "stringifiedbytes": "hello"
+    }
+    "#;
+
+    let result: BytesTests = serde_json::from_str(&incoming).unwrap();
+
+    assert_eq!(result.myhexbytes, vec![65, 32, 66, 255, 0]);
+    assert_eq!(result.mybase64bytes, "MyString decoded.".as_bytes());
+    assert_eq!(result.stringifiedbytes, "hello".as_bytes());
+}


### PR DESCRIPTION
Implemented `null`-value deserialization for `Vec<u8>` using Visitor.

This is part 2 of the serialization improvement efforts described in #247 .

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGES.md
