### PR TITLE
Update signatory to v0.20

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -46,7 +46,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 serde_bytes = "0.11"
 serde_repr = "0.1"
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 signatory = { version = "0.20", features = ["ed25519", "ecdsa"] }
 signatory-dalek = "0.20"
 signatory-secp256k1 = "0.20"
@@ -59,7 +59,7 @@ uuid = { version = "0.8", default-features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 async-tungstenite = {version="0.5", features = ["tokio-runtime"]}
 tokio = { version = "0.2", features = ["macros"] }
-ripemd160 = "0.8"
+ripemd160 = "0.9"
 
 [dev-dependencies]
 serde_json = "1"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -47,9 +47,9 @@ serde_json = { version = "1" }
 serde_bytes = "0.11"
 serde_repr = "0.1"
 sha2 = { version = "0.8", default-features = false }
-signatory = { version = "0.19", features = ["ed25519", "ecdsa"] }
-signatory-dalek = "0.19"
-signatory-secp256k1 = "0.19"
+signatory = { version = "0.20", features = ["ed25519", "ecdsa"] }
+signatory-dalek = "0.20"
+signatory-secp256k1 = "0.20"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tai64 = { version = "3", features = ["chrono"] }

--- a/tendermint/src/amino_types.rs
+++ b/tendermint/src/amino_types.rs
@@ -42,8 +42,8 @@ use sha2::{Digest, Sha256};
 /// Compute the Amino prefix for the given registered type name
 pub fn compute_prefix(name: &str) -> Vec<u8> {
     let mut sh = Sha256::default();
-    sh.input(name.as_bytes());
-    let output = sh.result();
+    sh.update(name.as_bytes());
+    let output = sh.finalize();
 
     output
         .iter()


### PR DESCRIPTION
Updates:
`ripemd160` v0.8 => v0.9
`sha2` v0.8 => v0.9
`signatory` v0.19 => v0.20
