### PR TITLE
rpc: Fix and test WebSocket Tx event subscription

### DIFF
--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -1,7 +1,7 @@
 //! Tendermint RPC client.
 
 mod subscription;
-pub use subscription::{Subscription, SubscriptionClient, SubscriptionId, SubscriptionRouter};
+pub use subscription::{Subscription, SubscriptionClient, SubscriptionId};
 pub mod sync;
 
 mod transport;

--- a/rpc/src/client/subscription.rs
+++ b/rpc/src/client/subscription.rs
@@ -221,6 +221,7 @@ struct PendingUnsubscribe {
 }
 
 /// The current state of a subscription.
+#[cfg(feature = "websocket-client")]
 #[derive(Debug, Clone, PartialEq)]
 pub enum SubscriptionState {
     Pending,
@@ -241,9 +242,11 @@ pub struct SubscriptionRouter {
     subscriptions: HashMap<String, HashMap<SubscriptionId, ChannelTx<Result<Event>>>>,
     // A map of JSON-RPC request IDs (for `/subscribe` requests) to pending
     // subscription requests.
+    #[cfg(feature = "websocket-client")]
     pending_subscribe: HashMap<String, PendingSubscribe>,
     // A map of JSON-RPC request IDs (for the `/unsubscribe` requests) to pending
     // unsubscribe requests.
+    #[cfg(feature = "websocket-client")]
     pending_unsubscribe: HashMap<String, PendingUnsubscribe>,
 }
 
@@ -294,6 +297,7 @@ impl SubscriptionRouter {
     /// `req_id` must be a unique identifier for this particular pending
     /// subscription request operation, where `subs_id` must be the unique ID
     /// of the subscription we eventually want added.
+    #[cfg(feature = "websocket-client")]
     pub fn pending_add(
         &mut self,
         req_id: &str,
@@ -317,6 +321,7 @@ impl SubscriptionRouter {
     ///
     /// Returns an error if it fails to respond to the original caller to
     /// indicate success.
+    #[cfg(feature = "websocket-client")]
     pub async fn confirm_add(&mut self, req_id: &str) -> Result<()> {
         match self.pending_subscribe.remove(req_id) {
             Some(mut pending_subscribe) => {
@@ -334,6 +339,7 @@ impl SubscriptionRouter {
     /// Attempts to cancel the pending subscription with the given ID, sending
     /// the specified error to the original creator of the attempted
     /// subscription.
+    #[cfg(feature = "websocket-client")]
     pub async fn cancel_add(&mut self, req_id: &str, err: impl Into<Error>) -> Result<()> {
         match self.pending_subscribe.remove(req_id) {
             Some(mut pending_subscribe) => Ok(pending_subscribe
@@ -361,6 +367,7 @@ impl SubscriptionRouter {
 
     /// Keeps track of a pending unsubscribe request, which can either be
     /// confirmed or cancelled.
+    #[cfg(feature = "websocket-client")]
     pub fn pending_remove(
         &mut self,
         req_id: &str,
@@ -380,6 +387,7 @@ impl SubscriptionRouter {
 
     /// Confirm the pending unsubscribe request for the subscription with the
     /// given ID.
+    #[cfg(feature = "websocket-client")]
     pub async fn confirm_remove(&mut self, req_id: &str) -> Result<()> {
         match self.pending_unsubscribe.remove(req_id) {
             Some(mut pending_unsubscribe) => {
@@ -392,6 +400,7 @@ impl SubscriptionRouter {
 
     /// Cancel the pending unsubscribe request for the subscription with the
     /// given ID, responding with the given error.
+    #[cfg(feature = "websocket-client")]
     pub async fn cancel_remove(&mut self, req_id: &str, err: impl Into<Error>) -> Result<()> {
         match self.pending_unsubscribe.remove(req_id) {
             Some(mut pending_unsubscribe) => {
@@ -403,6 +412,7 @@ impl SubscriptionRouter {
 
     /// Helper to check whether the subscription with the given ID is
     /// currently active.
+    #[cfg(feature = "websocket-client")]
     pub fn is_active(&self, id: &SubscriptionId) -> bool {
         self.subscriptions
             .iter()
@@ -411,6 +421,7 @@ impl SubscriptionRouter {
 
     /// Obtain a mutable reference to the subscription with the given ID (if it
     /// exists).
+    #[cfg(feature = "websocket-client")]
     pub fn get_active_subscription_mut(
         &mut self,
         id: &SubscriptionId,
@@ -423,6 +434,7 @@ impl SubscriptionRouter {
 
     /// Utility method to determine the current state of the subscription with
     /// the given ID.
+    #[cfg(feature = "websocket-client")]
     pub fn subscription_state(&self, req_id: &str) -> Option<SubscriptionState> {
         if self.pending_subscribe.contains_key(req_id) {
             Some(SubscriptionState::Pending)
@@ -440,7 +452,9 @@ impl Default for SubscriptionRouter {
     fn default() -> Self {
         Self {
             subscriptions: HashMap::new(),
+            #[cfg(feature = "websocket-client")]
             pending_subscribe: HashMap::new(),
+            #[cfg(feature = "websocket-client")]
             pending_unsubscribe: HashMap::new(),
         }
     }
@@ -525,6 +539,7 @@ mod test {
         assert_eq!(ev, subs3_ev);
     }
 
+    #[cfg(feature = "websocket-client")]
     #[tokio::test]
     async fn router_pending_subscription() {
         let mut router = SubscriptionRouter::default();
@@ -577,6 +592,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "websocket-client")]
     #[tokio::test]
     async fn router_cancel_pending_subscription() {
         let mut router = SubscriptionRouter::default();

--- a/rpc/src/client/transport/mock/subscription.rs
+++ b/rpc/src/client/transport/mock/subscription.rs
@@ -1,8 +1,7 @@
 //! Subscription functionality for the Tendermint RPC mock client.
 
-use crate::client::subscription::SubscriptionDriverCmd;
+use crate::client::subscription::{SubscriptionDriverCmd, SubscriptionRouter};
 use crate::client::sync::{unbounded, ChannelRx, ChannelTx};
-use crate::client::SubscriptionRouter;
 use crate::event::Event;
 use crate::{Error, Result, Subscription, SubscriptionClient, SubscriptionId};
 use async_trait::async_trait;

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -262,9 +262,6 @@ impl WebSocketSubscriptionDriver {
             .split("}\n{")
             .map(|m| m.to_string())
             .collect::<Vec<String>>();
-        if msgs.is_empty() {
-            return;
-        }
         for mut msg in msgs {
             if !msg.starts_with('{') {
                 msg.insert(0, '{');

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -258,6 +258,9 @@ impl WebSocketSubscriptionDriver {
     async fn handle_text_msg(&mut self, msg: String) {
         // See https://github.com/tendermint/tendermint/issues/5373
         let msgs = msg
+            // TODO(thane): Find a better way of dealing with this. This is
+            //              brittle and will break if there's even just one
+            //              string in the message that contains the same pattern.
             .split("}\n{")
             .map(|m| m.to_string())
             .collect::<Vec<String>>();

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -258,31 +258,15 @@ impl WebSocketSubscriptionDriver {
     }
 
     async fn handle_text_msg(&mut self, msg: String) {
-        // See https://github.com/tendermint/tendermint/issues/5373
-        let msgs = msg
-            // TODO(thane): Find a better way of dealing with this. This is
-            //              brittle and will break if there's even just one
-            //              string in the message that contains the same pattern.
-            .split("}\n{")
-            .map(|m| m.to_string())
-            .collect::<Vec<String>>();
-        for mut msg in msgs {
-            if !msg.starts_with('{') {
-                msg.insert(0, '{');
+        match Event::from_string(&msg) {
+            Ok(ev) => {
+                self.router.publish(ev).await;
             }
-            if !msg.ends_with('}') {
-                msg.push('}');
-            }
-            match Event::from_string(&msg) {
-                Ok(ev) => {
-                    self.router.publish(ev).await;
-                }
-                Err(_) => {
-                    if let Ok(wrapper) =
-                        serde_json::from_str::<response::Wrapper<GenericJSONResponse>>(&msg)
-                    {
-                        self.handle_generic_response(wrapper).await;
-                    }
+            Err(_) => {
+                if let Ok(wrapper) =
+                    serde_json::from_str::<response::Wrapper<GenericJSONResponse>>(&msg)
+                {
+                    self.handle_generic_response(wrapper).await;
                 }
             }
         }

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -1,6 +1,8 @@
 //! WebSocket-based clients for accessing Tendermint RPC functionality.
 
-use crate::client::subscription::{SubscriptionDriverCmd, SubscriptionRouter, SubscriptionState};
+use crate::client::subscription::{
+    SubscriptionDriverCmd, SubscriptionState, TwoPhaseSubscriptionRouter,
+};
 use crate::client::sync::{unbounded, ChannelRx, ChannelTx};
 use crate::client::transport::get_tcp_host_port;
 use crate::endpoint::{subscribe, unsubscribe};
@@ -145,7 +147,7 @@ impl Response for GenericJSONResponse {}
 #[derive(Debug)]
 struct WebSocketSubscriptionDriver {
     stream: WebSocketStream<TokioAdapter<TcpStream>>,
-    router: SubscriptionRouter,
+    router: TwoPhaseSubscriptionRouter,
     cmd_rx: ChannelRx<SubscriptionDriverCmd>,
 }
 
@@ -156,7 +158,7 @@ impl WebSocketSubscriptionDriver {
     ) -> Self {
         Self {
             stream,
-            router: SubscriptionRouter::default(),
+            router: TwoPhaseSubscriptionRouter::default(),
             cmd_rx,
         }
     }

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -1,9 +1,8 @@
 //! WebSocket-based clients for accessing Tendermint RPC functionality.
 
-use crate::client::subscription::{SubscriptionDriverCmd, SubscriptionState};
+use crate::client::subscription::{SubscriptionDriverCmd, SubscriptionRouter, SubscriptionState};
 use crate::client::sync::{unbounded, ChannelRx, ChannelTx};
 use crate::client::transport::get_tcp_host_port;
-use crate::client::SubscriptionRouter;
 use crate::endpoint::{subscribe, unsubscribe};
 use crate::event::Event;
 use crate::{

--- a/rpc/src/event.rs
+++ b/rpc/src/event.rs
@@ -37,6 +37,7 @@ pub enum EventData {
     },
     #[serde(alias = "tendermint/event/Tx")]
     Tx {
+        #[serde(rename = "TxResult")]
         tx_result: TxInfo,
     },
     GenericJSONEvent(serde_json::Value),
@@ -46,7 +47,7 @@ pub enum EventData {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct TxInfo {
     pub height: String,
-    pub index: i64,
+    pub index: Option<i64>,
     pub tx: String,
     pub result: TxResult,
 }
@@ -54,9 +55,9 @@ pub struct TxInfo {
 /// Transaction result.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct TxResult {
-    pub log: String,
-    pub gas_wanted: String,
-    pub gas_used: String,
+    pub log: Option<String>,
+    pub gas_wanted: Option<String>,
+    pub gas_used: Option<String>,
     pub events: Vec<TmEvent>,
 }
 

--- a/tendermint/tests/integration.rs
+++ b/tendermint/tests/integration.rs
@@ -206,9 +206,6 @@ mod rpc {
             "Attempting to grab {} transaction events",
             expected_tx_values.len()
         );
-        // We reverse the expected tx values because we're popping them off the
-        // array as we check the received events.
-        expected_tx_values.reverse();
         let mut cur_tx_id = 0_u32;
 
         while !expected_tx_values.is_empty() {
@@ -217,7 +214,7 @@ mod rpc {
                 Some(res) = subs.next() => {
                     let ev = res.unwrap();
                     //println!("Got event: {:?}", ev);
-                    let next_val = expected_tx_values.pop().unwrap();
+                    let next_val = expected_tx_values.remove(0);
                     match ev.data {
                         EventData::Tx { tx_result } => match base64::decode(tx_result.tx) {
                             Ok(decoded_tx) => match String::from_utf8(decoded_tx) {


### PR DESCRIPTION
In partial fulfillment of #568.

This adds an integration test to ensure that transaction subscription works (WebSocket-based subscription with query=`tm.event='Tx'`).

I had to make some fields in the relevant data structures optional, since they aren't always returned by the RPC remote endpoint.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG.md
