### PR TITLE
a few invariants and a bugfix to block verification

### DIFF
--- a/docs/spec/fastsync/fastsync.tla
+++ b/docs/spec/fastsync/fastsync.tla
@@ -75,6 +75,9 @@ HeightsPlus == 1..MAX_HEIGHT+1
 \* a special value for an undefined height
 NilHeight == 0
 
+\* the height of the genesis block
+GenesisHeight == 1
+
 \* the set of all peer ids the node can receive a message from
 AllPeerIds == CORRECT \union FAULTY
 
@@ -180,16 +183,19 @@ OutMsgs ==
 (********************************** NODE ***********************************)
 
 InitNode ==
-     \E pIds \in SUBSET AllPeerIds \ {{}}:                   \* set of peers node established initial connections with
+     \E pIds \in SUBSET AllPeerIds:  \* set of peers node established initial connections with
+        /\ pIds /= {}                \* the peer set has at least one peer
         /\ blockPool = [
-                height |-> 1,
+                height |-> GenesisHeight + 1,       \* the genesis block is at height 1
+                syncHeight |-> GenesisHeight + 1,   \* and we are synchronized to it
                 peerIds |-> pIds,
                 peerHeights |-> [p \in AllPeerIds |-> NilHeight],     \* no peer height is known
-                blockStore |-> [h \in Heights |-> NilBlock],
+                blockStore |->
+                    [h \in Heights |->
+                      IF h > GenesisHeight THEN NilBlock ELSE CorrectBlock(1)],
                 receivedBlocks |-> [h \in Heights |-> NilPeer],
                 pendingBlocks |-> [h \in Heights |-> NilPeer],
-                syncedBlocks |-> -1,
-                syncHeight |-> 1
+                syncedBlocks |-> -1
            ]
        /\ state = "running"
 
@@ -368,12 +374,16 @@ ExecuteBlocks(bPool) ==
     LET block1 == bStore[bPool.height] IN
     LET block2 == bStore[bPool.height+1] IN
 
-    IF block1 = NilBlock \/ block2 = NilBlock \* we don't have two next consecutive blocks
-    THEN bPool
-    ELSE IF bPool.height > 1 /\ ~VerifyCommit(block1, block2.lastCommit)
-         THEN RemovePeers({bPool.receivedBlocks[block1.height], bPool.receivedBlocks[block2.height]}, bPool)
-         ELSE  \* all good, execute block at position height
-            [bPool EXCEPT !.height = bPool.height + 1]
+    IF block1 = NilBlock \/ block2 = NilBlock
+    THEN bPool  \* we don't have two next consecutive blocks
+    ELSE IF bPool.height = GenesisHeight + 1 /\ ~VerifyCommit(bStore[GenesisHeight], block1.lastCommit)
+         THEN \* corner case: the block right after genesis is corrupted, evict it
+              RemovePeers({bPool.receivedBlocks[GenesisHeight + 1]}, bPool)
+         ELSE IF ~VerifyCommit(block1, block2.lastCommit)  
+              THEN \* remove the peers of block1 and block2, as they are considered faulty
+              RemovePeers({bPool.receivedBlocks[block1.height], bPool.receivedBlocks[block2.height]}, bPool)
+              ELSE  \* all good, execute block at position height
+                [bPool EXCEPT !.height = bPool.height + 1]
 
 
 \* Defines logic for pruning peers.
@@ -661,6 +671,20 @@ Correctness2 ==
         \/ p \notin blockPool.peerIds
         \/ [] (state = "finished" => blockPool.height >= blockPool.peerHeights[p] - 1)
 
+\* A fix to Correctness2 that allows for a timeout
+Correctness3 ==
+   \A p \in CORRECT:
+        \/ p \notin blockPool.peerIds
+        \/ blockPool.syncedBlocks <= 0 \* timeout
+        \/ [] (state = "finished" => blockPool.height >= blockPool.peerHeights[p] - 1)
+
+Correctness3AsInv ==
+   \A p \in CORRECT:
+        \/ p \notin blockPool.peerIds
+        \/ blockPool.syncedBlocks <= 0 \* timeout
+        \/ (state = "finished" => blockPool.height >= blockPool.peerHeights[p] - 1)
+
+
 \* TODO: align with the English spec. Add reference to it
 Termination == WF_turn(FlipTurn) => <>(state = "finished")
 
@@ -672,6 +696,25 @@ PeerSetIsNeverEmpty == blockPool.peerIds /= {}
 \* Shows execution in which state = "finished" and MaxPeerHeight is not equal to 1
 StateNotFinished ==
     state /= "finished" \/ MaxPeerHeight(blockPool) = 1
+
+\* A false expectation that the protocol only finishes with the blocks
+\* from the processes that had not been suspected in being faulty
+SyncFromCorrectInv ==
+    \/ state /= "finished"
+    \/ \A h \in 1..blockPool.height:
+        blockPool.receivedBlocks[h] \in blockPool.peerIds \union {NilPeer}
+
+\* All synchronized blocks are well-formed and have sufficiently many votes
+CorrectBlocksInv ==
+    \/ state /= "finished"
+    \/ \A h \in 1..(blockPool.height - 1):
+        LET block == blockPool.blockStore[h] IN
+        block.wellFormed /\ block.lastCommit.enoughVotingPower
+
+\* A false expectation that a correct process is never removed from the set of peer ids.
+\* A correct process may reply too late and then gets evicted.
+CorrectNeverSuspectedInv ==
+    CORRECT \subseteq blockPool.peerIds
 
 BlockPoolInvariant ==
     \A h \in Heights:


### PR DESCRIPTION
This PR contains several Fastsync properties:

 * `Correctness3` and `Correctness3AsInv` that propose a fix to `Correctness2` (satisfied)
 * `SyncFromCorrectInv` that states a naive property that the synchronized blocks come only from the correct processes (violated)
 * `CorrectNeverSuspectedInv` that states that the correct peers are never suspected (violated)
 * `CorrectBlocksInv` that states that the synchronized blocks have correct block ids and enough voting power.

The current version of Fastsync violates `CorrectBlocksInv` in two ways:

 * As `InitNode` does not have the genesis block, a faulty peer may send the node a corrupt genesis block. We fix this by initializing `blockStore` with a correct genesis block at height 1.
 * As `ExecuteBlocks` does not verify a block at the height of 2, the last commit in block 2 may be corrupt. We fix this by introducing an extra test for the height of 2.
