### PR TITLE
Add integration test pinned to tendermint-go v0.33.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,11 +61,35 @@ jobs:
           command: test
           args: --all-features --no-fail-fast
 
-  test-integration-ignored:
+  # TODO(shonfeder): remove duplication once GitHub addresses one of these
+  #  - https://github.community/t/support-for-yaml-anchors/16128/15
+  #  - https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851/13
+  #  - https://github.community/t/using-matrix-variable-in-docker-image-name/17296
+  test-integration-stable:
     runs-on: ubuntu-latest
     services:
       tendermint:
-        image: tendermint/tendermint
+        image: tendermint/tendermint:v0.33.5
+        ports:
+          - 26656:26656
+          - 26657:26657
+          - 26660:26660
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p tendermint --test integration --no-fail-fast -- --ignored
+
+  test-integration-latest:
+    runs-on: ubuntu-latest
+    services:
+      tendermint:
+        image: tendermint/tendermint:latest
         ports:
           - 26656:26656
           - 26657:26657

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@ CommitSig:
 - Added CommitSig timestamp zero-check compatibility code [#259](https://github.com/informalsystems/tendermint-rs/issues/259)
 
 Testing:
-- Updated abci_info test to 0.17.0 ([#249](https://github.com/informalsystems/tendermint-rs/issues/249))
+- Add integration test to track tendermint-go v0.33.5 ([#324](https://github.com/informalsystems/tendermint-rs/pull/324))
+- Remove test for hard-coded version in `abci_info` ([#324](https://github.com/informalsystems/tendermint-rs/pull/324))
 
 Serialization:
 - Refactor serializers library to use modules, give a nicer annotation to structs and separated into its own folder. ([#247](https://github.com/informalsystems/tendermint-rs/issues/247))

--- a/tendermint/tests/integration.rs
+++ b/tendermint/tests/integration.rs
@@ -35,7 +35,6 @@ mod rpc {
     async fn abci_info() {
         let abci_info = localhost_rpc_client().abci_info().await.unwrap();
 
-        assert_eq!(&abci_info.version, "0.17.0");
         assert_eq!(abci_info.app_version, 1u64);
         // the kvstore app's reply will contain "{\"size\":0}" as data right from the start
         assert_eq!(&abci_info.data, "{\"size\":0}");


### PR DESCRIPTION
Closes #304

With this change, CI runs two integration tests:

1. A `stable` test to protect against regressions, run against a pinned
version of the tendermint/tendermint docker image.
2. A `latest` test to track whether we're maintaining parity with the
latest development version of tendermint-go.

IIUC, we'd ideally like (1) to be a required test, and to get visibility on (2) but not block the PR if it fails. I can configure (2) so that it the job succeeds even if the step fails, but then we lose clear visibility on the failure.

Please see individual commits for more detail.

* [X] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGES.md
