### PR TITLE
fix deserialize power field in validator_update

### DIFF
--- a/rpc/tests/support/block_results.json
+++ b/rpc/tests/support/block_results.json
@@ -110,8 +110,7 @@
         "pub_key": {
           "type": "ed25519",
           "data": "AmPqEmF5YNmlv2vu8lEcDeQ3hyR+lymnqx2VixdMEzA="
-        },
-        "power": "12681"
+        }
       }
     ],
     "consensus_param_updates": null

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -192,6 +192,7 @@ pub struct Update {
     pub pub_key: PublicKey,
 
     /// New voting power
+    #[serde(default)]
     pub power: vote::Power,
 }
 


### PR DESCRIPTION
When removing validator, the power field is set to zero and ignored in json format.