### PR TITLE
light-client: minor changes in Cargo.toml (metadata)

### DIFF
--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2018"
 license = "Apache-2.0"
 readme     = "README.md"
 keywords   = ["blockchain", "bft", "consensus", "cosmos", "tendermint"]
+repository = "https://github.com/informalsystems/tendermint-rs"
+
+description = """
+    Implementation of the Tendermint Light Client Verification Protocol.
+"""
 
 [dependencies]
 tendermint = { version = "0.15.0", path = "../tendermint" }


### PR DESCRIPTION
Added backlink to repository and a description to light-client crate (pre publishing):
https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate