### PR TITLE
Simplify basic bisecting scheduler logic

### DIFF
--- a/light-client/src/components/scheduler.rs
+++ b/light-client/src/components/scheduler.rs
@@ -63,14 +63,13 @@ pub fn basic_bisecting_schedule(
         .map(|lb| lb.height())
         .unwrap();
 
-    if trusted_height == current_height && trusted_height < target_height {
-        target_height
-    } else if trusted_height < current_height && trusted_height < target_height {
-        midpoint(trusted_height, current_height)
-    } else if trusted_height == target_height {
+    if trusted_height == current_height {
+        // We can't go further back, so let's try to verify the target height again,
+        // hopefully we have enough trust in the store by now.
         target_height
     } else {
-        midpoint(current_height, target_height)
+        // Pick a midpoint H between `trusted_height <= H <= current_height`.
+        midpoint(trusted_height, current_height)
     }
 }
 
@@ -118,8 +117,8 @@ pub fn valid_schedule(
     }
 }
 
-#[pre(low < high)]
-#[post(low < ret && ret <= high)]
+#[pre(low <= high)]
+#[post(low <= ret && ret <= high)]
 fn midpoint(low: Height, high: Height) -> Height {
     low + (high + 1 - low) / 2
 }


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

See: #334

### Question

Should the items below can be split into their own issues, or discussed directly at #334?

- [ ] Look at simplifying the `valid_schedule` function as well (ie. the postcondition for all schedulers).
- [ ] As mentioned in #334, can we get rid of the `current_height` parameter and depend only on the light store and the target height to decide what to verify next?
- [ ] Should we also look at reducing the coupling between the scheduler and the light store? Perhaps by introducing new methods in the `Scheduler` trait? It would then be the responsibility of the light client or some wrapper to call the appropriate method on the scheduler.

---

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
