### PR TITLE
chore: remove redundant field name

### DIFF
--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -54,7 +54,7 @@ pub trait VerificationPredicates: Send {
             light_block.signed_header.header.next_validators_hash == next_validators_hash,
             VerificationError::InvalidNextValidatorSet {
                 header_next_validators_hash: light_block.signed_header.header.next_validators_hash,
-                next_validators_hash: next_validators_hash
+                next_validators_hash,
             }
         );
 


### PR DESCRIPTION
This is coming up in automated integrations and in local tooling as
a warning. To reduce the noise it causes we remove the redundant field
assignment.

Ref: https://rust-lang.github.io/rust-clippy/master/#redundant_field_names

***

* [ ] ~~Referenced an issue explaining the need for the change~~
* [ ] ~~Updated all relevant documentation in docs~~
* [ ] ~~Updated all code comments where relevant~~
* [ ] ~~Wrote tests~~
* [ ] ~~Updated CHANGES.md~~
