### PR TITLE
Rename `untrusted_validators` param to `trusted_validators` in `check_enough_trust`

### DIFF
--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -42,11 +42,11 @@ pub trait VotingPowerCalculator: Send {
     fn check_enough_trust(
         &self,
         untrusted_header: &SignedHeader,
-        untrusted_validators: &ValidatorSet,
+        trusted_validators: &ValidatorSet,
         trust_threshold: TrustThreshold,
     ) -> Result<(), VerificationError> {
         let voting_power =
-            self.voting_power_in(untrusted_header, untrusted_validators, trust_threshold)?;
+            self.voting_power_in(untrusted_header, trusted_validators, trust_threshold)?;
 
         if trust_threshold.is_enough_power(voting_power.tallied, voting_power.total) {
             Ok(())


### PR DESCRIPTION
See https://github.com/informalsystems/tendermint-rs/pull/306#discussion_r445121843

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
