### PR TITLE
rpc: guard client with feature flag

### DIFF
--- a/light-node/Cargo.toml
+++ b/light-node/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 gumdrop = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 tendermint = { version = "0.13.0-dev", path = "../tendermint" }
-tendermint-rpc = { version = "0.1.0", path = "../rpc" }
+tendermint-rpc = { version = "0.1.0", path = "../rpc", features = [ "client" ] }
 tokio = { version = "0.2", features = ["full"] }
 
 [dependencies.abscissa_core]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -4,17 +4,22 @@ version = "0.1.0"
 authors = ["Alexander Simmerl <a.simmerl@gmail.com>"]
 edition = "2018"
 
+[features]
+default = []
+client = [ "async-tungstenite", "futures", "http", "hyper", "tokio" ]
+
 [dependencies]
-async-tungstenite = {version="0.5", features = ["tokio-runtime"]}
 bytes = "0.5"
-futures = "0.3"
 getrandom = "0.1"
-http = "0.2"
-hyper = "0.13"
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 serde_json = "1"
 tendermint = { version = "0.13.0", path = "../tendermint" }
 thiserror = "1"
-tokio = { version = "0.2", features = ["macros"] }
 uuid = { version = "0.8", default-features = false }
+
+async-tungstenite = { version="0.5", features = ["tokio-runtime"], optional = true }
+futures = { version = "0.3", optional = true }
+http = { version = "0.2", optional = true }
+hyper = { version = "0.13", optional = true }
+tokio = { version = "0.2", features = ["macros"], optional = true }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -10,6 +10,8 @@ use tendermint::Genesis;
 
 use crate::{endpoint::*, Error, Request, Response};
 
+pub mod event_listener;
+
 /// Tendermint RPC client.
 ///
 /// Presently supports JSONRPC via HTTP.

--- a/rpc/src/client/event_listener.rs
+++ b/rpc/src/client/event_listener.rs
@@ -1,5 +1,8 @@
 //! Tendermint Websocket event listener client
 
+// TODO(ismail): document fields or re-use the abci types
+#![allow(missing_docs)]
+
 use async_tungstenite::{tokio::connect_async, tokio::TokioAdapter, tungstenite::Message};
 use futures::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -1,6 +1,8 @@
 //! JSONRPC error types
 
+#[cfg(feature = "client")]
 use async_tungstenite::tungstenite::Error as WSError;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Display};
 use thiserror::Error;
@@ -102,18 +104,21 @@ impl Display for Error {
     }
 }
 
+#[cfg(feature = "client")]
 impl From<http::Error> for Error {
     fn from(http_error: http::Error) -> Error {
         Error::http_error(http_error.to_string())
     }
 }
 
+#[cfg(feature = "client")]
 impl From<hyper::Error> for Error {
     fn from(hyper_error: hyper::Error) -> Error {
         Error::http_error(hyper_error.to_string())
     }
 }
 
+#[cfg(feature = "client")]
 impl From<WSError> for Error {
     fn from(websocket_error: WSError) -> Error {
         Error::websocket_error(websocket_error.to_string())

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,11 +1,12 @@
 //! Tendermint RPC definitons and types.
 
+#[cfg(feature = "client")]
 mod client;
+#[cfg(feature = "client")]
+pub use client::{event_listener, Client};
+
 pub mod endpoint;
 pub mod error;
-// TODO(ismail): document fields or re-use the abci types
-#[allow(missing_docs)]
-pub mod event_listener;
 mod id;
 mod method;
 pub mod request;
@@ -13,6 +14,5 @@ pub mod response;
 mod version;
 
 pub use self::{
-    client::Client, error::Error, id::Id, method::Method, request::Request, response::Response,
-    version::Version,
+    error::Error, id::Id, method::Method, request::Request, response::Response, version::Version,
 };

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -56,5 +56,5 @@ zeroize = { version = "1.1", features = ["zeroize_derive"] }
 ripemd160 = "0.9"
 
 [dev-dependencies]
-tendermint-rpc = { version = "0.1.0", path = "../rpc" }
+tendermint-rpc = { version = "0.1.0", path = "../rpc", features = [ "client" ] }
 tokio = { version = "0.2", features = [ "macros" ] }


### PR DESCRIPTION
Guard client code paths To avoid the transient dependency on net related crates for users who are primarily interested in the core types.

Follow-up #339
Ref #337

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] ~~Updated all relevant documentation in docs~~
* [ ] ~~Updated all code comments where relevant~~
* [ ] ~~Wrote tests~~
* [ ] Updated CHANGES.md
