### PR TITLE
CHANGELOG for v0.16, lib version updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The release contains Rust API-breaking changes. The implementation is compatible
 
 ### FEATURES:
 
-- [tendermint/proto] A tendermint-proto crate was created that contains the Rust structs.
+- [tendermint/proto] A tendermint-proto crate was created that contains the Rust structs for protobuf.
 - [tendermint/proto-compiler] A tendermint-proto-compiler crate was created that generates the tendermint-proto structs from the Tendermint Core Protobuf definitions.
 
 ### IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,44 @@
 ## Unreleased
 
-### Light Client
+## v0.16.0
 
-- Add missing documentation to all items ([#472])
-- Add major contributors as authors of the `light-client`, `light-node`, and `rpc` crate ([#472])
-- Remove and consolidate deprecated [lite] and [lite_impl] modules from the `tendermint` crate ([#500])
+*Aug 28, 2020*
 
-[#472]: https://github.com/informalsystems/tendermint-rs/pull/472
-[lite_impl]: https://github.com/informalsystems/tendermint-rs/tree/master/tendermint/src/lite_impl
+This release is the first release of the [testgen][testgen] utility, a generator for Tendermint types for unit, integration
+and model-based testing. It is a utility for producing tendermint datastructures from minimal input, targeted for testing.
 
-### Proto crate
+The release contains Rust API-breaking changes. The implementation is compatible with v0.33 of Tendermint Core.
 
-- Created Rust structs from Tendermint Proto files ([#504])
+ ⚠️ ️Deprecation warning ⚠️ : The [lite][lite-dir] module was removed. Please take a look at the [light-client][light-client-dir] crate.
+
+### BREAKING CHANGES:
+
+- [tendermint] The `ed25519-dalek` and `k256` crates now natively support signature traits, the `signatory` wrapper was eliminated.
+- [tendermint] Remove and consolidate deprecated [lite] and [lite_impl] modules
+- [light-client] Use primary error as context of `NoWitnessLeft` error [#477]
+
+### FEATURES:
+
+- [tendermint/proto] A tendermint-proto crate was created that contains the Rust structs.
+- [tendermint/proto-compiler] A tendermint-proto-compiler crate was created that generates the tendermint-proto structs from the Tendermint Core Protobuf definitions.
+
+### IMPROVEMENTS:
+
+- [light-client] and [light-node] Improved documentation, added major contributors as authors of the `light-client`, `light-node`, and `rpc` crate
+- [tendermint] fix broken links in documentation
+- [tendermint] Updated CONTRIBUTING.md document
+- [light-client] started using [testgen] in tests
+
+### BUG FIXES:
+
+- [light-client] Fix predicate bug [#474]
+
+[testgen]: https://github.com/informalsystems/tendermint-rs/tree/master/testgen
+[tendermint/proto]: https://github.com/informalsystems/tendermint-rs/tree/master/proto
+[tendermint/proto-compiler]: https://github.com/informalsystems/tendermint-rs/tree/master/proto-compiler
+[tendermint]: https://github.com/informalsystems/tendermint-rs
+[#474]: https://github.com/informalsystems/tendermint-rs/pull/474
+[#477]: https://github.com/informalsystems/tendermint-rs/pull/477
 
 ## v0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,54 +2,68 @@
 
 ## v0.16.0
 
-*Aug 28, 2020*
+*Aug 31, 2020*
 
-This release is the first release of the [testgen][testgen] utility, a generator for Tendermint types for unit, integration
-and model-based testing. It is a utility for producing tendermint datastructures from minimal input, targeted for testing.
+This release is the first release of the [testgen][testgen-dir] utility, 
+a generator for Tendermint types for unit and integration tests and and for model-based testing. 
+It is a utility for producing tendermint datastructures from minimal input, targeted for testing.
 
-The release contains Rust API-breaking changes. The implementation is compatible with v0.33 of Tendermint Core.
+The release also contains various Rust API-breaking changes. It remains compatible with v0.33 of Tendermint Core.
 
- ⚠️ ️Deprecation warning ⚠️ : The [lite][lite-dir] module was removed. Please take a look at the [light-client][light-client-dir] crate.
+ ⚠️ ️Deprecation warning ⚠️ : The `lite` module was removed. Please take a look at the [light-client][light-client-dir] crate.
 
 ### BREAKING CHANGES:
 
-- [tendermint] The `ed25519-dalek` and `k256` crates now natively support signature traits, the `signatory` wrapper was eliminated.
-- [tendermint] Remove and consolidate deprecated [lite] and [lite_impl] modules
-- [light-client] Use primary error as context of `NoWitnessLeft` error [#477]
+- [repo] CHANGES.md renamed to CHANGELOG.md
+- [tendermint] Eliminate use of `signatory` wrapper crate in favour of underlying `ed25519-dalek` and `k256` crates. `ed25519-dalek` is now v1.0 and `k256` provides a pure Rust implementation of secp256k1 rather than wrapping the C library ([#522])
+- [tendermint] Remove `lite` and `lite_impl` modules. See the new `light-client`
+  crate ([#500])
 
 ### FEATURES:
 
-- [tendermint/proto] A tendermint-proto crate was created that contains the Rust structs for protobuf.
+- [tendermint/proto] A tendermint-proto crate was created that contains the Rust structs for protobuf,
+preparing for compatibility with Tendermint Core v0.34 ([#508])
 - [tendermint/proto-compiler] A tendermint-proto-compiler crate was created that generates the tendermint-proto structs from the Tendermint Core Protobuf definitions.
+- [testgen] Introduce the `testgen` crate for generating Tendermint types from
+  minimal input ([#468])
 
 ### IMPROVEMENTS:
 
-- [light-client] and [light-node] Improved documentation, added major contributors as authors of the `light-client`, `light-node`, and `rpc` crate
-- [tendermint] fix broken links in documentation
-- [tendermint] Updated CONTRIBUTING.md document
-- [light-client] started using [testgen] in tests
+- [light-client] Use the `testgen` for generating tests
+- [light-client] Use primary error as context of `NoWitnessLeft` error ([#477])
+- [repo] Various improvements to documentation and crate structure
+- [repo] Add CONTRIBUTING.md document ([#470])
+- [specs] Updates to fork detection English spec for evidence handling in
+  Tendermint and IBC ([#479])
+- [specs] Model checking results and updates for the fast sync TLA+ spec ([#466])
 
 ### BUG FIXES:
 
-- [light-client] Fix predicate bug [#474]
+- [light-client] Fix to reject headers from the future ([#474])
 
-[testgen]: https://github.com/informalsystems/tendermint-rs/tree/master/testgen
-[tendermint/proto]: https://github.com/informalsystems/tendermint-rs/tree/master/proto
-[tendermint/proto-compiler]: https://github.com/informalsystems/tendermint-rs/tree/master/proto-compiler
-[tendermint]: https://github.com/informalsystems/tendermint-rs
+[light-client-dir]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client
+[testgen-dir]: https://github.com/informalsystems/tendermint-rs/tree/master/testgen
+
+[#466]: https://github.com/informalsystems/tendermint-rs/pull/466
+[#468]: https://github.com/informalsystems/tendermint-rs/pull/468
+[#470]: https://github.com/informalsystems/tendermint-rs/pull/470
 [#474]: https://github.com/informalsystems/tendermint-rs/pull/474
 [#477]: https://github.com/informalsystems/tendermint-rs/pull/477
+[#479]: https://github.com/informalsystems/tendermint-rs/pull/479
+[#500]: https://github.com/informalsystems/tendermint-rs/pull/500
+[#508]: https://github.com/informalsystems/tendermint-rs/pull/508
+[#522]: https://github.com/informalsystems/tendermint-rs/pull/522
 
 ## v0.15.0
 
 *July 17, 2020*
 
-This release is the first official release of the revamped [light-client][light-client-dir] library and the [light-node] command-line interface.
+This release is the first official release of the revamped [light-client][light-client-dir] library and the [light-node][light-node-dir] command-line interface.
 Together they provide a complete Tendermint light client implementation that performs squential and skipping verification
 and attempts to detect forks across its peers. Complete TLA+ specifications for light client verification are included,
-along with work-in-progress on the specs for detection. The implementation is compatible with v0.33 of Tendermint Core.
+along with work-in-progress specs for fork detection. The implementation is compatible with v0.33 of Tendermint Core.
 
-Note that both the [light-client][light-client-dir]  and [light-node] crates are to be considered experimental software that will still undergo a 
+Note that both the [light-client][light-client-dir]  and [light-node][light-node-dir] crates are to be considered experimental software that will still undergo a 
 lot of improvements and iterations. The goal of releasing an early version of our Light Client is to make it accessible, to get people use it, and to receive feedback.
 
 An overview of the current design of the light client is provided in [ADR-006]
@@ -74,8 +88,6 @@ and [ADR-007].
   complete with an rpc server for querying the latest state of the light node
   while it syncs with the blockchain. See the [light-node][light-node-dir] crate
   for details.
-
-### IMPROVEMENTS:
 
 ### BUG FIXES:
 
@@ -112,7 +124,7 @@ This release mainly targets compatibility with Tendermint [v0.33.x] but contains
 Also noteworthy is that the rpc module was broken out into a separate crate ([tendermint-rpc]).
 
 ⚠️ ️Deprecation warning ⚠️ : This might be that last release containing the [lite] module.
-It will be replaced with the [light-client] crate (soon).
+It will be replaced with the [light-client][light-client-dir] crate (soon).
 
 CommitSig:
 - Refactored CommitSig into a more Rust-friendly enum. ([#247])
@@ -160,7 +172,7 @@ CI:
 [v0.33.x]: https://github.com/tendermint/tendermint/blob/v0.33.5/CHANGELOG.md#v0335
 [tendermint-rpc]: https://github.com/informalsystems/tendermint-rs/tree/master/rpc#tendermint-rpc
 [lite]: https://github.com/informalsystems/tendermint-rs/tree/master/tendermint/src/lite
-[light-client]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client
+[light-client-dir]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client
 
 ## [0.13.0] (2020-04-20)
 

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client"
-version    = "0.15.0"
+version    = "0.16.0"
 edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -19,8 +19,8 @@ description = """
 """
 
 [dependencies]
-tendermint = { version = "0.15.0", path = "../tendermint" }
-tendermint-rpc = { version = "0.15.0", path = "../rpc", features = ["client"] }
+tendermint = { version = "0.16.0", path = "../tendermint" }
+tendermint-rpc = { version = "0.16.0", path = "../rpc", features = ["client"] }
 
 anomaly = { version = "0.2.0", features = ["serializer"] }
 contracts = "0.4.0"

--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -10,7 +10,7 @@
     nonstandard_style
 )]
 #![doc(
-    html_root_url = "https://docs.rs/tendermint-light-client/0.15.0",
+    html_root_url = "https://docs.rs/tendermint-light-client/0.16.0",
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 

--- a/light-node/Cargo.toml
+++ b/light-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-node"
-version    = "0.15.0"
+version    = "0.16.0"
 edition    = "2018"
 license    = "Apache-2.0"
 repository = "https://github.com/informalsystems/tendermint-rs"
@@ -38,9 +38,9 @@ jsonrpc-derive = "14.2"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1.0"
 sled = "0.33.0"
-tendermint = { version = "0.15.0", path = "../tendermint" }
-tendermint-light-client = { version = "0.15.0", path = "../light-client" }
-tendermint-rpc = { version = "0.15.0", path = "../rpc", features = [ "client" ] }
+tendermint = { version = "0.16.0", path = "../tendermint" }
+tendermint-light-client = { version = "0.16.0", path = "../light-client" }
+tendermint-rpc = { version = "0.16.0", path = "../rpc", features = [ "client" ] }
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["full"] }
 

--- a/light-node/src/lib.rs
+++ b/light-node/src/lib.rs
@@ -15,7 +15,7 @@
     unused_qualifications
 )]
 #![doc(
-    html_root_url = "https://docs.rs/tendermint-light-node/0.15.0",
+    html_root_url = "https://docs.rs/tendermint-light-node/0.16.0",
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-rpc"
-version    = "0.15.0"
+version    = "0.16.0"
 edition    = "2018"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
@@ -34,7 +34,7 @@ getrandom = "0.1"
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 serde_json = "1"
-tendermint = { version = "0.15.0", path = "../tendermint" }
+tendermint = { version = "0.16.0", path = "../tendermint" }
 thiserror = "1"
 uuid = { version = "0.8", default-features = false }
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.15.0" # Also update `html_root_url` in lib.rs and
+version    = "0.16.0" # Also update `html_root_url` in lib.rs and
                       # depending crates (rpc, light-node, ..) when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -15,7 +15,7 @@
 )]
 #![forbid(unsafe_code)]
 #![doc(
-    html_root_url = "https://docs.rs/tendermint/0.15.0",
+    html_root_url = "https://docs.rs/tendermint/0.16.0",
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Andrey Kuprianov <andrey@informal.systems>"]
 edition = "2018"
 
 [dependencies]
-tendermint = { version = "0.15.0", path = "../tendermint" }
-tendermint-light-client = { version = "0.15.0", path = "../light-client" }
+tendermint = { version = "0.16.0", path = "../tendermint" }
+tendermint-light-client = { version = "0.16.0", path = "../light-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ed25519-dalek = "1"


### PR DESCRIPTION
Closes #93 

v0.16 release documents updated:
* CHANGELOG
* light-client, light-node and tendermint `lib.rs` version numbers
* light-client, light-node, rpc and tendermint `Cargo.toml`s
* testgen `Cargo.toml` tendermint dependencies

The rpc doesn't actually need a new release, if I was correct in parsing the commits. We only updated documentation. But it's nice to keep versioning together.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
