### PR TITLE
Minor comment updates and var renames

### DIFF
--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -34,7 +34,7 @@ pub enum Fork {
 
 /// Interface for a fork detector
 pub trait ForkDetector: Send {
-    /// Detect forks using the given the verified block, trusted block,
+    /// Detect forks using the given verified block, trusted block,
     /// and list of witnesses to verify the given light block against.
     fn detect_forks(
         &self,

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -34,12 +34,12 @@ pub enum Fork {
 
 /// Interface for a fork detector
 pub trait ForkDetector: Send {
-    /// Detect forks using the given light block, trusted state,
+    /// Detect forks using the given the verified block, trusted block,
     /// and list of witnesses to verify the given light block against.
     fn detect_forks(
         &self,
         verified_block: &LightBlock,
-        trusted_state: &LightBlock,
+        trusted_block: &LightBlock,
         witnesses: Vec<&Instance>,
     ) -> Result<ForkDetection, Error>;
 }
@@ -80,7 +80,7 @@ impl ForkDetector for ProdForkDetector {
     fn detect_forks(
         &self,
         verified_block: &LightBlock,
-        trusted_state: &LightBlock,
+        trusted_block: &LightBlock,
         witnesses: Vec<&Instance>,
     ) -> Result<ForkDetection, Error> {
         let primary_hash = self
@@ -105,7 +105,7 @@ impl ForkDetector for ProdForkDetector {
 
             // XXX: Shouldn't this have already happened? Why do we need
             // to re-mark the trusted block as verified?
-            state.light_store.update(&trusted_state, Status::Verified);
+            state.light_store.update(&trusted_block, Status::Verified);
 
             state.light_store.update(&witness_block, Status::Unverified);
 

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -103,11 +103,13 @@ impl ForkDetector for ProdForkDetector {
                 continue;
             }
 
-            // XXX: Shouldn't this have already happened? Why do we need
-            // to re-mark the trusted block as verified?
-            state.light_store.update(&trusted_block, Status::Verified);
+            state
+                .light_store
+                .insert(trusted_block.clone(), Status::Verified);
 
-            state.light_store.update(&witness_block, Status::Unverified);
+            state
+                .light_store
+                .insert(witness_block.clone(), Status::Unverified);
 
             let result = witness
                 .light_client

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -38,7 +38,7 @@ pub trait ForkDetector: Send {
     /// and list of witnesses to verify the given light block against.
     fn detect_forks(
         &self,
-        light_block: &LightBlock,
+        verified_block: &LightBlock,
         trusted_state: &LightBlock,
         witnesses: Vec<&Instance>,
     ) -> Result<ForkDetection, Error>;
@@ -79,11 +79,13 @@ impl ForkDetector for ProdForkDetector {
     /// Perform fork detection. See the documentation `ProdForkDetector` for details.
     fn detect_forks(
         &self,
-        light_block: &LightBlock,
+        verified_block: &LightBlock,
         trusted_state: &LightBlock,
         witnesses: Vec<&Instance>,
     ) -> Result<ForkDetection, Error> {
-        let primary_hash = self.hasher.hash_header(&light_block.signed_header.header);
+        let primary_hash = self
+            .hasher
+            .hash_header(&verified_block.signed_header.header);
 
         let mut forks = Vec::with_capacity(witnesses.len());
 
@@ -92,7 +94,7 @@ impl ForkDetector for ProdForkDetector {
 
             let witness_block = witness
                 .light_client
-                .get_or_fetch_block(light_block.height(), &mut state)?;
+                .get_or_fetch_block(verified_block.height(), &mut state)?;
 
             let witness_hash = self.hasher.hash_header(&witness_block.signed_header.header);
 
@@ -109,16 +111,16 @@ impl ForkDetector for ProdForkDetector {
 
             let result = witness
                 .light_client
-                .verify_to_target(light_block.height(), &mut state);
+                .verify_to_target(verified_block.height(), &mut state);
 
             match result {
                 Ok(_) => forks.push(Fork::Forked {
-                    primary: light_block.clone(),
+                    primary: verified_block.clone(),
                     witness: witness_block,
                 }),
                 Err(e) if e.kind().has_expired() => {
                     forks.push(Fork::Forked {
-                        primary: light_block.clone(),
+                        primary: verified_block.clone(),
                         witness: witness_block,
                     });
                 }

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -101,6 +101,8 @@ impl ForkDetector for ProdForkDetector {
                 continue;
             }
 
+            // XXX: Shouldn't this have already happened? Why do we need
+            // to re-mark the trusted block as verified?
             state.light_store.update(&trusted_state, Status::Verified);
 
             state.light_store.update(&witness_block, Status::Unverified);

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -26,9 +26,13 @@ pub struct Options {
     /// and trusted validator set is sufficient for a commit to be
     /// accepted going forward.
     pub trust_threshold: TrustThreshold,
-    /// The trusting period
+    /// How long a validator set is trusted for (must be shorter than the chain's
+    /// unbonding period)
     pub trusting_period: Duration,
     /// Correction parameter dealing with only approximately synchronized clocks.
+    /// The local clock should always be ahead of timestamps from the blockchain; this
+    /// is the maximum amount that the local clock may drift behind a timestamp from the
+    /// blockchain.
     pub clock_drift: Duration,
     /// The current time
     pub now: Time,
@@ -183,7 +187,7 @@ impl LightClient {
                 });
             }
 
-            // Trace the current height as a dependency of the block at the target height
+            // Log the current height as a dependency of the block at the target height
             state.trace_block(target_height, current_height);
 
             // If the trusted state is now at a height equal to the target height, we are done. [LCV-DIST-LIFE.1]

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -298,19 +298,19 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Perform fork detection with the given verified block and trusted state.
+    /// Perform fork detection with the given verified block and trusted block.
     #[pre(self.peers.primary().is_some())]
     fn detect_forks(
         &self,
         verified_block: &LightBlock,
-        trusted_state: &LightBlock,
+        trusted_block: &LightBlock,
     ) -> Result<ForkDetection, Error> {
         if self.peers.witnesses().is_empty() {
             bail!(ErrorKind::NoWitnesses);
         }
 
         self.fork_detector
-            .detect_forks(verified_block, &trusted_state, self.peers.witnesses())
+            .detect_forks(verified_block, &trusted_block, self.peers.witnesses())
     }
 
     /// Run the supervisor event loop in the same thread.

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -62,7 +62,7 @@ enum HandleInput {
     LatestTrusted(Callback<Result<Option<LightBlock>, Error>>),
 }
 
-/// An light client `Instance` packages a `LightClient` together with its `State`.
+/// A light client `Instance` packages a `LightClient` together with its `State`.
 #[derive(Debug)]
 pub struct Instance {
     /// The light client for this instance


### PR DESCRIPTION
Update a few comments.

Rename `light_block -> verified_block` and `trusted_state -> trusted_block` to clarify the distinction during fork detection.

Also questions about:

- (re-) marking the trusted block as verified 
- reporting evidence to all peers