### PR TITLE
spec: Rust like pseudo code for Sequential supervisor and core verification

### DIFF
--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -1,10 +1,10 @@
 
 ```rust
-/// Stores the Light Blocks which could not be confirmed to have originated from
+/// Stores the LightBlocks which could not be confirmed to have originated from
 /// the same chain as the predecesor light blocks.
 type FetchedStack = Stack<LightBlock>;
 
-/// Pair of light block and height of the light block which was highest 
+/// Pair of light block and height of the light block which was the 
 /// highest one for which we believe originated from the same chain
 type ChainPair = (LightBlock, Height);
 
@@ -21,7 +21,7 @@ trait Trace {
 
     /// Returns the list of all LightBlock which were inserted through 
     /// insert with associated previous current_height().
-    fn verification_chain(&self) -> LinkedList<ChainPair>;
+    fn chain(&self) -> LinkedList<ChainPair>;
 }
 
 
@@ -34,7 +34,7 @@ pub fn verify_to_target(
     target_height: Height) -> Result<Trace, (LightBlock, Reason)> {
 
     // Verified state always has one starting LightBlock
-    let mut trace = Trace::from(startingLightBlock);
+    let mut trace = Trace::from(starting_light_block);
     let mut fetch_stack = FetchedStack::empty();
 
     // insert the light block of target height, simplifies the loop
@@ -86,7 +86,7 @@ trait LightStore {
 
     /// Stores the list of ChainPair, possibly changing the highest LightBlock;
     /// Precondition is the existence of Light Block for which the chain can be linked
-    /// with the already stored ChainPair. Failing if the chain can bot be linked with
+    /// with the already stored ChainPair. Failing if the chain can not be linked with
     /// existing history or if there is conflicting information.
     fn store_chain(&mut self, chain: LinkedList<ChainPair>) -> Result<(), Error>;
     

--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -102,6 +102,15 @@ trait LightStore {
     /// Returning the chain of light blocks which are removed. To be used if a fork is discovered
     /// after insertions of light blocks.
     fn recover(&mut self, boundary: Height) -> LinkedList<ChainPair>;
+
+    /// Returns the firsts LightBlock above if it exists.
+    fn above(&self, height: Height) -> Option<&LightBlock>;
+    
+    /// Returns the firsts LightBlock below if it exists.
+    fn below(&self, height: Height) -> Option<&LightBlock>;
+    
+    /// Tries to get a certain height.
+    fn get(&self, height: Height) -> Option<&LightBlock>;
 }
 
 /// Current understanding how a LightNode functions.

--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -82,9 +82,9 @@ pub fn verify_to_target(
 trait LightStore {
     /// Current highest LightBlock which we believe to be from a chain 
     /// for which this store is associated with.
-    fn highest_trusted(&self) -> LightBlock;
+    fn highest(&self) -> LightBlock;
 
-    /// Stores the list of ChainPair, possibly changing the highest_trusted LightBlock;
+    /// Stores the list of ChainPair, possibly changing the highest LightBlock;
     /// Precondition is the existence of Light Block for which the chain can be linked
     /// with the already stored ChainPair. Failing if the chain can bot be linked with
     /// existing history or if there is conflicting information.
@@ -109,7 +109,8 @@ pub fn sequential_supervisor() -> Result<(), Forked> {
     loop {
 	    // get the next height
         let target_height = input();
-        // trusted_store contains all (LightBlock, previous) which passed fork detection
+        // light_store contains all (LightBlock, previous), for this supervisor all have passed
+        // fork detection and there will be no recoveries, etc.
 		
 		// Verify
         let mut result = Err(NoPeer);
@@ -127,10 +128,10 @@ pub fn sequential_supervisor() -> Result<(), Forked> {
         assert_eq!(target_height, result.current_height());
 		
         // Cross-check
-        let fork_result = fork_detector(witnesses(), trusted_store.heighest_trusted(), target_height);
+        let fork_result = fork_detector(witnesses(), light_store.heighest_trusted(), target_height);
         match fork_result {
             NoFork => {
-                trusted_store.store_chain(result.verification_chain());
+                light_store.store_chain(result.verification_chain());
             }
             Fork(proof_of_fork) => {
                 submit_evidence(proof_of_fork);

--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -1,0 +1,143 @@
+
+```rust
+/// Stores the Light Blocks which could not be confirmed to have originated from
+/// the same chain as the predecesor light blocks.
+type FetchedStack = Stack<LightBlock>;
+
+/// Pair of light block and height of the light block which was highest 
+/// highest one for which we believe originated from the same chain
+type ChainPair = (LightBlock, Height);
+
+/// Traces the history of verify_to_target.
+trait Trace {
+    /// Returns the height of the current highest inserted
+    fn current_height(&self) -> Height;
+
+    /// Returns the current highest inserted light block.
+    fn current(&self) -> &LightBlock;
+
+    /// Insert a new highest light block. assert(self.current_height() < light_block.height())
+    fn insert(&mut self, light_block: LightBlock) -> Result<(), Error>;
+
+    /// Returns the list of all LightBlock which were inserted through 
+    /// insert with associated previous current_height().
+    fn verification_chain(&self) -> LinkedList<ChainPair>;
+}
+
+
+/// Given a primary and a starting_light_block confirm that the light block of target_height received
+/// from primary for target_height is from the same chain as the starting_light_block.
+/// Solution for forward skipping verification.
+pub fn verify_to_target(
+    primary: PeerID,
+    starting_light_block: LightBlock,
+    target_height: Height) -> Result<Trace, (LightBlock, Reason)> {
+
+    // Verified state always has one starting LightBlock
+    let mut trace = Trace::from(startingLightBlock);
+    let mut fetch_stack = FetchedStack::empty();
+
+    // insert the light block of target height, simplifies the loop
+    // we can say that at each iteration there should be something on stack
+    fetch_stack.push(fetch_light_block(primary, target_height));
+
+    while trace.current_height() < targetHeight {
+        // unverified state is never empty
+        assert!(!fetch_stack.is_empty());
+        // always try with previously received
+        let lowest_unverified = fetch_stack.peek().unwrap().clone();
+        
+        // do the necessary checks
+        let verdict = valid_and_verified(trace.current(), &lowest_unverified);
+
+        match verdict {
+            // validated LightBlock, improve the verified_state
+            Valid => {
+                fetch_stack.pop();
+                trace.insert(lowest_unverified);
+                continue;
+            },
+            // invalid block stop
+            Invalid(reason) => {
+                return Err((lowest_unverified, reason))
+            },
+            Untrusted => {
+                // we need an intermediate LightBlock
+                current_height = 
+                    compute_height(trace.current_height(), lowest_unverified.height());
+            }
+        }
+    }
+
+    assert_eq!(trace.current_height(), target_height);
+    assert!(fetch_stack.is_empty());
+
+    return Ok(trace);
+}
+
+/// LightStore no longer has notions of Trusted, Verified, Unverified and Failed.
+/// The LightBlocks which are stored are all assumed to have originated from the
+/// same chain, irrespective of the peer from which we received it. The store
+/// provides the invariant that there is a 1-1 mapping from height to a LightBlock.
+trait LightStore {
+    /// Current highest LightBlock which we believe to be from a chain 
+    /// for which this store is associated with.
+    fn highest_trusted(&self) -> LightBlock;
+
+    /// Stores the list of ChainPair, possibly changing the highest_trusted LightBlock;
+    /// Precondition is the existence of Light Block for which the chain can be linked
+    /// with the already stored ChainPair. Failing if the chain can bot be linked with
+    /// existing history or if there is conflicting information.
+    fn store_chain(&mut self, chain: LinkedList<ChainPair>) -> Result<(), Error>;
+    
+    /// Stores one ChainLink, failing if there is conflicting information in the store.
+    /// (forks, etc.). Can be used when light blocks are received out of order.
+    fn store_pair(&mut self, link: ChainLink) -> Result<(), Error>;
+
+    /// Get verification chain of LightBlock ending at height high and starting starting from low.
+    fn get_chain(&self, low: Height, high: Height) -> LinkedList<ChainPair>;
+
+    /// In a case a fork is detected allows the light store to recover for a specified boundary
+    /// height. Erases all light blocks from the store with height greater or equal to boundary.
+    /// Returning the chain of light blocks which are removed. To be used if a fork is discovered
+    /// after insertions of light blocks.
+    fn recover(&mut self, boundary: Height) -> LinkedList<ChainPair>;
+}
+
+/// Current understanding how a LightNode functions.
+pub fn sequential_supervisor() -> Result<(), Forked> {
+    loop {
+	    // get the next height
+        let target_height = input();
+        // trusted_store contains all (LightBlock, previous) which passed fork detection
+		
+		// Verify
+        let mut result = Err(NoPeer);
+        // try with primaries until you succeed or there are no more peers
+        while result.is_err() {
+            result = verify_to_target(get_primary(), trusted_store.heighest_trusted(), target_height);
+            if result.is_err() {
+                // if primary if faulty, replace it (no garbage, which should be cleaned)
+                replace_primary()
+            }
+        }
+
+        // safe verified state of the primary
+        let result: Trace = result.unwrap();
+        assert_eq!(target_height, result.current_height());
+		
+        // Cross-check
+        let fork_result = fork_detector(witnesses(), trusted_store.heighest_trusted(), target_height);
+        match fork_result {
+            NoFork => {
+                trusted_store.store_chain(result.verification_chain());
+            }
+            Fork(proof_of_fork) => {
+                submit_evidence(proof_of_fork);
+                return Err(Forked);
+            }
+        }
+    }
+    Ok(())
+}
+```

--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -1,8 +1,8 @@
 
 ```rust
 /// Stores the LightBlocks which could not be confirmed to have originated from
-/// the same chain as the predecesor light blocks.
-type FetchedStack = Stack<LightBlock>;
+/// the same chain as the predecessor light blocks.
+type FetchedStack = Vec<LightBlock>;
 
 /// Pair of light block and height of the light block which was the 
 /// highest one for which we believe originated from the same chain

--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -31,7 +31,7 @@ trait Trace {
 pub fn verify_to_target(
     primary: PeerID,
     starting_light_block: LightBlock,
-    target_height: Height) -> Result<Trace, (LightBlock, Reason)> {
+    target_height: Height) -> Result<Trace, (LightBlock, VerificationError)> {
 
     // Verified state always has one starting LightBlock
     let mut trace = Trace::from(starting_light_block);
@@ -58,8 +58,8 @@ pub fn verify_to_target(
                 continue;
             },
             // invalid block stop
-            Invalid(reason) => {
-                return Err((lowest_unverified, reason))
+            Invalid(error) => {
+                return error
             },
             Untrusted => {
                 // we need an intermediate LightBlock
@@ -101,16 +101,16 @@ trait LightStore {
     /// height. Erases all light blocks from the store with height greater or equal to boundary.
     /// Returning the chain of light blocks which are removed. To be used if a fork is discovered
     /// after insertions of light blocks.
-    fn recover(&mut self, boundary: Height) -> LinkedList<ChainPair>;
+    fn recover(&mut self, boundary: Height) -> Result<LinkedList<ChainPair>, LightStoreError>;
 
     /// Returns the firsts LightBlock above if it exists.
-    fn above(&self, height: Height) -> Option<&LightBlock>;
+    fn above(&self, height: Height) -> Result<&LightBlock, ListStoreError>;
     
     /// Returns the firsts LightBlock below if it exists.
-    fn below(&self, height: Height) -> Option<&LightBlock>;
+    fn below(&self, height: Height) -> Result<&LightBlock, ListStoreError>;
     
     /// Tries to get a certain height.
-    fn get(&self, height: Height) -> Option<&LightBlock>;
+    fn get(&self, height: Height) -> Result<&LightBlock, ListStoreError>;
 }
 
 /// Current understanding how a LightNode functions.

--- a/docs/spec/supervisor/supervisor.md
+++ b/docs/spec/supervisor/supervisor.md
@@ -5,9 +5,9 @@
 type FetchedStack = Vec<LightBlock>;
 
 /// Chain of verification with a starting root.
-enum Chain {
+enum VerificationChain {
     Root(LightBlock),
-    Link(LightBlock, Box<Chain>)
+    Link(LightBlock, Box<VerificationChain>)
 }
 
 /// Traces the history of verify_to_target.
@@ -23,7 +23,7 @@ trait Trace {
 
     /// Returns the list of all LightBlock which were inserted through 
     /// insert with associated previous current_height().
-    fn chain(&self) -> Chain;
+    fn chain(&self) -> VerificationChain;
 }
 
 
@@ -95,24 +95,24 @@ trait LightStore {
     /// for which this store is associated with.
     fn highest(&self) -> LightBlock;
 
-    /// Stores the list of Chain, possibly changing the highest LightBlock;
+    /// Stores the list of VerificationChain, possibly changing the highest LightBlock;
     /// Precondition is the existence of Light Block for which the chain can be linked
-    /// with the already stored Chain. Failing if the chain can not be linked with
+    /// with the already stored VerificationChain. Failing if the chain can not be linked with
     /// existing history or if there is conflicting information.
-    fn store_chain(&mut self, chain: Chain) -> Result<(), Error>;
+    fn store_chain(&mut self, chain: VerificationChain) -> Result<(), Error>;
     
-    /// Stores one ChainLink, failing if there is conflicting information in the store.
+    /// Stores one VerificationChain, failing if there is conflicting information in the store.
     /// (forks, etc.). Can be used when light blocks are received out of order.
-    fn store_pair(&mut self, link: ChainLink) -> Result<(), Error>;
+    fn store_pair(&mut self, link: VerificationChain) -> Result<(), Error>;
 
     /// Get verification chain of LightBlock ending at height high and starting starting from low.
-    fn get_chain(&self, low: Height, high: Height) -> Chain;
+    fn get_chain(&self, low: Height, high: Height) -> VerificationChain;
 
     /// In a case a fork is detected allows the light store to recover for a specified boundary
     /// height. Erases all light blocks from the store with height greater or equal to boundary.
     /// Returning the chain of light blocks which are removed. To be used if a fork is discovered
     /// after insertions of light blocks.
-    fn recover(&mut self, boundary: Height) -> Result<Chain, LightStoreError>;
+    fn recover(&mut self, boundary: Height) -> Result<VerificationChain, LightStoreError>;
 
     /// Returns the firsts LightBlock above if it exists.
     fn above(&self, height: Height) -> Result<&LightBlock, ListStoreError>;


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

[rendered](https://github.com/informalsystems/tendermint-rs/blob/1351513ade78fd4e1864783742be5ae41f1d05f1/docs/spec/supervisor/supervisor.md)

As @josef-widder mentioned here is the pseudo code proposal for specification and code changes. I was not sure how to name this and where to put it so we can change it as others see fit. 

**Goals?**

The proposed pseudo code should solve the main issues of `LightStore` having an unbounded interface which makes code of skipping forward verification more complicated than needed. If implemented it should solve several issues which came out of it.

**Possible issues?**
- with this proposal the `LightStore` requires that when inserting new information it is always possible to build a verification chain with what is already in it
- the requirement above makes backward verification using just hashes impossible as the links with lower `LightBlocks `are impossible to recreate in this situation

**Proposal details**
- current `LightStore` is now split: 
        1.  what were once verified LightBlocks are now stored in `Trace`
        2. `Unverified` LightBlocks are now on the `FetchedStack`
        3. There are no longer `Failed` LightBlocks as there can be only one and that one is returned as an error reason in `verify_to_target`
        4. The notion of `Trusted` is removed, and with the sequential supervisor everything in what is now `LightStore` is what were previously trusted.
- History of how `LightBlocks` were verified can be retrieved from the `LightStore`
- `LightStore` can recover from possible forks in the future by removing `LightBlocks` which are now considered to be from a fork.

**Order in which to review for easier understanding**
- basically top to bottom
- first part is related to skipping verification until the `LightStore` (excluding)
- second part relevant for supervisor and possible `ForkDetection` and `Relayer` requirements

**Issue which prompted this PR**
- #494 

**Issues this approach should solve.**
- #499 : chain invariant is easily retrievable, and chain computation is built-in the `LightStore` now
- #487 : previous losses of trusted `LightBlock` are no longer possible as we always ask for the highest from the supervisor `LightStore`
- #434 : no longer relevant with refactors proposed here
- #428 : logic is very much split and the API is now easier to reason about
- #420 : same as for 487
- #333 : simplified by design

**Should help with easier implementation of**
- #415 : should be easier to collect evidence as verification trace is collected
- #497 : for all the mentioned height combinations it should be possible to easily get the light block for verification.

**Issues which should be reworded depending on the changes here**
- #334 : everything stored in the `LightStore` is assumed to have passed verification at some point


* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
