### PR TITLE
Move ValidatorSet::hash method over the HeaderHasher trait

### DIFF
--- a/light-client/src/components/verifier.rs
+++ b/light-client/src/components/verifier.rs
@@ -3,8 +3,8 @@ use crate::{
     errors::ErrorExt,
     light_client::Options,
     operations::{
-        CommitValidator, HeaderHasher, ProdCommitValidator, ProdHeaderHasher,
-        ProdVotingPowerCalculator, VotingPowerCalculator,
+        CommitValidator, Hasher, ProdCommitValidator, ProdHasher, ProdVotingPowerCalculator,
+        VotingPowerCalculator,
     },
     types::LightBlock,
 };
@@ -60,7 +60,7 @@ pub struct ProdVerifier {
     predicates: Box<dyn VerificationPredicates>,
     voting_power_calculator: Box<dyn VotingPowerCalculator>,
     commit_validator: Box<dyn CommitValidator>,
-    header_hasher: Box<dyn HeaderHasher>,
+    hasher: Box<dyn Hasher>,
 }
 
 impl ProdVerifier {
@@ -68,13 +68,13 @@ impl ProdVerifier {
         predicates: impl VerificationPredicates + 'static,
         voting_power_calculator: impl VotingPowerCalculator + 'static,
         commit_validator: impl CommitValidator + 'static,
-        header_hasher: impl HeaderHasher + 'static,
+        hasher: impl Hasher + 'static,
     ) -> Self {
         Self {
             predicates: Box::new(predicates),
             voting_power_calculator: Box::new(voting_power_calculator),
             commit_validator: Box::new(commit_validator),
-            header_hasher: Box::new(header_hasher),
+            hasher: Box::new(hasher),
         }
     }
 }
@@ -85,7 +85,7 @@ impl Default for ProdVerifier {
             ProdPredicates,
             ProdVotingPowerCalculator,
             ProdCommitValidator,
-            ProdHeaderHasher,
+            ProdHasher,
         )
     }
 }
@@ -96,7 +96,7 @@ impl Verifier for ProdVerifier {
             &*self.predicates,
             &*self.voting_power_calculator,
             &*self.commit_validator,
-            &*self.header_hasher,
+            &*self.hasher,
             &trusted,
             &untrusted,
             options,

--- a/light-client/src/operations.rs
+++ b/light-client/src/operations.rs
@@ -1,7 +1,7 @@
 //! Crypto function traits allowing mocking out during testing
 
-pub mod header_hasher;
-pub use self::header_hasher::*;
+pub mod hasher;
+pub use self::hasher::*;
 
 pub mod voting_power;
 pub use self::voting_power::*;

--- a/light-client/src/operations/commit_validator.rs
+++ b/light-client/src/operations/commit_validator.rs
@@ -31,6 +31,7 @@ impl CommitValidator for ProdCommitValidator {
                 "no signatures for commit".to_string()
             ));
         }
+
         if signed_header.commit.signatures.len() != validator_set.validators().len() {
             bail!(VerificationError::ImplementationSpecific(format!(
                 "pre-commit length: {} doesn't match validator length: {}",


### PR DESCRIPTION
And rename the latter to just `Hasher`.

Close: #359
Ref: #342 

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
