### PR TITLE
Fix `VotingPowerCalculator::voting_power_in`

### DIFF
--- a/light-client/src/callback.rs
+++ b/light-client/src/callback.rs
@@ -20,7 +20,7 @@ impl<A> Callback<A> {
     }
 
     /// Call the underlying closure on `result`.
-    pub fn call(self, result: A) -> () {
+    pub fn call(self, result: A) {
         (self.inner)(result);
     }
 }

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -132,7 +132,7 @@ impl VotingPowerCalculator for ProdVotingPowerCalculator {
             }
 
             // If the vote is neither absent nor nil, tally its power
-            if true || signature.is_commit() {
+            if signature.is_commit() {
                 tallied_voting_power += validator.power();
             } else {
                 // It's OK. We include stray signatures (~votes for nil)

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -55,10 +55,8 @@ pub trait VotingPowerCalculator: Send {
         untrusted_validators: &ValidatorSet,
     ) -> Result<VotingPower, VerificationError> {
         let trust_threshold = TrustThreshold::TWO_THIRDS;
-
         let voting_power =
             self.voting_power_of(untrusted_header, untrusted_validators, trust_threshold)?;
-
         if trust_threshold.is_enough_power(voting_power.tallied, voting_power.total) {
             Ok(voting_power)
         } else {
@@ -93,7 +91,7 @@ impl VotingPowerCalculator for ProdVotingPowerCalculator {
         let mut tallied_voting_power = 0_u64;
         let mut seen_validators = HashSet::new();
 
-        for (idx, signature) in signatures.into_iter().enumerate() {
+        for (idx, signature) in signatures.iter().enumerate() {
             let vote = vote_from_non_absent_signature(signature, idx as u64, &signed_header.commit);
             let vote = match vote {
                 Some(vote) => vote,
@@ -162,8 +160,8 @@ fn vote_from_non_absent_signature(
             timestamp,
             signature,
         } => (
-            validator_address.clone(),
-            timestamp.clone(),
+            *validator_address,
+            *timestamp,
             signature.clone(),
             Some(commit.block_id.clone()),
         ),
@@ -171,12 +169,7 @@ fn vote_from_non_absent_signature(
             validator_address,
             timestamp,
             signature,
-        } => (
-            validator_address.clone(),
-            timestamp.clone(),
-            signature.clone(),
-            None,
-        ),
+        } => (*validator_address, *timestamp, signature.clone(), None),
     };
 
     Some(Vote {

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -39,7 +39,6 @@ pub trait VotingPowerCalculator: Send {
         untrusted_validators: &ValidatorSet,
         trust_threshold: TrustThreshold,
     ) -> Result<VotingPower, VerificationError> {
-        println!("check_validators_overlap");
         let voting_power =
             self.voting_power_of(untrusted_header, untrusted_validators, trust_threshold)?;
 
@@ -55,7 +54,6 @@ pub trait VotingPowerCalculator: Send {
         untrusted_header: &SignedHeader,
         untrusted_validators: &ValidatorSet,
     ) -> Result<VotingPower, VerificationError> {
-        println!("check_signers_overlap");
         let two_thirds = TrustThreshold::new(2, 3).unwrap();
         let voting_power =
             self.voting_power_of(untrusted_header, untrusted_validators, two_thirds)?;

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -135,7 +135,8 @@ impl VotingPowerCalculator for ProdVotingPowerCalculator {
                 // to measure validator availability.
             }
 
-            // TODO: Break out when we have enough voting power
+            // TODO: Break out of the loop when we have enough voting power.
+            // See https://github.com/informalsystems/tendermint-rs/issues/235
         }
 
         let voting_power = VotingPower {

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -101,28 +101,16 @@ impl VotingPowerCalculator for ProdVotingPowerCalculator {
                 None => continue, // Ok, some signatures can be absent
             };
 
+            // Ensure we only count a validator's power once
             if seen_validators.contains(&vote.validator_address) {
-                println!(
-                    "  > already seen vote from this validator: {}",
-                    vote.validator_address
-                );
-
                 continue;
             } else {
                 seen_validators.insert(vote.validator_address);
             }
 
-            // TODO: Check that we didn't see a vote from this validator twice...
             let validator = match validator_set.validator(vote.validator_address) {
                 Some(validator) => validator,
-                None => {
-                    // println!(
-                    //     "  > couldn't find validator with address {}",
-                    //     vote.validator_address,
-                    // );
-
-                    continue;
-                }
+                None => continue, // Cannot find matching validator, so we skip the vote
             };
 
             let signed_vote = SignedVote::new(

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -104,7 +104,9 @@ impl VotingPowerCalculator for ProdVotingPowerCalculator {
         for (signature, vote) in non_absent_votes {
             // Ensure we only count a validator's power once
             if seen_validators.contains(&vote.validator_address) {
-                continue;
+                bail!(VerificationError::DuplicateValidator(
+                    vote.validator_address
+                ));
             } else {
                 seen_validators.insert(vote.validator_address);
             }

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -54,11 +54,12 @@ pub trait VotingPowerCalculator: Send {
         untrusted_header: &SignedHeader,
         untrusted_validators: &ValidatorSet,
     ) -> Result<VotingPower, VerificationError> {
-        let two_thirds = TrustThreshold::new(2, 3).unwrap();
-        let voting_power =
-            self.voting_power_of(untrusted_header, untrusted_validators, two_thirds)?;
+        let trust_threshold = TrustThreshold::TWO_THIRDS;
 
-        if two_thirds.is_enough_power(voting_power.tallied, voting_power.total) {
+        let voting_power =
+            self.voting_power_of(untrusted_header, untrusted_validators, trust_threshold)?;
+
+        if trust_threshold.is_enough_power(voting_power.tallied, voting_power.total) {
             Ok(voting_power)
         } else {
             Err(VerificationError::InsufficientSignersOverlap(voting_power))

--- a/light-client/src/predicates/errors.rs
+++ b/light-client/src/predicates/errors.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::errors::ErrorExt;
 use crate::operations::voting_power::VotingPowerTally;
-use crate::types::{Hash, Height, Time, Validator};
+use crate::types::{Hash, Height, Time, Validator, ValidatorAddress};
 
 /// The various errors which can be raised by the verifier component,
 /// when validating or verifying a light block.
@@ -22,13 +22,15 @@ pub enum VerificationError {
     #[error("insufficient signers overlap: {0}")]
     InsufficientSignersOverlap(VotingPowerTally),
 
-    #[error(
-        "validators and signatures count do no match: {validators_count} != {signatures_count}"
-    )]
-    ValidatorsAndSignaturesCountMismatch {
-        validators_count: usize,
-        signatures_count: usize,
-    },
+    // #[error(
+    //     "validators and signatures count do no match: {validators_count} != {signatures_count}"
+    // )]
+    // ValidatorsAndSignaturesCountMismatch {
+    //     validators_count: usize,
+    //     signatures_count: usize,
+    // },
+    #[error("duplicate validator with address {0}")]
+    DuplicateValidator(ValidatorAddress),
 
     #[error("Couldn't verify signature `{signature:?}` with validator `{validator:?}` on sign_bytes `{sign_bytes:?}`")]
     InvalidSignature {

--- a/light-client/src/predicates/errors.rs
+++ b/light-client/src/predicates/errors.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::errors::ErrorExt;
-use crate::operations::voting_power::VotingPower;
+use crate::operations::voting_power::VotingPowerTally;
 use crate::types::{Hash, Height, Time, Validator};
 
 /// The various errors which can be raised by the verifier component,
@@ -17,10 +17,10 @@ pub enum VerificationError {
     ImplementationSpecific(String),
 
     #[error("not enough trust because insufficient validators overlap: {0}")]
-    NotEnoughTrust(VotingPower),
+    NotEnoughTrust(VotingPowerTally),
 
     #[error("insufficient signers overlap: {0}")]
-    InsufficientSignersOverlap(VotingPower),
+    InsufficientSignersOverlap(VotingPowerTally),
 
     #[error(
         "validators and signatures count do no match: {validators_count} != {signatures_count}"

--- a/light-client/src/predicates/errors.rs
+++ b/light-client/src/predicates/errors.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::errors::ErrorExt;
-use crate::types::{Hash, Height, Time, TrustThreshold};
+use crate::operations::voting_power::VotingPower;
+use crate::types::{Hash, Height, Time, Validator};
 
 /// The various errors which can be raised by the verifier component,
 /// when validating or verifying a light block.
@@ -15,20 +16,26 @@ pub enum VerificationError {
     #[error("implementation specific: {0}")]
     ImplementationSpecific(String),
 
+    #[error("not enough trust because insufficient validators overlap: {0}")]
+    NotEnoughTrust(VotingPower),
+
+    #[error("insufficient signers overlap: {0}")]
+    InsufficientSignersOverlap(VotingPower),
+
     #[error(
-        "insufficient validators overlap: total_power={total_power} signed_power={signed_power} trust_threshold={trust_threshold}"
+        "validators and signatures count do no match: {validators_count} != {signatures_count}"
     )]
-    InsufficientValidatorsOverlap {
-        total_power: u64,
-        signed_power: u64,
-        trust_threshold: TrustThreshold,
+    ValidatorsAndSignaturesCountMismatch {
+        validators_count: usize,
+        signatures_count: usize,
     },
 
-    #[error("insufficient voting power: total_power={total_power} voting_power={voting_power}")]
-    InsufficientVotingPower { total_power: u64, voting_power: u64 },
-
-    #[error("invalid commit power: total_power={total_power} signed_power={signed_power}")]
-    InsufficientCommitPower { total_power: u64, signed_power: u64 },
+    #[error("Couldn't verify signature `{signature:?}` with validator `{validator:?}` on sign_bytes `{sign_bytes:?}`")]
+    InvalidSignature {
+        signature: Vec<u8>,
+        validator: Validator,
+        sign_bytes: Vec<u8>,
+    },
 
     #[error("invalid commit: {0}")]
     InvalidCommit(String),
@@ -76,7 +83,7 @@ impl ErrorExt for VerificationError {
     /// Whether this error means that the light block
     /// cannot be trusted w.r.t. the latest trusted state.
     fn not_enough_trust(&self) -> bool {
-        if let Self::InsufficientValidatorsOverlap { .. } = self {
+        if let Self::NotEnoughTrust { .. } = self {
             true
         } else {
             false

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -9,6 +9,7 @@ use tendermint::{
         Commit as TMCommit,
     },
     lite::TrustThresholdFraction,
+    validator::Info as TMValidatorInfo,
     validator::Set as TMValidatorSet,
 };
 
@@ -29,6 +30,9 @@ pub type Header = TMHeader;
 
 /// Set of validators
 pub type ValidatorSet = TMValidatorSet;
+
+/// Info about a single validator
+pub type Validator = TMValidatorInfo;
 
 /// A commit contains the justification (ie. a set of signatures)
 /// that a block was consensus, as committed by a set previous block of validators.

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -4,6 +4,7 @@ use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
 use tendermint::{
+    account::Id as TMAccountId,
     block::{
         header::Header as TMHeader, signed_header::SignedHeader as TMSignedHeader,
         Commit as TMCommit,
@@ -33,6 +34,9 @@ pub type ValidatorSet = TMValidatorSet;
 
 /// Info about a single validator
 pub type Validator = TMValidatorInfo;
+
+/// Validator address
+pub type ValidatorAddress = TMAccountId;
 
 /// A commit contains the justification (ie. a set of signatures)
 /// that a block was consensus, as committed by a set previous block of validators.

--- a/light-client/tests/light_client.rs
+++ b/light-client/tests/light_client.rs
@@ -104,7 +104,11 @@ fn run_test_case(tc: TestCase<LightBlock>) {
 
                 latest_trusted = Trusted::new(new_state.signed_header, new_state.next_validators);
             }
-            Err(_) => {
+            Err(e) => {
+                dbg!(e);
+                // if !expects_err {
+                //     dbg!(e);
+                // }
                 assert!(expects_err);
             }
         }
@@ -240,9 +244,10 @@ fn run_bisection_test(tc: TestBisection<LightBlock>) {
             assert!(!expects_err);
         }
         Err(e) => {
-            if !expects_err {
-                dbg!(e);
-            }
+            dbg!(e);
+            // if !expects_err {
+            //     dbg!(e);
+            // }
             assert!(expects_err);
         }
     }

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -97,6 +97,12 @@ pub struct TrustThresholdFraction {
 }
 
 impl TrustThresholdFraction {
+    /// Constant for a trust threshold of 2/3.
+    pub const TWO_THIRDS: Self = Self {
+        numerator: 2,
+        denominator: 3,
+    };
+
     /// Instantiate a TrustThresholdFraction if the given denominator and
     /// numerator are valid.
     ///


### PR DESCRIPTION
Fix #282 
Fix #335

 - Provide two helper methods for checking validators overlap and if there is enough trust w.r.t. the trusted state
- Only count `Commit` signatures towards the voting power (#282)
- Do not rely on `signed_votes` method to get the votes
- Only count the voting power of a validator once (#335)

### Notes

- [x] Needs to throw a proper error in some places
- [x] Trust threshold is currently hardcoded and should be rather passed in
- [x] The method should likely be renamed or its signature should be changed to reflect the new behavior
- [ ] ~~Most of logic and comments are taken from the Go code, so perhaps some attribution should be added as well~~
- [ ] ~~Tests are failing because the signatures currently fail to verify, likely because of mismatch with their validator~~

---

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
