### PR TITLE
abci: fix rpc response deserialization

### DIFF
--- a/rpc/tests/support/block_results.json
+++ b/rpc/tests/support/block_results.json
@@ -8,9 +8,9 @@
         "code": "0",
         "log": "[{\"msg_index\":\"0\",\"success\":true,\"log\":\"\"}]",
         "info": "",
-        "gas_wanted": "200000",
-        "gas_used": "105662",
-        "data": "",
+        "gasWanted": "200000",
+        "gasUsed": "105662",
+        "data": null,
         "events": [
           {
             "type": "someevent1",
@@ -36,9 +36,9 @@
         "code": "0",
         "log": "[{\"msg_index\":\"0\",\"success\":true,\"log\":\"\"}]",
         "info": "",
-        "gas_wanted": "99164",
-        "gas_used": "99164",
-        "data": "",
+        "gasWanted": "99164",
+        "gasUsed": "99164",
+        "data": null,
         "events": [
           {
             "type": "someevent2",
@@ -64,9 +64,9 @@
         "code": "0",
         "log": "[{\"msg_index\":\"0\",\"success\":true,\"log\":\"\"}]",
         "info": "",
-        "gas_wanted": "200000",
-        "gas_used": "106515",
-        "data": "",
+        "gasWanted": "200000",
+        "gasUsed": "106515",
+        "data": null,
         "events": [
           {
             "type": "someeventtype1",

--- a/tendermint/src/abci/responses.rs
+++ b/tendermint/src/abci/responses.rs
@@ -1,7 +1,7 @@
 //! ABCI response types used by the `/block_results` RPC endpoint.
 
 use super::{code::Code, data::Data, gas::Gas, info::Info, log::Log, tag::Tag};
-use crate::{consensus, validator};
+use crate::{consensus, serializers, validator};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::{self, Display};
 
@@ -50,6 +50,7 @@ pub struct DeliverTx {
     pub code: Code,
 
     /// ABCI application data
+    #[serde(deserialize_with = "serializers::null_as_default")]
     pub data: Data,
 
     /// ABCI log data (nondeterministic)
@@ -59,9 +60,11 @@ pub struct DeliverTx {
     pub info: Info,
 
     /// Amount of gas wanted
+    #[serde(rename = "gasWanted")]
     pub gas_wanted: Gas,
 
     /// Amount of gas used
+    #[serde(rename = "gasUsed")]
     pub gas_used: Gas,
 
     /// Events

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -54,5 +54,6 @@ pub(crate) use raw_commit_sig::RawCommitSig;
 mod tests;
 
 mod custom;
+pub use custom::null_as_default;
 pub use custom::parse_non_empty_block_id;
 pub use custom::parse_non_empty_hash;

--- a/tendermint/src/serializers/custom.rs
+++ b/tendermint/src/serializers/custom.rs
@@ -59,3 +59,13 @@ where
         Ok(None)
     }
 }
+
+/// Parse null as default
+pub fn null_as_default<'de, D, T: Default + Deserialize<'de>>(
+    deserializer: D,
+) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(<Option<T>>::deserialize(deserializer)?.unwrap_or_default())
+}


### PR DESCRIPTION
Fix rpc response deserialization issues. fix #423 

By the way, the `null_as_default` deserializer might be good to use on some other fields.