### PR TITLE
Revert empty Merkle tree hashing for v0.15 release

### DIFF
--- a/tendermint/src/merkle.rs
+++ b/tendermint/src/merkle.rs
@@ -21,7 +21,7 @@ pub fn simple_hash_from_byte_vectors(byte_vecs: Vec<Vec<u8>>) -> Hash {
 fn simple_hash_from_byte_slices_inner(byte_slices: &[Vec<u8>]) -> Hash {
     let length = byte_slices.len();
     match length {
-        0 => empty_hash(),
+        0 => [0; HASH_SIZE],
         1 => leaf_hash(byte_slices[0].as_slice()),
         _ => {
             let k = get_split_point(length);
@@ -40,20 +40,6 @@ fn get_split_point(length: usize) -> usize {
         2 => 1,
         _ => length.next_power_of_two() / 2,
     }
-}
-
-// tmhash({})
-fn empty_hash() -> Hash {
-    // the empty string / byte slice
-    let empty = Vec::with_capacity(0);
-
-    // hash it !
-    let digest = Sha256::digest(&empty);
-
-    // copy the GenericArray out
-    let mut hash_bytes = [0u8; HASH_SIZE];
-    hash_bytes.copy_from_slice(&digest);
-    hash_bytes
 }
 
 // tmhash(0x00 || leaf)
@@ -111,7 +97,7 @@ mod tests {
     #[test]
     fn test_rfc6962_empty_tree() {
         let empty_tree_root_hex =
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+            "0000000000000000000000000000000000000000000000000000000000000000";
         let empty_tree_root = &hex::decode(empty_tree_root_hex).unwrap();
         let empty_tree: Vec<Vec<u8>> = vec![vec![]; 0];
 


### PR DESCRIPTION
Closes #538 

Reverting the identified commit turned out to be a hassle because of other changes that happened in testing since then.
Instead, I identified the actual change and created a commit that reverts the source code in the crucial place.

I left the newly created test in place, only I changed it to succeed in the current scenario.

If all goes well, this commit will be easier to revert in #540 after the v0.16 release

Note: the commit description falsely states v0.15 release. This is prepared for the v0.16 release.

No need for changelog update here, since this is reverting a new implementation to a previous - already expected - one.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [X] Wrote tests
* [ ] Updated CHANGELOG.md
