### PR TITLE
CommitSig refactor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Pending
 
+CommitSig:
+- Refactored CommitSig into a more Rust-friendly enum. ([#197](https://github.com/informalsystems/tendermint-rs/issues/197))
+- Added CommitSig compatibility code to Absent vote [#260](https://github.com/informalsystems/tendermint-rs/issues/260)
+- Added CommitSig timestamp zero-check compatibility code [#259](https://github.com/informalsystems/tendermint-rs/issues/259)
+
 Testing:
 - Updated abci_info test to 0.17.0 ([#249](https://github.com/informalsystems/tendermint-rs/issues/249))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## Pending
 
 CommitSig:
-- Refactored CommitSig into a more Rust-friendly enum. ([#197](https://github.com/informalsystems/tendermint-rs/issues/197))
+- Refactored CommitSig into a more Rust-friendly enum. ([#247](https://github.com/informalsystems/tendermint-rs/issues/247))
 - Added CommitSig compatibility code to Absent vote [#260](https://github.com/informalsystems/tendermint-rs/issues/260)
 - Added CommitSig timestamp zero-check compatibility code [#259](https://github.com/informalsystems/tendermint-rs/issues/259)
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -45,6 +45,7 @@ prost-amino-derive = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 serde_bytes = "0.11"
+serde_repr = "0.1"
 sha2 = { version = "0.8", default-features = false }
 signatory = { version = "0.19", features = ["ed25519", "ecdsa"] }
 signatory-dalek = "0.19"

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 #[serde(try_from = "RawCommitSig")]
 pub enum CommitSig {
     /// no vote was received from a validator.
-// Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
+    // Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
     BlockIDFlagAbsent,
     /// voted for the Commit.BlockID.
     BlockIDFlagCommit {

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -77,7 +77,7 @@ impl TryFrom<RawCommitSig> for CommitSig {
             }
             BlockIDFlag::BlockIDFlagCommit => {
                 if value.timestamp.is_none() {
-                    Err("timestamp is null for BlockIDFlagCommit CommitSig")
+                    Err("timestamp is missing for BlockIDFlagCommit CommitSig")
                 } else if value.signature.is_none() {
                     Err("signature is null for BlockIDFlagCommit CommitSig")
                 } else {

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -45,7 +45,6 @@ pub enum CommitSig {
 impl TryFrom<RawCommitSig> for CommitSig {
     type Error = &'static str;
 
-    // Todo: @melekes asked: where's validator_address validation?
     fn try_from(value: RawCommitSig) -> Result<Self, Self::Error> {
         // Validate CommitSig (strict)
         match value.block_id_flag {

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -1,78 +1,117 @@
 //! CommitSig within Commit
 
-use crate::serializers;
+use crate::serializers::BlockIDFlag;
+use crate::serializers::RawCommitSig;
 use crate::{account, Signature, Time};
-use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
-
-/// BlockIDFlag is used to indicate the validator has voted either for nil, a particular BlockID or was absent.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum BlockIDFlag {
-    /// BlockIDFlagAbsent - no vote was received from a validator.
-    BlockIDFlagAbsent = 1,
-    /// BlockIDFlagCommit - voted for the Commit.BlockID.
-    BlockIDFlagCommit = 2,
-    /// BlockIDFlagNil - voted for nil.
-    BlockIDFlagNil = 3,
-}
-
-impl BlockIDFlag {
-    /// Deserialize this type from a byte
-    pub fn from_u8(byte: u8) -> Option<BlockIDFlag> {
-        match byte {
-            1 => Some(BlockIDFlag::BlockIDFlagAbsent),
-            2 => Some(BlockIDFlag::BlockIDFlagCommit),
-            3 => Some(BlockIDFlag::BlockIDFlagNil),
-            _ => None,
-        }
-    }
-
-    /// Serialize this type as a byte
-    pub fn to_u8(self) -> u8 {
-        self as u8
-    }
-
-    /// Serialize this type as a 32-bit unsigned integer
-    pub fn to_u32(self) -> u32 {
-        self as u32
-    }
-}
-
-impl Serialize for BlockIDFlag {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.to_u8().serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for BlockIDFlag {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let byte = u8::deserialize(deserializer)?;
-        BlockIDFlag::from_u8(byte)
-            .ok_or_else(|| D::Error::custom(format!("invalid block ID flag: {}", byte)))
-    }
-}
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 
 /// CommitSig represents a signature of a validator.
 /// It's a part of the Commit and can be used to reconstruct the vote set given the validator set.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct CommitSig {
-    /// Block ID FLag
-    pub block_id_flag: BlockIDFlag,
-
-    /// Validator address
-    #[serde(deserialize_with = "serializers::parse_non_empty_id")]
-    pub validator_address: Option<account::Id>,
-
-    /// Timestamp
-    pub timestamp: Time,
-
-    /// Signature
-    #[serde(deserialize_with = "serializers::parse_non_empty_signature")]
-    pub signature: Option<Signature>,
+#[serde(try_from = "RawCommitSig")]
+pub enum CommitSig {
+    /// no vote was received from a validator.
+    // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+    BlockIDFlagAbsent,
+    // === Real code after compatibility issue is resolved
+    /*
+    BlockIDFlagAbsent {
+        /// Validator address
+        validator_address: account::Id,
+    },
+    */
+    // >>> end of real code
+    /// voted for the Commit.BlockID.
+    BlockIDFlagCommit {
+        /// Validator address
+        validator_address: account::Id,
+        /// Timestamp of vote
+        timestamp: Time,
+        /// Signature of vote
+        signature: Signature,
+    },
+    /// voted for nil.
+    BlockIDFlagNil {
+        /// Validator address
+        validator_address: account::Id,
+        /// Timestamp of vote
+        timestamp: Time,
+        /// Signature of vote
+        signature: Signature,
+    },
 }
 
-impl CommitSig {
-    /// Checks if a validator's vote is absent
-    pub fn is_absent(&self) -> bool {
-        self.block_id_flag == BlockIDFlag::BlockIDFlagAbsent
+impl TryFrom<RawCommitSig> for CommitSig {
+    type Error = &'static str;
+
+    // Todo: @melekes asked: where's validator_address validation?
+    fn try_from(value: RawCommitSig) -> Result<Self, Self::Error> {
+        // Validate CommitSig (strict)
+        match value.block_id_flag {
+            BlockIDFlag::BlockIDFlagAbsent => {
+                if value.timestamp.is_some() {
+                    // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/259
+                    if value.timestamp.unwrap() != Time::parse_from_rfc3339("0001-01-01T00:00:00Z").unwrap() {
+                        return Err("timestamp is present for BlockIDFlagAbsent CommitSig");
+                    }
+                    // === Real code after compatibility issue is resolved
+                    /*
+                    return Err("timestamp is present for BlockIDFlagAbsent CommitSig");
+                    */
+                    // >>> end of real code
+                }
+                if value.signature.is_some() {
+                    return Err("signature is present for BlockIDFlagAbsent CommitSig");
+                }
+                // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+                Ok(CommitSig::BlockIDFlagAbsent)
+                // === Real code after compatibility issue is resolved
+                /*
+                Ok(CommitSig::BlockIDFlagAbsent {
+                    validator_address: value.validator_address,
+                })
+                */
+                // >>> end of real code
+            }
+            BlockIDFlag::BlockIDFlagCommit => {
+                if value.timestamp.is_none() {
+                    Err("timestamp is null for BlockIDFlagCommit CommitSig")
+                } else if value.signature.is_none() {
+                    Err("signature is null for BlockIDFlagCommit CommitSig")
+                } else {
+                    Ok(CommitSig::BlockIDFlagCommit {
+                        // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+                        validator_address: value.validator_address.unwrap(),
+                        // === Real code after compatibility issue is resolved
+                        /*
+                        validator_address: value.validator_address,
+                        */
+                        // >>> end of real code
+                        timestamp: value.timestamp.unwrap(),
+                        signature: value.signature.unwrap(),
+                    })
+                }
+            }
+            BlockIDFlag::BlockIDFlagNil => {
+                if value.timestamp.is_none() {
+                    Err("timestamp is null for BlockIDFlagNil CommitSig")
+                } else if value.signature.is_none() {
+                    Err("signature is null for BlockIDFlagNil CommitSig")
+                } else {
+                    Ok(CommitSig::BlockIDFlagNil {
+                        // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+                        validator_address: value.validator_address.unwrap(),
+                        // === Real code after compatibility issue is resolved
+                        /*
+                        validator_address: value.validator_address,
+                        */
+                        // >>> end of real code
+                        timestamp: value.timestamp.unwrap(),
+                        signature: value.signature.unwrap(),
+                    })
+                }
+            }
+        }
     }
 }

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -52,7 +52,9 @@ impl TryFrom<RawCommitSig> for CommitSig {
             BlockIDFlag::BlockIDFlagAbsent => {
                 if value.timestamp.is_some() {
                     // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/259
-                    if value.timestamp.unwrap() != Time::parse_from_rfc3339("0001-01-01T00:00:00Z").unwrap() {
+                    if value.timestamp.unwrap()
+                        != Time::parse_from_rfc3339("0001-01-01T00:00:00Z").unwrap()
+                    {
                         return Err("timestamp is present for BlockIDFlagAbsent CommitSig");
                     }
                     // === Real code after compatibility issue is resolved

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -12,16 +12,8 @@ use std::convert::TryFrom;
 #[serde(try_from = "RawCommitSig")]
 pub enum CommitSig {
     /// no vote was received from a validator.
-    // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+// Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
     BlockIDFlagAbsent,
-    // === Real code after compatibility issue is resolved
-    /*
-    BlockIDFlagAbsent {
-        /// Validator address
-        validator_address: account::Id,
-    },
-    */
-    // >>> end of real code
     /// voted for the Commit.BlockID.
     BlockIDFlagCommit {
         /// Validator address
@@ -42,53 +34,35 @@ pub enum CommitSig {
     },
 }
 
+// Todo: https://github.com/informalsystems/tendermint-rs/issues/259 - CommitSig Timestamp can be zero time
+// Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
 impl TryFrom<RawCommitSig> for CommitSig {
     type Error = &'static str;
 
     fn try_from(value: RawCommitSig) -> Result<Self, Self::Error> {
-        // Validate CommitSig (strict)
         match value.block_id_flag {
             BlockIDFlag::BlockIDFlagAbsent => {
-                if value.timestamp.is_some() {
-                    // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/259
-                    if value.timestamp.unwrap()
+                if value.timestamp.is_some()
+                    && value.timestamp.unwrap()
                         != Time::parse_from_rfc3339("0001-01-01T00:00:00Z").unwrap()
-                    {
-                        return Err("timestamp is present for BlockIDFlagAbsent CommitSig");
-                    }
-                    // === Real code after compatibility issue is resolved
-                    /*
+                {
                     return Err("timestamp is present for BlockIDFlagAbsent CommitSig");
-                    */
-                    // >>> end of real code
                 }
                 if value.signature.is_some() {
                     return Err("signature is present for BlockIDFlagAbsent CommitSig");
                 }
-                // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
                 Ok(CommitSig::BlockIDFlagAbsent)
-                // === Real code after compatibility issue is resolved
-                /*
-                Ok(CommitSig::BlockIDFlagAbsent {
-                    validator_address: value.validator_address,
-                })
-                */
-                // >>> end of real code
             }
             BlockIDFlag::BlockIDFlagCommit => {
                 if value.timestamp.is_none() {
                     Err("timestamp is missing for BlockIDFlagCommit CommitSig")
                 } else if value.signature.is_none() {
                     Err("signature is missing for BlockIDFlagCommit CommitSig")
+                } else if value.validator_address.is_none() {
+                    Err("validator_address is missing for BlockIDFlagCommit CommitSig")
                 } else {
                     Ok(CommitSig::BlockIDFlagCommit {
-                        // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
                         validator_address: value.validator_address.unwrap(),
-                        // === Real code after compatibility issue is resolved
-                        /*
-                        validator_address: value.validator_address,
-                        */
-                        // >>> end of real code
                         timestamp: value.timestamp.unwrap(),
                         signature: value.signature.unwrap(),
                     })
@@ -99,15 +73,11 @@ impl TryFrom<RawCommitSig> for CommitSig {
                     Err("timestamp is missing for BlockIDFlagNil CommitSig")
                 } else if value.signature.is_none() {
                     Err("signature is missing for BlockIDFlagNil CommitSig")
+                } else if value.validator_address.is_none() {
+                    Err("validator_address is missing for BlockIDFlagNil CommitSig")
                 } else {
                     Ok(CommitSig::BlockIDFlagNil {
-                        // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
                         validator_address: value.validator_address.unwrap(),
-                        // === Real code after compatibility issue is resolved
-                        /*
-                        validator_address: value.validator_address,
-                        */
-                        // >>> end of real code
                         timestamp: value.timestamp.unwrap(),
                         signature: value.signature.unwrap(),
                     })

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -79,7 +79,7 @@ impl TryFrom<RawCommitSig> for CommitSig {
                 if value.timestamp.is_none() {
                     Err("timestamp is missing for BlockIDFlagCommit CommitSig")
                 } else if value.signature.is_none() {
-                    Err("signature is null for BlockIDFlagCommit CommitSig")
+                    Err("signature is missing for BlockIDFlagCommit CommitSig")
                 } else {
                     Ok(CommitSig::BlockIDFlagCommit {
                         // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
@@ -96,9 +96,9 @@ impl TryFrom<RawCommitSig> for CommitSig {
             }
             BlockIDFlag::BlockIDFlagNil => {
                 if value.timestamp.is_none() {
-                    Err("timestamp is null for BlockIDFlagNil CommitSig")
+                    Err("timestamp is missing for BlockIDFlagNil CommitSig")
                 } else if value.signature.is_none() {
-                    Err("signature is null for BlockIDFlagNil CommitSig")
+                    Err("signature is missing for BlockIDFlagNil CommitSig")
                 } else {
                     Ok(CommitSig::BlockIDFlagNil {
                         // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260

--- a/tendermint/src/lite_impl/signed_header.rs
+++ b/tendermint/src/lite_impl/signed_header.rs
@@ -67,15 +67,8 @@ impl lite::Commit for block::signed_header::SignedHeader {
         for commit_sig in self.commit.signatures.iter() {
             let extracted_validator_address;
             match commit_sig {
-                // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+                // Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
                 CommitSig::BlockIDFlagAbsent => continue,
-                // === Real code after compatibility issue is resolved
-                /*
-                CommitSig::BlockIDFlagAbsent => {
-                    validator_address, ..
-                } => extracted_validator_address = validator_address,
-                */
-                // >>> end of real code
                 CommitSig::BlockIDFlagCommit {
                     validator_address, ..
                 } => extracted_validator_address = validator_address,

--- a/tendermint/src/lite_impl/signed_header.rs
+++ b/tendermint/src/lite_impl/signed_header.rs
@@ -61,7 +61,7 @@ impl lite::Commit for block::signed_header::SignedHeader {
         }
 
         // TODO: this last check is only necessary if we do full verification (2/3)
-        // Todo: @melekes asked why the above is a TODO, find out and resolve it or open an issue
+        // https://github.com/informalsystems/tendermint-rs/issues/281
         // returns ImplementationSpecific error if it detects a signer
         // that is not present in the validator set:
         for commit_sig in self.commit.signatures.iter() {

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -40,11 +40,13 @@ pub(crate) mod bytes;
 pub(crate) mod from_str;
 pub(crate) mod time_duration;
 
+mod raw_commit_sig;
+pub(crate) use raw_commit_sig::BlockIDFlag;
+pub(crate) use raw_commit_sig::RawCommitSig;
+
 #[cfg(test)]
 mod tests;
 
 mod custom;
 pub(crate) use custom::parse_non_empty_block_id;
 pub(crate) use custom::parse_non_empty_hash;
-pub(crate) use custom::parse_non_empty_id;
-pub(crate) use custom::parse_non_empty_signature;

--- a/tendermint/src/serializers/custom.rs
+++ b/tendermint/src/serializers/custom.rs
@@ -1,7 +1,6 @@
 //! Custom, legacy serializers
 
-use crate::account::{Id, LENGTH};
-use crate::{block, Hash, Signature};
+use crate::{block, Hash};
 use serde::{de::Error as _, Deserialize, Deserializer};
 use std::str::FromStr;
 
@@ -58,37 +57,4 @@ where
             },
         }))
     }
-}
-
-/// Option<Id> deserialization
-pub(crate) fn parse_non_empty_id<'de, D>(deserializer: D) -> Result<Option<Id>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    if s.is_empty() {
-        Ok(None)
-    } else {
-        // TODO: how can we avoid rewriting code here?
-        match Id::from_str(&s).map_err(|_| {
-            D::Error::custom(format!(
-                "expected {}-character hex string, got {:?}",
-                LENGTH * 2,
-                s
-            ))
-        }) {
-            Ok(id) => Ok(Option::from(id)),
-            Err(_) => Ok(None),
-        }
-    }
-}
-
-/// Option<Signature> deserialization
-pub(crate) fn parse_non_empty_signature<'de, D>(
-    deserializer: D,
-) -> Result<Option<Signature>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Deserialize::deserialize(deserializer).map(|x: Option<_>| x.unwrap_or(None))
 }

--- a/tendermint/src/serializers/raw_commit_sig.rs
+++ b/tendermint/src/serializers/raw_commit_sig.rs
@@ -1,0 +1,66 @@
+//! RawCommitSig type for deserialization
+use crate::{account, Signature, Time};
+use serde::{Deserialize, Deserializer};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::str::FromStr;
+use serde::de::Error;
+
+// Implements decision: https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-025-commit.md#decision
+
+/// indicate which BlockID the signature is for
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+#[repr(u8)]
+pub enum BlockIDFlag {
+    /// vote is not included in the Commit.Precommits
+    BlockIDFlagAbsent = 1,
+    /// voted for the Commit.BlockID
+    BlockIDFlagCommit = 2,
+    /// voted for nil
+    BlockIDFlagNil = 3,
+}
+
+/// RawCommitSig struct for interim deserialization of JSON object
+#[derive(Deserialize)]
+pub struct RawCommitSig {
+    /// indicate which BlockID the signature is for
+    pub block_id_flag: BlockIDFlag,
+    /// Validator Address
+    // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+    #[serde(default, deserialize_with = "emptystring_or_accountid")]
+    pub validator_address: Option<account::Id>,
+    // === Real code after compatibility issue is resolved
+    /*
+    pub validator_address: account::Id,
+    */
+    // >>> end of real code
+    /// Timestamp
+    #[serde(default)]
+    pub timestamp: Option<Time>,
+    /// Signature
+    #[serde(default, deserialize_with = "option_signature")]
+    pub signature: Option<Signature>,
+}
+
+fn option_signature<'de, D>(deserializer: D) -> Result<Option<Signature>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(|x: Option<_>| x.unwrap_or(None))
+}
+
+// <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+fn emptystring_or_accountid<'de, D>(deserializer: D) -> Result<Option<account::Id>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = String::deserialize(deserializer)?;
+    if string.is_empty() {
+        Ok(None)
+    } else {
+        account::Id::from_str(&string)
+            .map(|r| Some(r))
+            .map_err(|e| D::Error::custom(format!("{}", e)))
+    }
+}
+// === Real code after compatibility issue is resolved
+// >>> end of real code

--- a/tendermint/src/serializers/raw_commit_sig.rs
+++ b/tendermint/src/serializers/raw_commit_sig.rs
@@ -25,14 +25,9 @@ pub struct RawCommitSig {
     /// indicate which BlockID the signature is for
     pub block_id_flag: BlockIDFlag,
     /// Validator Address
-    // <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+    // Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
     #[serde(default, deserialize_with = "emptystring_or_accountid")]
     pub validator_address: Option<account::Id>,
-    // === Real code after compatibility issue is resolved
-    /*
-    pub validator_address: account::Id,
-    */
-    // >>> end of real code
     /// Timestamp
     #[serde(default)]
     pub timestamp: Option<Time>,
@@ -48,7 +43,7 @@ where
     Deserialize::deserialize(deserializer).map(|x: Option<_>| x.unwrap_or(None))
 }
 
-// <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+// Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
 fn emptystring_or_accountid<'de, D>(deserializer: D) -> Result<Option<account::Id>, D::Error>
 where
     D: Deserializer<'de>,
@@ -62,5 +57,3 @@ where
             .map_err(|e| D::Error::custom(format!("{}", e)))
     }
 }
-// === Real code after compatibility issue is resolved
-// >>> end of real code

--- a/tendermint/src/serializers/raw_commit_sig.rs
+++ b/tendermint/src/serializers/raw_commit_sig.rs
@@ -1,9 +1,9 @@
 //! RawCommitSig type for deserialization
 use crate::{account, Signature, Time};
+use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
-use serde::de::Error;
 
 // Implements decision: https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-025-commit.md#decision
 
@@ -58,7 +58,7 @@ where
         Ok(None)
     } else {
         account::Id::from_str(&string)
-            .map(|r| Some(r))
+            .map(Some)
             .map_err(|e| D::Error::custom(format!("{}", e)))
     }
 }

--- a/tendermint/src/serializers/tests.rs
+++ b/tendermint/src/serializers/tests.rs
@@ -1,5 +1,8 @@
 //! Serialization tests
 
+use crate::account::Id;
+use crate::block::CommitSig;
+use crate::time::Time;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -29,6 +32,12 @@ struct BytesTests {
     #[serde(with = "super::bytes::string")]
     stringifiedbytes: Vec<u8>,
 }
+
+const EXAMPLE_SIGNATURE: [u8; 64] = [
+    63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40,
+    39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+];
 
 #[test]
 fn serialize_integer_into_string() {
@@ -149,4 +158,122 @@ fn deserialize_emptyvec_from_null() {
     assert_eq!(result.myhexbytes, Vec::<u8>::new());
     assert_eq!(result.mybase64bytes, Vec::<u8>::new());
     assert_eq!(result.stringifiedbytes, Vec::<u8>::new());
+}
+
+// <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+#[test]
+fn deserialize_commit_sig_absent_vote() {
+    let incoming = r#"
+    {
+        "block_id_flag": 1,
+        "timestamp": "0001-01-01T00:00:00Z"
+    }
+    "#;
+
+    let result: CommitSig = serde_json::from_str(&incoming).unwrap();
+
+    if let CommitSig::BlockIDFlagAbsent = result {
+    } else {
+        panic!(format!("expected BlockIDFlagAbsent, received {:?}", result));
+    }
+}
+// === Real code after compatibility issue is resolved
+/*
+#[test]
+fn deserialize_commit_sig_absent_vote() {
+    let incoming = r#"
+    {
+        "block_id_flag": 1,
+        "validator_address": "4142434445464748494A4B4C4D4E4F5051525354"
+    }
+    "#;
+
+    let result: CommitSig = serde_json::from_str(&incoming).unwrap();
+
+    if let CommitSig::BlockIDFlagAbsent { validator_address } = result {
+        assert_eq!(
+            validator_address,
+            Id::new([
+                65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84
+            ])
+        );
+    } else {
+        panic!(format!("expected BlockIDFlagAbsent, received {:?}", result));
+    }
+}
+*/
+// >>> end of real code
+
+#[test]
+fn deserialize_commit_sig_commit_vote() {
+    let incoming = r#"
+    {
+        "block_id_flag": 2,
+        "validator_address": "4142434445464748494A4B4C4D4E4F5051525354",
+        "timestamp": "1970-01-01T00:00:00Z",
+        "signature": "Pz49PDs6OTg3NjU0MzIxMC8uLSwrKikoJyYlJCMiISAfHh0cGxoZGBcWFRQTEhEQDw4NDAsKCQgHBgUEAwIBAA=="
+    }
+    "#;
+
+    let result: CommitSig = serde_json::from_str(&incoming).unwrap();
+
+    if let CommitSig::BlockIDFlagCommit {
+        validator_address,
+        timestamp,
+        signature,
+    } = result
+    {
+        assert_eq!(
+            validator_address,
+            Id::new([
+                65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84
+            ])
+        );
+        assert_eq!(timestamp, Time::unix_epoch());
+        assert_eq!(
+            signature,
+            crate::signature::Signature::Ed25519(signatory::ed25519::Signature::new(
+                EXAMPLE_SIGNATURE
+            ))
+        );
+    } else {
+        panic!(format!("expected BlockIDFlagCommit, received {:?}", result));
+    }
+}
+
+#[test]
+fn deserialize_commit_sig_nil_vote() {
+    let incoming = r#"
+    {
+        "block_id_flag": 3,
+        "validator_address": "4142434445464748494A4B4C4D4E4F5051525354",
+        "timestamp": "1970-01-01T00:00:00Z",
+        "signature": "Pz49PDs6OTg3NjU0MzIxMC8uLSwrKikoJyYlJCMiISAfHh0cGxoZGBcWFRQTEhEQDw4NDAsKCQgHBgUEAwIBAA=="
+    }
+    "#;
+
+    let result: CommitSig = serde_json::from_str(&incoming).unwrap();
+
+    if let CommitSig::BlockIDFlagNil {
+        validator_address,
+        timestamp,
+        signature,
+    } = result
+    {
+        assert_eq!(
+            validator_address,
+            Id::new([
+                65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84
+            ])
+        );
+        assert_eq!(timestamp, Time::unix_epoch());
+        assert_eq!(
+            signature,
+            crate::signature::Signature::Ed25519(signatory::ed25519::Signature::new(
+                EXAMPLE_SIGNATURE
+            ))
+        );
+    } else {
+        panic!(format!("expected BlockIDFlagNil, received {:?}", result));
+    }
 }

--- a/tendermint/src/serializers/tests.rs
+++ b/tendermint/src/serializers/tests.rs
@@ -160,7 +160,7 @@ fn deserialize_emptyvec_from_null() {
     assert_eq!(result.stringifiedbytes, Vec::<u8>::new());
 }
 
-// <<< Compatibility code for https://github.com/informalsystems/tendermint-rs/issues/260
+// Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
 #[test]
 fn deserialize_commit_sig_absent_vote() {
     let incoming = r#"
@@ -177,32 +177,6 @@ fn deserialize_commit_sig_absent_vote() {
         panic!(format!("expected BlockIDFlagAbsent, received {:?}", result));
     }
 }
-// === Real code after compatibility issue is resolved
-/*
-#[test]
-fn deserialize_commit_sig_absent_vote() {
-    let incoming = r#"
-    {
-        "block_id_flag": 1,
-        "validator_address": "4142434445464748494A4B4C4D4E4F5051525354"
-    }
-    "#;
-
-    let result: CommitSig = serde_json::from_str(&incoming).unwrap();
-
-    if let CommitSig::BlockIDFlagAbsent { validator_address } = result {
-        assert_eq!(
-            validator_address,
-            Id::new([
-                65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84
-            ])
-        );
-    } else {
-        panic!(format!("expected BlockIDFlagAbsent, received {:?}", result));
-    }
-}
-*/
-// >>> end of real code
 
 #[test]
 fn deserialize_commit_sig_commit_vote() {


### PR DESCRIPTION
This is a second - slightly less complex - stab at refactoring CommitSig.

Resolves the following:
#247 - CommitSig refactor
#259 - CommitSig timestamp can be "0000" time instead of null (Go compatibility issue)
#260 - CommitSig validator address not present in Absent votes (Go compatibility issue)

- The two compatibility issues had to be included or else the tests would have failed. With that said, the compatibility issues should remain open until they are fixed in the Go code. The fixed code is also included here and it's commented out.

Please review and comment. We can change the way we deal with the compatibility code, if this looks unruly.

~~- @melekes had two questions in a previous review of this code: where is the validator_address validation (I think that was not implemented before) and why is there a TODO about full verification and what should we do about it. - I would like to clarify these and open issues around them or resolve them in this PR, if we don't need to do anything about them.~~
Anton's questions were either answered in the PR or a new issue opened about it.

~~Because of the above questions, I'm putting this PR into "draft" mode, although it's ready to be reviewed.~~

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGES.md
