### PR TITLE
light-client: turn Handle into a trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Light Client:
 
 - Expose latest_trusted from Supervisor Handle ([#394])
+- Turn `Handle` into a trait for ease of integration ([#401])
+
+[#394]: https://github.com/informalsystems/tendermint-rs/pull/394
+[#401]: https://github.com/informalsystems/tendermint-rs/pull/401
 
 ## [0.14.1] (2020-06-23)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 Light Client:
 
 - Expose latest_trusted from Supervisor Handle ([#394])
-- Turn `Handle` into a trait for ease of integration ([#401])
+- Turn `Handle` into a trait for ease of integration and testability ([#401])
 
 [#394]: https://github.com/informalsystems/tendermint-rs/pull/394
 [#401]: https://github.com/informalsystems/tendermint-rs/pull/401

--- a/light-client/examples/light_client.rs
+++ b/light-client/examples/light_client.rs
@@ -1,3 +1,12 @@
+use std::collections::HashMap;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use gumdrop::Options;
+
+use tendermint_light_client::supervisor::{Handle as _, Instance, Supervisor};
 use tendermint_light_client::{
     components::{
         clock::SystemClock,
@@ -11,16 +20,7 @@ use tendermint_light_client::{
     peer_list::PeerList,
     state::State,
     store::{sled::SledStore, LightStore},
-    supervisor::{Instance, Supervisor},
     types::{Height, PeerId, Status, Time, TrustThreshold},
-};
-
-use gumdrop::Options;
-
-use std::collections::HashMap;
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
 };
 
 #[derive(Debug, Options)]


### PR DESCRIPTION
As we start to depend on the surface of the `Handle` we benefit from it being a trait that can be implemented on a per need basis. This will result in less overhead constructing object graphs in places where we want to assert behaviour of other types in remote places, i.e. the light-node RPC server. Overall we hope for an increased ease in writing tests on module level.

Ref #219
Ref #398

* [x] Referenced an issue explaining the need for the change
* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [ ] ~~Wrote tests~~
* [x] Updated CHANGES.md
