### PR TITLE
tendermint: remove `tai64` crate

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -52,7 +52,6 @@ sha2 = { version = "0.9", default-features = false }
 signature = "1.2"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tai64 = { version = "3", features = ["chrono"] }
 thiserror = "1"
 tendermint-proto = { path = "../proto" }
 toml = { version = "0.5" }

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -4,7 +4,6 @@ use crate::error::{Error, Kind};
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
-use tai64::TAI64N;
 
 use std::fmt;
 use std::ops::{Add, Sub};
@@ -17,18 +16,18 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub struct Time(DateTime<Utc>);
 
 impl Time {
-    /// Get a `Timestamp` representing the current wall clock time
+    /// Get [`Time`] value representing the current wall clock time
     pub fn now() -> Self {
         Time(Utc::now())
     }
 
-    /// Get the `UNIX_EPOCH` time ("1970-01-01 00:00:00 UTC") as a `Timestamp`
+    /// Get the [`UNIX_EPOCH`] time ("1970-01-01 00:00:00 UTC") as a [`Time`]
     pub fn unix_epoch() -> Self {
         UNIX_EPOCH.into()
     }
 
-    /// Calculate the amount of time which has passed since another `Timestamp`
-    /// as a `std::time::Duration`
+    /// Calculate the amount of time which has passed since another [`Time`]
+    /// as a [`std::time::Duration`]
     pub fn duration_since(&self, other: Time) -> Result<Duration, Error> {
         self.0
             .signed_duration_since(other.0)
@@ -36,7 +35,7 @@ impl Time {
             .map_err(|_| Kind::OutOfRange.into())
     }
 
-    /// Parse a timestamp from an RFC 3339 date
+    /// Parse [`Time`] from an RFC 3339 date
     pub fn parse_from_rfc3339(s: &str) -> Result<Time, Error> {
         Ok(Time(DateTime::parse_from_rfc3339(s)?.with_timezone(&Utc)))
     }
@@ -46,7 +45,7 @@ impl Time {
         self.0.to_rfc3339_opts(SecondsFormat::Nanos, true)
     }
 
-    /// Convert this timestamp to a `SystemTime`
+    /// Convert [`Time`] to [`SystemTime`]
     pub fn to_system_time(&self) -> Result<SystemTime, Error> {
         let duration_since_epoch = self.duration_since(Self::unix_epoch())?;
         Ok(UNIX_EPOCH + duration_since_epoch)
@@ -91,18 +90,6 @@ impl From<Time> for SystemTime {
     }
 }
 
-impl From<TAI64N> for Time {
-    fn from(t: TAI64N) -> Time {
-        Time(t.to_datetime_utc())
-    }
-}
-
-impl From<Time> for TAI64N {
-    fn from(t: Time) -> TAI64N {
-        TAI64N::from_datetime_utc(&t.0)
-    }
-}
-
 impl Add<Duration> for Time {
     type Output = Self;
 
@@ -121,8 +108,8 @@ impl Sub<Duration> for Time {
     }
 }
 
-/// Parse `Timestamp` from a type
+/// Parse [`Time`] from a type
 pub trait ParseTimestamp {
-    /// Parse `Timestamp`, or return an `Error` if parsing failed
+    /// Parse [`Time`], or return an [`Error`] if parsing failed
     fn parse_timestamp(&self) -> Result<Time, Error>;
 }


### PR DESCRIPTION
A very long time ago this was used as a (monotonic, leap-second-free) internal representation for the `Time` type.

It was switched to use `chrono::DateTime<Utc>` and is now no longer needed.