### PR TITLE
add license meta data to rpc crate

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.14.0"
 authors = ["Alexander Simmerl <a.simmerl@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
+homepage   = "https://www.tendermint.com/"
+repository = "https://github.com/informalsystems/tendermint-rs"
+readme     = "README.md"
 
 description = """
     tenndermint-rpc contains the core types returned by a Tendermint node's RPC endpoint.

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "tendermint-rpc"
 version = "0.14.0"
 authors = ["Alexander Simmerl <a.simmerl@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
 
 description = """
     tenndermint-rpc contains the core types returned by a Tendermint node's RPC endpoint.


### PR DESCRIPTION
Running into:
```
Compiling tendermint-rpc v0.14.0 (/Users/ismail/IdeaProjects/tendermint-rs/target/package/tendermint-rpc-0.14.0)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 10s
   Uploading tendermint-rpc v0.14.0 (/Users/ismail/IdeaProjects/tendermint-rs/rpc)
error: api errors (status 200 OK): missing or empty metadata fields: license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata
```
when trying to publish the rpc crate.
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
