### PR TITLE
close #409: sort validators by address on deserialization

### DIFF
--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -55,7 +55,8 @@ fn parse_vals<'de, D>(d: D) -> Result<Vec<Info>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let mut vals: Vec<Info> = Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())?;
+    let mut vals: Vec<Info>
+        = Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())?;
     Set::sort_validators(&mut vals);
     Ok(vals)
 }

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -35,7 +35,7 @@ impl Set {
     /// Sort the validators according to the current Tendermint requirements
     /// (v. 0.33 -> by validator address, ascending)
     fn sort_validators(vals: &mut Vec<Info>) {
-        vals.sort_by(|v1, v2| v1.address.partial_cmp(&v2.address).unwrap());
+        vals.sort_by_key(|v| v.address);
     }
 }
 

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -55,8 +55,8 @@ fn parse_vals<'de, D>(d: D) -> Result<Vec<Info>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let mut vals: Vec<Info>
-        = Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())?;
+    let mut vals: Vec<Info> =
+        Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())?;
     Set::sort_validators(&mut vals);
     Ok(vals)
 }

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -23,13 +23,19 @@ impl Set {
     /// Create a new validator set.
     /// vals is mutable so it can be sorted by address.
     pub fn new(mut vals: Vec<Info>) -> Set {
-        vals.sort_by(|v1, v2| v1.address.partial_cmp(&v2.address).unwrap());
+        Self::sort_validators(&mut vals);
         Set { validators: vals }
     }
 
     /// Get Info of the underlying validators.
     pub fn validators(&self) -> &Vec<Info> {
         &self.validators
+    }
+
+    /// Sort the validators according to the current Tendermint requirements
+    /// (v. 0.33 -> by validator address, ascending)
+    fn sort_validators(vals: &mut Vec<Info>) {
+        vals.sort_by(|v1, v2| v1.address.partial_cmp(&v2.address).unwrap());
     }
 }
 
@@ -49,7 +55,9 @@ fn parse_vals<'de, D>(d: D) -> Result<Vec<Info>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())
+    let mut vals: Vec<Info> = Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())?;
+    Set::sort_validators(&mut vals);
+    Ok(vals)
 }
 
 /// Validator information


### PR DESCRIPTION
As discussed in #409, in order to maintain the type invariant of `validator::Set`, the validators are now sorted correctly also on deserializing the structure.

*NB! when migrating from v. 0.33 to 0.34, the sorting order in `sort_validators` function needs to be changed.*

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
