### PR TITLE
Empty Merkle tree hash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
 - Add spec for the light client attack evidence handling ([#544])
+- return rfc6962 hash for empty merkle tree ([#498])
 
 [#544]: https://github.com/informalsystems/tendermint-rs/pull/544
+[#498]: https://github.com/informalsystems/tendermint-rs/issues/498
 
 ## v0.16.0
 

--- a/tendermint/src/merkle.rs
+++ b/tendermint/src/merkle.rs
@@ -21,7 +21,7 @@ pub fn simple_hash_from_byte_vectors(byte_vecs: Vec<Vec<u8>>) -> Hash {
 fn simple_hash_from_byte_slices_inner(byte_slices: &[Vec<u8>]) -> Hash {
     let length = byte_slices.len();
     match length {
-        0 => [0; HASH_SIZE],
+        0 => empty_hash(),
         1 => leaf_hash(byte_slices[0].as_slice()),
         _ => {
             let k = get_split_point(length);
@@ -40,6 +40,20 @@ fn get_split_point(length: usize) -> usize {
         2 => 1,
         _ => length.next_power_of_two() / 2,
     }
+}
+
+// tmhash({})
+fn empty_hash() -> Hash {
+    // the empty string / byte slice
+    let empty = Vec::with_capacity(0);
+
+    // hash it !
+    let digest = Sha256::digest(&empty);
+
+    // copy the GenericArray out
+    let mut hash_bytes = [0u8; HASH_SIZE];
+    hash_bytes.copy_from_slice(&digest);
+    hash_bytes
 }
 
 // tmhash(0x00 || leaf)
@@ -97,7 +111,7 @@ mod tests {
     #[test]
     fn test_rfc6962_empty_tree() {
         let empty_tree_root_hex =
-            "0000000000000000000000000000000000000000000000000000000000000000";
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         let empty_tree_root = &hex::decode(empty_tree_root_hex).unwrap();
         let empty_tree: Vec<Vec<u8>> = vec![vec![]; 0];
 


### PR DESCRIPTION
Closes #540 .

Re-introduces the fix for empty Merkle tree hashing. This was created by Ismail before but it was pulled for the v0.16.0 release. We need it for 0.17.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG.md
