### PR TITLE
fix broken links

### DIFF
--- a/docs/spec/fastsync/fastsync.md
+++ b/docs/spec/fastsync/fastsync.md
@@ -1137,7 +1137,7 @@ Arguments:
 
 <!-- [[blockchain]] The specification of the Tendermint blockchain. Tags refering to this specification are labeled [TMBC-*]. -->
 
-[block]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md
+[block]: https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md
 
 <!-- [blockchain]: https://github.com/informalsystems/VDD/tree/master/blockchain/blockchain.md -->
 
@@ -1201,7 +1201,7 @@ Arguments:
 
 [FN-LuckyCase-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-luckycase
 
-[blockchain-validator-set]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md#data-structures
+[blockchain-validator-set]: https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#data-structures
 
 [fullnode-data-structures]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#data-structures
 

--- a/docs/spec/lightclient/detection/detection.md
+++ b/docs/spec/lightclient/detection/detection.md
@@ -504,7 +504,7 @@ func ForkDetector(ls LightStore)  {
 [TMBC-FM-2THIRDS-link]: https://github.com/tendermint/spec/blob/master/spec/consensus/light-client/verification.md
 
 
-[block]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md
+[block]: https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md
 
 [blockchain]: https://github.com/informalsystems/VDD/tree/master/blockchain/blockchain.md
 

--- a/docs/spec/lightclient/verification/verification.md
+++ b/docs/spec/lightclient/verification/verification.md
@@ -1160,7 +1160,7 @@ func Main (primary PeerID, lightStore LightStore, targetHeight Height)
 
 [RPC]: https://docs.tendermint.com/master/rpc/
 
-[block]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md
+[block]: https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md
 
 [TMBC-HEADER-link]: #tmbc-header.1
 [TMBC-SEQ-link]: #tmbc-seq.1

--- a/tendermint/src/abci/transaction.rs
+++ b/tendermint/src/abci/transaction.rs
@@ -60,7 +60,7 @@ impl Serialize for Transaction {
 /// Transaction data is a wrapper for a list of transactions, where
 /// transactions are arbitrary byte arrays.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#data>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#data>
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct Data {
     txs: Option<Vec<Transaction>>,

--- a/tendermint/src/block.rs
+++ b/tendermint/src/block.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// Blocks consist of a header, transactions, votes (the commit), and a list of
 /// evidence of malfeasance (i.e. signing conflicting votes).
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#block>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#block>
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Block {
     /// Block header

--- a/tendermint/src/block/commit.rs
+++ b/tendermint/src/block/commit.rs
@@ -10,7 +10,7 @@ use std::{ops::Deref, slice};
 /// of validators.
 /// TODO: Update links below!
 /// <https://github.com/tendermint/tendermint/blob/51dc810d041eaac78320adc6d53ad8b160b06601/types/block.go#L486-L502>
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#lastcommit>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#lastcommit>
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct Commit {
     /// Block height

--- a/tendermint/src/block/header.rs
+++ b/tendermint/src/block/header.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// consensus, as well as commitments to the data in the current block, the
 /// previous block, and the results returned by the application.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#header>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#header>
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct Header {
     /// Header version
@@ -63,7 +63,7 @@ pub struct Header {
 /// `Version` contains the protocol version for the blockchain and the
 /// application.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#version>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#version>
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct Version {
     /// Block version

--- a/tendermint/src/block/id.rs
+++ b/tendermint/src/block/id.rs
@@ -15,7 +15,7 @@ pub const PREFIX_LENGTH: usize = 10;
 /// Block identifiers which contain two distinct Merkle roots of the block,
 /// as well as the number of parts in the block.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#blockid>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#blockid>
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Id {
     /// The block's main hash is the Merkle root of all the fields in the

--- a/tendermint/src/evidence.rs
+++ b/tendermint/src/evidence.rs
@@ -10,7 +10,7 @@ use {
 /// encoded using an Amino prefix. There is currently only a single type of
 /// evidence: `DuplicateVoteEvidence`.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#evidence>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#evidence>
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "value")]
 pub enum Evidence {
@@ -52,7 +52,7 @@ impl ConflictingHeadersEvidence {
 
 /// Evidence data is a wrapper for a list of `Evidence`.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#evidencedata>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#evidencedata>
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct Data {
     evidence: Option<Vec<Evidence>>,

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Tendermint timestamps
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#time>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#time>
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Time(DateTime<Utc>);
 

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -14,7 +14,7 @@ use {
 /// Votes are signed messages from validators for a particular block which
 /// include information about the validator signing it.
 ///
-/// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#vote>
+/// <https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md#vote>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Vote {
     /// Type of vote (prevote or precommit)


### PR DESCRIPTION
This pr fixes broken links. 

There are a couple of links that lead to a file called `blockchain/fullnode.md` but this file doesn't exist. Not sure what it should be replaced with?

closes #492 


* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
