### PR TITLE
Change Licence terms to all files in the Repo, not only README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in any programming language.
 Copyright © 2020 Informal Systems
 
 Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+you may not use the files in this repository except in compliance with the License.
 You may obtain a copy of the License at
 
     https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
As written now, licensed is only the README.md file itself. The license needs to be applied to the whole repository.