### PR TITLE
Replace `signatory` with `ed25519-dalek` and `k256` crates

### DIFF
--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -146,10 +146,13 @@ impl VotingPowerCalculator for ProdVotingPowerCalculator {
 
             // Check vote is valid
             let sign_bytes = signed_vote.sign_bytes();
-            if !validator.verify_signature(&sign_bytes, signed_vote.signature()) {
+            if validator
+                .verify_signature(&sign_bytes, signed_vote.signature())
+                .is_err()
+            {
                 bail!(VerificationError::InvalidSignature {
-                    signature: signed_vote.signature().to_vec(),
-                    validator,
+                    signature: signed_vote.signature().to_bytes(),
+                    validator: Box::new(validator),
                     sign_bytes,
                 });
             }
@@ -186,14 +189,14 @@ fn non_absent_vote(commit_sig: &CommitSig, validator_index: u64, commit: &Commit
         } => (
             *validator_address,
             *timestamp,
-            signature.clone(),
+            signature,
             Some(commit.block_id.clone()),
         ),
         CommitSig::BlockIDFlagNil {
             validator_address,
             timestamp,
             signature,
-        } => (*validator_address, *timestamp, signature.clone(), None),
+        } => (*validator_address, *timestamp, signature, None),
     };
 
     Some(Vote {
@@ -204,7 +207,7 @@ fn non_absent_vote(commit_sig: &CommitSig, validator_index: u64, commit: &Commit
         timestamp,
         validator_address,
         validator_index,
-        signature,
+        signature: *signature,
     })
 }
 

--- a/light-client/src/predicates/errors.rs
+++ b/light-client/src/predicates/errors.rs
@@ -43,7 +43,7 @@ pub enum VerificationError {
         /// Signature as a byte array
         signature: Vec<u8>,
         /// Validator which provided the signature
-        validator: Validator,
+        validator: Box<Validator>,
         /// Bytes which were signed
         sign_bytes: Vec<u8>,
     },

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -27,16 +27,17 @@ authors = [
 
 [package.metadata.docs.rs]
 all-features = true
-
-[badges]
-codecov = { repository = "..."}
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 anomaly = "0.2"
 async-trait = "0.1"
 bytes = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
+ed25519 = "1"
+ed25519-dalek = { version = "= 1.0.0-pre.4", features = ["serde"] }
 futures = "0.3"
+k256 = { version = "0.4", optional = true, features = ["ecdsa"] }
 once_cell = "1.3"
 prost-amino = "0.6"
 prost-amino-derive = "0.6"
@@ -45,9 +46,7 @@ serde_json = "1"
 serde_bytes = "0.11"
 serde_repr = "0.1"
 sha2 = { version = "0.9", default-features = false }
-signatory = { version = "0.20", features = ["ed25519", "ecdsa"] }
-signatory-dalek = "0.20"
-signatory-secp256k1 = { version = "0.20", optional = true }
+signature = "1.2"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tai64 = { version = "3", features = ["chrono"] }
@@ -61,4 +60,4 @@ tendermint-rpc = { path = "../rpc", features = [ "client" ] }
 tokio = { version = "0.2", features = [ "macros" ] }
 
 [features]
-secp256k1 = ["signatory-secp256k1", "ripemd160"]
+secp256k1 = ["k256", "ripemd160"]

--- a/tendermint/src/amino_types/proposal.rs
+++ b/tendermint/src/amino_types/proposal.rs
@@ -17,7 +17,6 @@ use bytes::BufMut;
 use once_cell::sync::Lazy;
 use prost_amino::{EncodeError, Message};
 use prost_amino_derive::Message;
-use signatory::ed25519;
 use std::convert::TryFrom;
 
 #[derive(Clone, PartialEq, Message)]

--- a/tendermint/src/amino_types/signature.rs
+++ b/tendermint/src/amino_types/signature.rs
@@ -2,7 +2,6 @@ use super::validate;
 use crate::{chain, consensus};
 use bytes::BufMut;
 use prost_amino::{DecodeError, EncodeError};
-use signatory::ed25519;
 
 /// Amino messages which are signable within a Tendermint network
 pub trait SignableMsg {

--- a/tendermint/src/amino_types/vote.rs
+++ b/tendermint/src/amino_types/vote.rs
@@ -19,7 +19,6 @@ use bytes::BufMut;
 use once_cell::sync::Lazy;
 use prost_amino::{error::EncodeError, Message};
 use prost_amino_derive::Message;
-use signatory::ed25519;
 use std::convert::TryFrom;
 
 const VALIDATOR_ADDR_SIZE: usize = 20;

--- a/tendermint/src/config/node_key.rs
+++ b/tendermint/src/config/node_key.rs
@@ -2,9 +2,10 @@
 
 use crate::{
     error::{Error, Kind},
+    node,
     private_key::PrivateKey,
+    public_key::PublicKey,
 };
-use crate::{node, public_key::PublicKey};
 use anomaly::format_err;
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
@@ -42,7 +43,7 @@ impl NodeKey {
     /// Get the public key for this keypair
     pub fn public_key(&self) -> PublicKey {
         match &self.priv_key {
-            PrivateKey::Ed25519(key) => key.public_key(),
+            PrivateKey::Ed25519(keypair) => keypair.public.into(),
         }
     }
 
@@ -50,7 +51,7 @@ impl NodeKey {
     pub fn node_id(&self) -> node::Id {
         #[allow(unreachable_patterns)]
         match &self.public_key() {
-            PublicKey::Ed25519(key) => node::Id::from(*key),
+            PublicKey::Ed25519(pubkey) => node::Id::from(*pubkey),
             _ => unreachable!(),
         }
     }

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -4,6 +4,7 @@
 //! blockchain networks, including chain information types, secret connections,
 //! and remote procedure calls (JSONRPC).
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     warnings,
     missing_docs,
@@ -50,12 +51,13 @@ pub mod vote;
 #[cfg(test)]
 mod test;
 
-pub use crate::genesis::Genesis;
 pub use crate::{
     block::Block,
     error::{Error, Kind},
+    genesis::Genesis,
     hash::Hash,
     moniker::Moniker,
+    private_key::PrivateKey,
     public_key::{PublicKey, TendermintKey},
     signature::Signature,
     time::Time,
@@ -63,4 +65,3 @@ pub use crate::{
     version::Version,
     vote::Vote,
 };
-pub use private_key::PrivateKey;

--- a/tendermint/src/node/id.rs
+++ b/tendermint/src/node/id.rs
@@ -1,9 +1,12 @@
 //! Tendermint node IDs
 
-use crate::error::{Error, Kind};
+use crate::{
+    error::{Error, Kind},
+    public_key::Ed25519,
+};
+
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
-use signatory::ed25519;
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
@@ -58,8 +61,8 @@ impl Debug for Id {
     }
 }
 
-impl From<ed25519::PublicKey> for Id {
-    fn from(pk: ed25519::PublicKey) -> Id {
+impl From<Ed25519> for Id {
+    fn from(pk: Ed25519) -> Id {
         let digest = Sha256::digest(pk.as_bytes());
         let mut bytes = [0u8; LENGTH];
         bytes.copy_from_slice(&digest[..LENGTH]);

--- a/tendermint/src/serializers/tests.rs
+++ b/tendermint/src/serializers/tests.rs
@@ -132,9 +132,7 @@ fn deserialize_commit_sig_commit_vote() {
         assert_eq!(timestamp, Time::unix_epoch());
         assert_eq!(
             signature,
-            crate::signature::Signature::Ed25519(signatory::ed25519::Signature::new(
-                EXAMPLE_SIGNATURE
-            ))
+            crate::signature::Signature::Ed25519(ed25519::Signature::new(EXAMPLE_SIGNATURE))
         );
     } else {
         panic!(format!("expected BlockIDFlagCommit, received {:?}", result));
@@ -169,9 +167,7 @@ fn deserialize_commit_sig_nil_vote() {
         assert_eq!(timestamp, Time::unix_epoch());
         assert_eq!(
             signature,
-            crate::signature::Signature::Ed25519(signatory::ed25519::Signature::new(
-                EXAMPLE_SIGNATURE
-            ))
+            crate::signature::Signature::Ed25519(ed25519::Signature::new(EXAMPLE_SIGNATURE))
         );
     } else {
         panic!(format!("expected BlockIDFlagNil, received {:?}", result));

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -108,8 +108,8 @@ impl SignedVote {
     }
 
     /// Return the actual signature on the canonicalized vote.
-    pub fn signature(&self) -> &[u8] {
-        self.signature.as_ref()
+    pub fn signature(&self) -> &Signature {
+        &self.signature
     }
 }
 

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2018"
 tendermint = { version = "0.15.0", path = "../tendermint" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+ed25519-dalek = "= 1.0.0-pre.4"
 gumdrop = "0.8.0"
-signatory = { version = "0.20", features = ["ed25519", "ecdsa"] }
-signatory-dalek = "0.20"
 simple-error = "0.2.1"
 
 [[bin]]

--- a/testgen/src/commit.rs
+++ b/testgen/src/commit.rs
@@ -183,12 +183,12 @@ mod tests {
                     let sign_bytes =
                         get_vote_sign_bytes(block_header.chain_id.as_str(), &block_vote);
                     assert!(!verify_signature(
-                        &valset2[i].get_verifier().unwrap(),
+                        &valset2[i].get_public_key().unwrap(),
                         &sign_bytes,
                         signature
                     ));
                     assert!(verify_signature(
-                        &valset1[i].get_verifier().unwrap(),
+                        &valset1[i].get_public_key().unwrap(),
                         &sign_bytes,
                         signature
                     ));

--- a/testgen/src/helpers.rs
+++ b/testgen/src/helpers.rs
@@ -1,11 +1,13 @@
 //! Helper functions
 
 use serde::de::DeserializeOwned;
-use signatory::signature::Verifier;
-use signatory_dalek::Ed25519Verifier;
 use simple_error::*;
 use std::io::{self, Read};
-use tendermint::{amino_types, signature::Signature, vote};
+use tendermint::{
+    amino_types, public_key,
+    signature::{Signature, Verifier},
+    vote,
+};
 
 /// A macro that generates a complete setter method from a one-liner with necessary information
 #[macro_export]
@@ -45,13 +47,14 @@ pub fn get_vote_sign_bytes(chain_id: &str, vote: &vote::Vote) -> Vec<u8> {
         amino_types::vote::Vote::from(vote),
         chain_id,
         vote.validator_address,
-        vote.signature.clone(),
+        vote.signature,
     );
     signed_vote.sign_bytes()
 }
 
-pub fn verify_signature(verifier: &Ed25519Verifier, msg: &[u8], signature: &Signature) -> bool {
+pub fn verify_signature(verifier: &public_key::Ed25519, msg: &[u8], signature: &Signature) -> bool {
     match signature {
         tendermint::signature::Signature::Ed25519(sig) => verifier.verify(msg, sig).is_ok(),
+        _ => false,
     }
 }


### PR DESCRIPTION
Native support for the `signature` traits used by the `signatory*` was recently added to `ed25519-dalek` in v1.0.0-pre.4, and the `k256` crate recently added a native pure Rust implementation of ECDSA/secp256k1.

Together these changes eliminate the need for the `signatory*` wrapper crates. Additionally, `k256` eliminates the need for the rust-secp256k1 C-based library, which has been problematic with e.g. WASM (#391).

This commit eliminates all `signatory` dependencies and uses `ed25519-dalek` and `k256` directly instead. Both of these were already dependencies, so it's not adding any additional dependencies, but instead removes several of them.