### PR TITLE
Perform signers overlap check last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 - `[light-client]` Fix bug where a commit with only absent signatures would be
   deemed valid instead of invalid ([#650])
+- `[light-client]` Revert a change introduced in [#652] that would enable DoS attacks,
+  where full nodes could spam the light client with massive commits (eg. 10k validators).
 
-[#652]: https://github.com/informalsystems/tendermint-rs/issues/650
+[#650]: https://github.com/informalsystems/tendermint-rs/issues/650
+[#652]: https://github.com/informalsystems/tendermint-rs/pulls/652
 
 ## v0.17.0-rc1
 

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -261,13 +261,6 @@ pub fn verify(
         &trusted.signed_header.header,
     )?;
 
-    // Verify that more than 2/3 of the validators correctly committed the block.
-    vp.has_sufficient_signers_overlap(
-        &untrusted.signed_header,
-        &untrusted.validators,
-        voting_power_calculator,
-    )?;
-
     let trusted_next_height = trusted.height().increment();
 
     if untrusted.height() == trusted_next_height {
@@ -291,6 +284,13 @@ pub fn verify(
             voting_power_calculator,
         )?;
     }
+
+    // Verify that more than 2/3 of the validators correctly committed the block.
+    vp.has_sufficient_signers_overlap(
+        &untrusted.signed_header,
+        &untrusted.validators,
+        voting_power_calculator,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Close: #656

The change introduced in 355791f (as part of #652) enables DoS attacks, where full nodes could spam the light client with massive commits (eg. 10k validators).

See https://github.com/informalsystems/tendermint-rs/pull/652/commits/355791f2635a49aa82bbb5751a0e6f46bca94cf9#r515981617 for more info.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
