### PR TITLE
proto: re-export `prost_types` as `well_known_types`

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -85,6 +85,7 @@ mod tendermint {
     }
 }
 
+pub use prost_types as well_known_types;
 pub use tendermint::*;
 
 mod domaintype;


### PR DESCRIPTION
My main interest is being able to get to `prost_types::Timestamp` without having to include `prost_types` in addition to
`tendermint-proto`, however I think there might be more cases where it's helpful to have access to the well-known proto types in the future.