### PR TITLE
Fix for running MBT on Macs

### DIFF
--- a/testgen/jsonatr-lib/apalache_to_lite_test.json
+++ b/testgen/jsonatr-lib/apalache_to_lite_test.json
@@ -13,7 +13,7 @@
         "signed_header": "$ | block_to_signed_header",
         "next_validator_set": "$ | block_next_validators | ids_to_validator_set",
         "trusting_period": "1400000000000",
-        "now": "$utc_timestamp"
+        "now": "2020-09-25T08:18:04.996061145Z"
       }
     },
     {

--- a/testgen/jsonatr-lib/unix.json
+++ b/testgen/jsonatr-lib/unix.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "utc_timestamp",
-      "kind": "COMMAND",
-      "source": "date --utc +%FT%H:%M:%S.%NZ",
+      "kind": "INLINE",
+      "source": "2020-09-25T08:18:04.996061145Z",
       "stdin": false
     },
     {

--- a/testgen/jsonatr-lib/unix.json
+++ b/testgen/jsonatr-lib/unix.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "utc_timestamp",
-      "kind": "INLINE",
-      "source": "2020-09-25T08:18:04.996061145Z",
+      "kind": "COMMAND",
+      "source": "date --utc +%FT%H:%M:%S.%NZ",
       "stdin": false
     },
     {


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->
closes #587 

As discussed with @andrey-kuprianov, this command isn't really used anywhere except just to get it parsed into the existing `TestCase struct` from Conformance Tests. This is because MBT currently uses it to run tests with the existing test driver. We should eventually clean that up but this is a quick fix for now.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
