### PR TITLE
Run Clippy on all targets (standard, tests, examples and benchmarks)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --workspace -- --check
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --workspace -- --check
+          args: --all -- --check
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --all-targets
 
   test-stable:
     runs-on: ubuntu-latest

--- a/light-client/src/predicates/errors.rs
+++ b/light-client/src/predicates/errors.rs
@@ -113,19 +113,11 @@ impl VerificationError {
 
 impl ErrorExt for VerificationError {
     fn not_enough_trust(&self) -> bool {
-        if let Self::NotEnoughTrust { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::NotEnoughTrust { .. })
     }
 
     fn has_expired(&self) -> bool {
-        if let Self::NotWithinTrustPeriod { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::NotWithinTrustPeriod { .. })
     }
 
     fn is_timeout(&self) -> bool {

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -55,18 +55,12 @@ impl CommitSig {
 
     /// Whether this signature is a commit  (validator voted for the Commit.BlockId)
     pub fn is_commit(&self) -> bool {
-        match self {
-            Self::BlockIDFlagCommit { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::BlockIDFlagCommit { .. })
     }
 
     /// Whether this signature is nil (validator voted for nil)
     pub fn is_nil(&self) -> bool {
-        match self {
-            Self::BlockIDFlagNil { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::BlockIDFlagNil { .. })
     }
 }
 

--- a/testgen/src/tester.rs
+++ b/testgen/src/tester.rs
@@ -71,31 +71,19 @@ pub enum TestResult {
 
 impl TestResult {
     pub fn is_success(&self) -> bool {
-        match self {
-            TestResult::Success(_) => true,
-            _ => false,
-        }
+        matches!(self, TestResult::Success(_))
     }
     pub fn is_failure(&self) -> bool {
-        match self {
-            TestResult::Failure {
-                message: _,
-                location: _,
-            } => true,
-            _ => false,
-        }
+        matches!(self, TestResult::Failure {
+            message: _,
+            location: _,
+        })
     }
     pub fn is_readerror(&self) -> bool {
-        match self {
-            TestResult::ReadError => true,
-            _ => false,
-        }
+        matches!(self, TestResult::ReadError)
     }
     pub fn is_parseerror(&self) -> bool {
-        match self {
-            TestResult::ParseError => true,
-            _ => false,
-        }
+        matches!(self, TestResult::ParseError)
     }
 }
 


### PR DESCRIPTION

Add the `--all-targets` flag to the invocation of Clippy in order to check all targets (standard, tests, examples and benchmarks).

---

Also renames the deprecated `--all` flag of `rustfmt` to `--workspace`.

---

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
