### PR TITLE
links to tendermint/spec

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,11 +1,9 @@
 # Specification
 
-The primary English specifications for Tendermint data structures can be found in the
-[tendermint/spec repository](https://github.com/tendermint/spec).
+This directory served as location for English and TLA+
+specifications of the Tendermint protocols "fast sync" and "light
+client". The corresponding specification work is not happening in this directory
+anymore but in the [tendermint/spec](https://github.com/tendermint/spec)
+repository. The most recent versions of the specifications can be found
+there.
 
-This repository contains English and TLA+ specifications for the following
-protocols:
-
-- [Fast Sync](./fastsync) - Block synchronization protocol
-- [Light Client](./lightclient) - Light client verification, fork detection, and
-  fork accountability protocols 

--- a/docs/spec/fastsync/README.md
+++ b/docs/spec/fastsync/README.md
@@ -1,5 +1,13 @@
 # Fast Sync Subprotocol Specification
 
+## Disclaimer
+
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/fastsync/)
+for the most recent version.
+
+## Abstract
+
 This directory contains English and TLA+ specifications for the FastSync
 protocol as it is currently implemented in the Tendermint Core codebase.
 

--- a/docs/spec/fastsync/Tinychain.tla
+++ b/docs/spec/fastsync/Tinychain.tla
@@ -1,5 +1,9 @@
 -------------------------- MODULE Tinychain ----------------------------------
-(* A very abstract model of Tendermint blockchain. Its only purpose is to highlight
+(* This specification is not maintained anymore. The most recent version can be found at:
+
+   https://github.com/tendermint/spec/tree/master/rust-spec/fastsync
+
+   A very abstract model of Tendermint blockchain. Its only purpose is to highlight
    the relation between validator sets, next validator sets, and last commits.
  *)
 

--- a/docs/spec/fastsync/fastsync.md
+++ b/docs/spec/fastsync/fastsync.md
@@ -1,5 +1,12 @@
 # Fastsync
 
+## Disclaimer
+
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/)
+for the most recent version.
+
+## Abstract
 
 Fastsync is a protocol that is used by a node to catch-up to the
 current state of a Tendermint blockchain. Its typical use case is a

--- a/docs/spec/fastsync/fastsync.tla
+++ b/docs/spec/fastsync/fastsync.tla
@@ -1,5 +1,9 @@
 ----------------------------- MODULE fastsync -----------------------------
 (*
+ This specification is not maintained anymore. The most recent version can be found at:
+
+ https://github.com/tendermint/spec/tree/master/rust-spec/fastsync
+
  In this document we give the high level specification of the fast sync
  protocol as implemented here:
  https://github.com/tendermint/tendermint/tree/master/blockchain/v2.

--- a/docs/spec/fastsync/scheduler.tla
+++ b/docs/spec/fastsync/scheduler.tla
@@ -1,5 +1,9 @@
 ------------------------------- MODULE scheduler -------------------------------
 (*
+ This specification is not maintained anymore. The most recent version can be found at:
+
+ https://github.com/tendermint/spec/tree/master/rust-spec/fastsync
+
  A specification of the fast sync scheduler that is introduced in blockchain/v2:
  
  https://github.com/tendermint/tendermint/tree/brapse/blockchain-v2-riri-reactor-2

--- a/docs/spec/lightclient/README.md
+++ b/docs/spec/lightclient/README.md
@@ -1,5 +1,14 @@
 # Light Client Specification
 
+## Disclaimer
+
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/)
+for the most recent version.
+
+## Abstract
+
+
 This directory contains work-in-progress English and TLA+ specifications for the Light Client
 protocol. Implementations of the light client can be found in
 [Rust](https://github.com/informalsystems/tendermint-rs/tree/master/light-client) and

--- a/docs/spec/lightclient/attacks/evidence-handling.md
+++ b/docs/spec/lightclient/attacks/evidence-handling.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/)
+for the most recent version.
+
 
 # Light client attacks
 

--- a/docs/spec/lightclient/detection/README.md
+++ b/docs/spec/lightclient/detection/README.md
@@ -1,6 +1,13 @@
 
 # Tendermint fork detection and IBC fork detection
 
+## Disclaimer
+
+This directory is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/)
+for the most recent version.
+
+
 ## Status
 
 This is a work in progress.

--- a/docs/spec/lightclient/detection/detection.md
+++ b/docs/spec/lightclient/detection/detection.md
@@ -1,4 +1,9 @@
-***This an unfinished draft. Comments are welcome!***
+
+# Disclaimer
+
+This specification is  an unfinished draft and not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/)
+for the most recent version.
 
 
 

--- a/docs/spec/lightclient/detection/discussions.md
+++ b/docs/spec/lightclient/detection/discussions.md
@@ -1,4 +1,8 @@
+## Disclaimer
 
+This document is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/)
+for the most recent version.
 
 
 ## Results of Discussions and Decisions 

--- a/docs/spec/lightclient/detection/draft-functions.md
+++ b/docs/spec/lightclient/detection/draft-functions.md
@@ -1,5 +1,14 @@
 # Draft of Functions for Fork detection and Proof of Fork Submisstion
 
+
+## Disclaimer
+
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/)
+for the most recent version.
+
+## Abstract 
+
 This document collects drafts of function for generating and
 submitting proof of fork in the IBC context
 

--- a/docs/spec/lightclient/detection/req-ibc-detection.md
+++ b/docs/spec/lightclient/detection/req-ibc-detection.md
@@ -1,5 +1,10 @@
 # Requirements for Fork Detection in the IBC Context
 
+## Disclaimer
+
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/)
+for the most recent version.
 
 ## What you need to know about IBC
 

--- a/docs/spec/lightclient/verification/Blockchain_A_1.tla
+++ b/docs/spec/lightclient/verification/Blockchain_A_1.tla
@@ -1,5 +1,10 @@
 ------------------------ MODULE Blockchain_A_1 -----------------------------
 (*
+
+ * This specification is not maintained anymore. The most recent version can be found at:
+
+ * https://github.com/tendermint/spec/tree/master/rust-spec/lightclient/verification
+
   This is a high-level specification of Tendermint blockchain
   that is designed specifically for the light client.
   Validators have the voting power of one. If you like to model various

--- a/docs/spec/lightclient/verification/Lightclient_A_1.tla
+++ b/docs/spec/lightclient/verification/Lightclient_A_1.tla
@@ -1,5 +1,9 @@
 -------------------------- MODULE Lightclient_A_1 ----------------------------
 (**
+ * This specification is not maintained anymore. The most recent version can be found at:
+
+ * https://github.com/tendermint/spec/tree/master/rust-spec/lightclient/verification
+
  * A state-machine specification of the lite client, following the English spec:
  *
  * https://github.com/informalsystems/tendermint-rs/blob/master/docs/spec/lightclient/verification.md

--- a/docs/spec/lightclient/verification/verification.md
+++ b/docs/spec/lightclient/verification/verification.md
@@ -1,6 +1,12 @@
 # Light Client Verification
 
+## Disclaimer
 
+This specification is not maintained. See
+[tendermint/spec](https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/verification/)
+for the most recent version.
+
+## Abstract
 
 The light client implements a read operation of a
 [header][TMBC-HEADER-link] from the [blockchain][TMBC-SEQ-link], by


### PR DESCRIPTION
#594: I added a note to the files that they are not maintained and that the newer versions are in tendermint/spec.

@konnov : I did this for the main TLA+ files but not for each `MCx_y_bla.tla`. Is it OK?