### PR TITLE
rpc: handle ping messages in WebSocket listener

### DIFF
--- a/rpc/src/client/event_listener.rs
+++ b/rpc/src/client/event_listener.rs
@@ -155,7 +155,6 @@ impl EventListener {
                 // we didn't get the connection closed message we wanted, so force connection closure
                 Ok(_) => Ok(()),
                 Err(e) => match e {
-                    // this is what we want
                     tungsteniteError::ConnectionClosed | tungsteniteError::AlreadyClosed => Ok(()),
                     _ => Err(RPCError::websocket_error(e.to_string())),
                 },

--- a/rpc/src/client/event_listener.rs
+++ b/rpc/src/client/event_listener.rs
@@ -150,7 +150,6 @@ impl EventListener {
             .map_err(|e| {
                 RPCError::websocket_error(format!("failed to close web socket connection: {}", e))
             })?;
-        // try to gracefully close the connection
         match self.socket.next().await {
             Some(r) => match r {
                 // we didn't get the connection closed message we wanted, so force connection closure

--- a/tendermint/tests/integration.rs
+++ b/tendermint/tests/integration.rs
@@ -159,11 +159,10 @@ mod rpc {
         // client.subscribe("tm.event='NewBlock'".to_owned()).await.unwrap();
 
         // Loop here is helpful when debugging parsing of JSON events
-        // loop{
-        let maybe_result_event = client.get_event().await.unwrap();
-        dbg!(&maybe_result_event);
-        // }
-        let result_event = maybe_result_event.expect("unexpected msg read");
+        //loop{
+        //for _ in 0..5 {
+        let result_event = client.get_event().await.unwrap();
+        dbg!(&result_event);
         match result_event.data {
             event_listener::TMEventData::EventDataNewBlock(nb) => {
                 dbg!("got EventDataNewBlock: {:?}", nb);
@@ -175,5 +174,7 @@ mod rpc {
                 panic!("got a GenericJSONEvent: {:?}", v);
             }
         }
+        //}
+        client.close().await.unwrap();
     }
 }


### PR DESCRIPTION
Closes #311.

Adds responding to WebSockets ping messages during the attempt to fetch the next event from the event stream.

I debated whether or not to wrap the fetching of the next message in a finite or an infinite loop, but wrapping it in a finite loop would just push that same responsibility further up the stack. Using this approach allows us to do away with the optionality of a `ResultEvent` and simplifies the method signature.

Also, I added in a `close` method for the listener to allow one to gracefully close the connection (avoids those ugly `websocket: close 1006 (abnormal closure): unexpected EOF` messages in the Tendermint logs).

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
