### PR TITLE
Fix all clippy lints

### DIFF
--- a/light-node/src/rpc.rs
+++ b/light-node/src/rpc.rs
@@ -34,7 +34,7 @@ where
 }
 
 mod sealed {
-    use jsonrpc_core::futures::future::{self, Future, FutureResult};
+    use jsonrpc_core::futures::future::{self, FutureResult};
     use jsonrpc_core::types::Error;
     use jsonrpc_derive::rpc;
 

--- a/testgen/src/commit.rs
+++ b/testgen/src/commit.rs
@@ -161,11 +161,13 @@ mod tests {
         let valset1 = sort_validators(&[
             Validator::new("a"),
             Validator::new("b"),
-            Validator::new("c")]);
+            Validator::new("c"),
+        ]);
         let valset2 = sort_validators(&[
             Validator::new("d"),
             Validator::new("e"),
-            Validator::new("f")]);
+            Validator::new("f"),
+        ]);
 
         let header = Header::new(&valset1)
             .next_validators(&valset2)

--- a/testgen/src/commit.rs
+++ b/testgen/src/commit.rs
@@ -158,16 +158,14 @@ mod tests {
 
     #[test]
     fn test_commit() {
-        let valset1 = sort_validators(&vec![
+        let valset1 = sort_validators(&[
             Validator::new("a"),
             Validator::new("b"),
-            Validator::new("c"),
-        ]);
-        let valset2 = sort_validators(&vec![
+            Validator::new("c")]);
+        let valset2 = sort_validators(&[
             Validator::new("d"),
             Validator::new("e"),
-            Validator::new("f"),
-        ]);
+            Validator::new("f")]);
 
         let header = Header::new(&valset1)
             .next_validators(&valset2)


### PR DESCRIPTION
It was getting a bit noisy (e.g. see: https://github.com/informalsystems/tendermint-rs/pull/571/files#diff-89fca07be889575fefb9e77a8de9051d)

This PR aims to fix all the open lints. An alternative way to get rid of the annotations but still keep clippy would be to call clippy in CI instead of using this action: https://github.com/actions-rs/clippy-check 

Note this only fixes a part (namely the clippy lints), not the compiler warnings which are a lot in e.g. `rpc/src/client/subscription.rs`. I assume this part will prob. improve with https://github.com/informalsystems/tendermint-rs/pull/572 as this means a major overhaul of the current subscription module anyways.

To reproduce the remaining warnings locally, run e.g.
`cargo test -p tendermint-light-client --test integration --no-fail-fast -- --ignored`