### PR TITLE
Remove public key field from DuplicateVoteEvidence

### DIFF
--- a/rpc/tests/support/block_with_evidences.json
+++ b/rpc/tests/support/block_with_evidences.json
@@ -43,7 +43,7 @@
           {
             "type": "tendermint/DuplicateVoteEvidence",
             "value": {
-              "VoteA": {
+              "vote_a": {
                 "type": 1,
                 "height": "21",
                 "round": "0",
@@ -59,7 +59,7 @@
                 "validator_index": "0",
                 "signature": "JDVzUjWVP9qWZJpKmN14FvmS4mXoLnwW7C1UjFtNQrVTQpL+ONg+IkYKGzVTDQtpOcGDbOLC2dbKvY/OToaWDA=="
               },
-              "VoteB": {
+              "vote_b": {
                 "type": 1,
                 "height": "21",
                 "round": "0",

--- a/rpc/tests/support/block_with_evidences.json
+++ b/rpc/tests/support/block_with_evidences.json
@@ -43,10 +43,6 @@
           {
             "type": "tendermint/DuplicateVoteEvidence",
             "value": {
-              "PubKey": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "MjQn17Z4VocTjeHm60JVjPV9A6hUTKYSNDTpQiglXlY="
-              },
               "VoteA": {
                 "type": 1,
                 "height": "21",

--- a/tendermint/src/evidence.rs
+++ b/tendermint/src/evidence.rs
@@ -2,7 +2,7 @@
 
 use std::slice;
 use {
-    crate::{block::signed_header::SignedHeader, serializers, PublicKey, Vote},
+    crate::{block::signed_header::SignedHeader, serializers, Vote},
     serde::{Deserialize, Serialize},
 };
 
@@ -26,8 +26,6 @@ pub enum Evidence {
 /// Duplicate vote evidence
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DuplicateVoteEvidence {
-    #[serde(rename = "PubKey")]
-    pub_key: PublicKey,
     #[serde(rename = "VoteA")]
     vote_a: Vote,
     #[serde(rename = "VoteB")]

--- a/tendermint/src/evidence.rs
+++ b/tendermint/src/evidence.rs
@@ -26,9 +26,7 @@ pub enum Evidence {
 /// Duplicate vote evidence
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DuplicateVoteEvidence {
-    #[serde(rename = "VoteA")]
     vote_a: Vote,
-    #[serde(rename = "VoteB")]
     vote_b: Vote,
 }
 


### PR DESCRIPTION
Closes #502 

Doesn't seem like the `pub_key` field was used anywhere at all.

* [x] Referenced an issue explaining the need for the change
* [ ] ~Updated all relevant documentation in docs~
* [ ] ~Updated all code comments where relevant~
* [x] ~Wrote~ Updated tests
* [ ] Updated CHANGELOG.md
