### PR TITLE
Remove `peer_id` parameter of `block_on` helper

### DIFF
--- a/light-client/src/components/io.rs
+++ b/light-client/src/components/io.rs
@@ -9,7 +9,7 @@ use tendermint_rpc::Client;
 
 use tendermint_rpc as rpc;
 
-use crate::types::{Height, LightBlock, PeerId};
+use crate::types::{Height, LightBlock};
 
 /// Type for selecting either a specific height or the latest one
 pub enum AtHeight {
@@ -76,7 +76,10 @@ mod prod {
 
     use std::time::Duration;
 
-    use crate::{bail, utils::block_on};
+    use crate::bail;
+    use crate::types::PeerId;
+    use crate::utils::block_on;
+
     use tendermint::block::signed_header::SignedHeader as TMSignedHeader;
     use tendermint::validator::Set as TMValidatorSet;
 

--- a/light-client/src/components/io.rs
+++ b/light-client/src/components/io.rs
@@ -1,6 +1,7 @@
 //! Provides an interface and a default implementation of the `Io` component
 
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use thiserror::Error;
 
 #[cfg(feature = "rpc-client")]
@@ -39,9 +40,9 @@ pub enum IoError {
     #[error("invalid height: {0}")]
     InvalidHeight(String),
 
-    /// The request timed out.
-    #[error("request to peer {0} timed out")]
-    Timeout(PeerId),
+    /// Task timed out.
+    #[error("task timed out after {} ms", .0.as_millis())]
+    Timeout(Duration),
 }
 
 impl IoError {
@@ -52,7 +53,6 @@ impl IoError {
 }
 
 /// Interface for fetching light blocks from a full node, typically via the RPC client.
-#[allow(missing_docs)] // This is required because of the `contracts` crate (TODO: open/link issue)
 pub trait Io: Send {
     /// Fetch a light block at the given height from a peer
     fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, IoError>;
@@ -127,16 +127,12 @@ mod prod {
 
         fn fetch_signed_header(&self, height: AtHeight) -> Result<TMSignedHeader, IoError> {
             let client = self.rpc_client.clone();
-            let res = block_on(
-                async move {
-                    match height {
-                        AtHeight::Highest => client.latest_commit().await,
-                        AtHeight::At(height) => client.commit(height).await,
-                    }
-                },
-                self.peer_id,
-                self.timeout,
-            )?;
+            let res = block_on(self.timeout, async move {
+                match height {
+                    AtHeight::Highest => client.latest_commit().await,
+                    AtHeight::At(height) => client.commit(height).await,
+                }
+            })?;
 
             match res {
                 Ok(response) => Ok(response.signed_header),
@@ -153,8 +149,7 @@ mod prod {
             };
 
             let client = self.rpc_client.clone();
-            let task = async move { client.validators(height).await };
-            let res = block_on(task, self.peer_id, self.timeout)?;
+            let res = block_on(self.timeout, async move { client.validators(height).await })?;
 
             match res {
                 Ok(response) => Ok(TMValidatorSet::new(response.validators)),

--- a/light-client/src/evidence.rs
+++ b/light-client/src/evidence.rs
@@ -42,8 +42,9 @@ mod prod {
         #[pre(self.peer_map.contains_key(&peer))]
         fn report(&self, e: Evidence, peer: PeerId) -> Result<Hash, IoError> {
             let client = self.rpc_client_for(peer)?;
-            let task = async move { client.broadcast_evidence(e).await };
-            let res = block_on(task, peer, None)?;
+
+            // TODO: Allow specifying a timeout
+            let res = block_on(None, async move { client.broadcast_evidence(e).await })?;
 
             match res {
                 Ok(response) => Ok(response.hash),

--- a/light-client/src/evidence.rs
+++ b/light-client/src/evidence.rs
@@ -25,7 +25,7 @@ mod prod {
     use crate::utils::block_on;
 
     use contracts::pre;
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use tendermint_rpc as rpc;
     use tendermint_rpc::Client;
@@ -35,6 +35,7 @@ mod prod {
     #[derive(Clone, Debug)]
     pub struct ProdEvidenceReporter {
         peer_map: HashMap<PeerId, tendermint::net::Address>,
+        timeout: Option<Duration>,
     }
 
     #[contract_trait]
@@ -43,8 +44,10 @@ mod prod {
         fn report(&self, e: Evidence, peer: PeerId) -> Result<Hash, IoError> {
             let client = self.rpc_client_for(peer)?;
 
-            // TODO: Allow specifying a timeout
-            let res = block_on(None, async move { client.broadcast_evidence(e).await })?;
+            let res = block_on(
+                self.timeout,
+                async move { client.broadcast_evidence(e).await },
+            )?;
 
             match res {
                 Ok(response) => Ok(response.hash),
@@ -57,8 +60,11 @@ mod prod {
         /// Constructs a new ProdEvidenceReporter component.
         ///
         /// A peer map which maps peer IDS to their network address must be supplied.
-        pub fn new(peer_map: HashMap<PeerId, tendermint::net::Address>) -> Self {
-            Self { peer_map }
+        pub fn new(
+            peer_map: HashMap<PeerId, tendermint::net::Address>,
+            timeout: Option<Duration>,
+        ) -> Self {
+            Self { peer_map, timeout }
         }
 
         #[pre(self.peer_map.contains_key(&peer))]

--- a/light-client/src/utils/block_on.rs
+++ b/light-client/src/utils/block_on.rs
@@ -1,11 +1,11 @@
 use std::{future::Future, time::Duration};
 
-use crate::{components::io::IoError, types::PeerId};
+use crate::components::io::IoError;
 
 /// Run a future to completion on a new thread, with the given timeout.
 ///
 /// This function will block the caller until the given future has completed.
-pub fn block_on<F>(f: F, peer: PeerId, timeout: Option<Duration>) -> Result<F::Output, IoError>
+pub fn block_on<F>(timeout: Option<Duration>, f: F) -> Result<F::Output, IoError>
 where
     F: Future + Send + 'static,
     F::Output: Send,
@@ -19,7 +19,7 @@ where
 
         if let Some(timeout) = timeout {
             let task = async { tokio::time::timeout(timeout, f).await };
-            rt.block_on(task).map_err(|_| IoError::Timeout(peer))
+            rt.block_on(task).map_err(|_| IoError::Timeout(timeout))
         } else {
             Ok(rt.block_on(f))
         }


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

The `block_on` helper should be able to be used in cases where there are no peer id to speak of, eg. when blocking on a task which does not talk to a node over the network.

Additionally, this PR adds an option to the supervisor builder to configure the timeout for fork evidence submission.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
