### PR TITLE
Use primary error as context of `NoWitnessLeft` error

### DIFF
--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -248,11 +248,9 @@ impl Supervisor {
                 }
             }
             // Verification failed
-            Err(_err) => {
-                // TODO: Log/record error
-
+            Err(err) => {
                 // Swap primary, and continue with new primary, if there is any witness left.
-                self.peers.replace_faulty_primary()?;
+                self.peers.replace_faulty_primary(Some(err))?;
                 self.verify(height)
             }
         }


### PR DESCRIPTION
So user can see the real error for verification failure.