### PR TITLE
light tests: remove assertions about number of bisections

### DIFF
--- a/tendermint/tests/lite.rs
+++ b/tendermint/tests/lite.rs
@@ -63,7 +63,6 @@ struct TestBisection {
     height_to_verify: Height,
     now: Time,
     expected_output: Option<String>,
-    expected_num_of_bisections: i32,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -324,13 +323,6 @@ async fn run_bisection_test(case: TestBisection) {
 
             let expected_state = TrustedState::new(untrusted_signed_header, untrusted_next_vals);
             assert_eq!(new_states[new_states.len() - 1], expected_state);
-            let _expected_num_of_bisections = case.expected_num_of_bisections;
-            // TODO: number of bisections started diverting in JSON tests and Rust impl
-            // assert_eq!(
-            //     new_states.len() as i32,
-            //     expected_num_of_bisections,
-            //     "expected # bisections"
-            // );
             assert!(!expects_err);
         }
         Err(_) => {


### PR DESCRIPTION
Quickfix that closes #276 (I had this change uncommited in my workspace and just pushed it)

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
