### PR TITLE
tendermint v0.14.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.14.1] (2020-06-23)
+
+- Update `prost-amino`/`prost-amino-derive` to v0.6 ([#367])
+
+[#367]: https://github.com/informalsystems/tendermint-rs/issues/367
+
 ## [0.14.0] (2020-06-19)
 
 This release mainly targets compatibility with Tendermint [v0.33.x] but contains a lot of smaller improvements regarding testing and (de)serialization.

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.14.0" # Also update `html_root_url` in lib.rs and
+version    = "0.14.1" # Also update `html_root_url` in lib.rs and
                       # depending crates (rpc, light-node, ..) when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -13,7 +13,7 @@
     unused_qualifications
 )]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/tendermint/0.14.0")]
+#![doc(html_root_url = "https://docs.rs/tendermint/0.14.1")]
 
 #[macro_use]
 pub mod error;


### PR DESCRIPTION
Cutting a small point release to get the following version bump for the KMS:

- Update `prost-amino`/`prost-amino-derive` to v0.6 ([#367])

[#367]: https://github.com/informalsystems/tendermint-rs/issues/367