### PR TITLE
git_commitish now accepts commit IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@
 - `[light-client]` Revert a change introduced in [#652] that would enable DoS attacks,
   where full nodes could spam the light client with massive commits (eg. 10k validators).
 
+### FEATURES:
+
+- `[tendermint/proto-compiler]` Protobuf structs generator now also accepts commit IDs from the Tendermint Go repository ([#660])
+
+
 [#650]: https://github.com/informalsystems/tendermint-rs/issues/650
 [#652]: https://github.com/informalsystems/tendermint-rs/pulls/652
 [#639]: https://github.com/informalsystems/tendermint-rs/pull/639
+[#660]: https://github.com/informalsystems/tendermint-rs/issues/660
 
 ## v0.17.0-rc1
 

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -1,6 +1,12 @@
 /// Tendermint protobuf version
+
+/// Tendermint repository URL.
 pub const TENDERMINT_REPO: &str = "https://github.com/tendermint/tendermint";
-pub const TENDERMINT_COMMITISH: &str = "tags/v0.34.0-rc4";
+// Commitish formats:
+// Tag: v0.34.0-rc4
+// Branch: master
+// Commit ID (full length): d7d0ffea13c60c98b812d243ba5a2c375f341c15
+pub const TENDERMINT_COMMITISH: &str = "d7d0ffea13c60c98b812d243ba5a2c375f341c15";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -1,21 +1,27 @@
 use git2::build::{CheckoutBuilder, RepoBuilder};
-use git2::{AutotagOption, FetchOptions, Repository};
+use git2::{AutotagOption, Commit, FetchOptions, Oid, Reference, Repository};
 use std::fs::remove_dir_all;
 use std::fs::{copy, create_dir_all};
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
-/// Clone/open, fetch and check out a specific commitish
+/// Clone or open+fetch a repository and check out a specific commitish
+/// In case of an existing repository, the origin remote will be set to `url`.
 pub fn get_commitish(dir: &PathBuf, url: &str, commitish: &str) {
-    if dir.exists() {
-        update_and_get_commitish(dir, commitish)
+    let repo = if dir.exists() {
+        fetch_existing(dir, url)
     } else {
-        clone_and_get_commitish(dir, url, commitish)
-    }
+        clone_new(dir, url)
+    };
+    checkout_commitish(&repo, commitish)
 }
 
-fn clone_and_get_commitish(dir: &PathBuf, url: &str, commitish: &str) {
-    println!("  [info] => Cloning {} to {}", url, dir.to_string_lossy());
+fn clone_new(dir: &PathBuf, url: &str) -> Repository {
+    println!(
+        "  [info] => Cloning {} into {} folder",
+        url,
+        dir.to_string_lossy()
+    );
 
     let mut fo = FetchOptions::new();
     fo.download_tags(AutotagOption::All);
@@ -24,26 +30,35 @@ fn clone_and_get_commitish(dir: &PathBuf, url: &str, commitish: &str) {
     let mut builder = RepoBuilder::new();
     builder.fetch_options(fo);
 
-    let repo = builder.clone(url, dir).unwrap();
-    checkout_commitish(&repo, commitish);
+    builder.clone(url, dir).unwrap()
 }
 
-fn update_and_get_commitish(dir: &PathBuf, commitish: &str) {
-    println!("  [info] => Opening {}", dir.to_string_lossy());
+fn fetch_existing<'a>(dir: &PathBuf, url: &str) -> Repository {
+    println!(
+        "  [info] => Fetching from {} into existing {} folder",
+        url,
+        dir.to_string_lossy()
+    );
     let repo = Repository::open(dir).unwrap();
 
     let mut fo = git2::FetchOptions::new();
     fo.download_tags(git2::AutotagOption::All);
+    fo.update_fetchhead(true);
 
-    let mut remote = repo.find_remote("origin").unwrap();
-    println!("  [info] => Fetching {} for repo", remote.name().unwrap());
-    remote.fetch(&[commitish], Some(&mut fo), None).unwrap();
+    let mut remote = repo
+        .find_remote("origin")
+        .unwrap_or_else(|_| repo.remote("origin", url).unwrap());
+    if remote.url().is_none() || remote.url().unwrap() != url {
+        repo.remote_set_url("origin", url).unwrap();
+    }
+    println!("  [info] => Fetching repo using remote `origin`");
+    let specs: &[&str] = &[];
+    remote.fetch(specs, Some(&mut fo), None).unwrap();
 
     let stats = remote.stats();
     if stats.local_objects() > 0 {
         println!(
-            "  [info] => Received {}/{} objects in {} bytes (used {} local \
-     objects)",
+            "  [info] => Received {}/{} objects in {} bytes (used {} local objects)",
             stats.indexed_objects(),
             stats.total_objects(),
             stats.received_bytes(),
@@ -58,32 +73,75 @@ fn update_and_get_commitish(dir: &PathBuf, commitish: &str) {
         );
     }
 
-    checkout_commitish(&repo, commitish);
+    Repository::open(dir).unwrap()
 }
 
 fn checkout_commitish(repo: &Repository, commitish: &str) {
-    let ref_name = format!("refs/{}", commitish);
-    let commitish_ref = repo.find_reference(&ref_name).unwrap();
+    let (reference, commit) = find_reference_or_commit(repo, commitish);
 
-    if commitish_ref.is_tag() {
-        println!(
-            "  [info] => Checking out repo in detached HEAD mode at {}",
-            commitish
-        );
-        repo.set_head_detached(commitish_ref.target().unwrap())
-            .unwrap();
-    } else if commitish_ref.is_branch() {
-        println!("  [info] => Checking out repo at branch {}", commitish);
-        repo.set_head(&ref_name).unwrap();
-    } else {
-        panic!(
-            "  [error] => Commitish \"{}\" is neither a tag nor a branch",
-            commitish
-        );
+    println!(
+        "  [info] => Checking out repo in detached HEAD mode:\n    \
+             [info] => id: {},\n    \
+             [info] => author: {},\n    \
+             [info] => committer: {},\n    \
+             [info] => summary: {}",
+        commit.id(),
+        commit.author(),
+        commit.committer(),
+        commit.summary().unwrap_or(""),
+    );
+
+    match reference {
+        None => repo.set_head_detached(commit.id()).unwrap(),
+        Some(reference) => {
+            println!("    [info] => name: {}", reference.shorthand().unwrap());
+            repo.set_head(reference.name().unwrap()).unwrap();
+        }
     }
 
-    repo.checkout_head(Some(CheckoutBuilder::new().force()))
-        .unwrap();
+    let mut checkout_options = CheckoutBuilder::new();
+    checkout_options
+        .force()
+        .remove_untracked(true)
+        .remove_ignored(true)
+        .use_theirs(true);
+    repo.checkout_head(Some(&mut checkout_options)).unwrap();
+}
+
+fn find_reference_or_commit<'a>(
+    repo: &'a Repository,
+    commitish: &str,
+) -> (Option<Reference<'a>>, Commit<'a>) {
+    let mut tried_origin = false; // we tried adding 'origin/' to the commitish
+
+    let mut try_reference = repo.resolve_reference_from_short_name(&commitish);
+    if try_reference.is_err() {
+        // Local branch might be missing, try the remote branch
+        try_reference = repo.resolve_reference_from_short_name(&format!("origin/{}", commitish));
+        tried_origin = true;
+        if try_reference.is_err() {
+            // Remote branch not found, last chance: try as a commit ID
+            return (
+                None,
+                repo.find_commit(Oid::from_str(commitish).unwrap()).unwrap(),
+            );
+        }
+    }
+
+    let mut reference = try_reference.unwrap();
+    if reference.is_branch() {
+        if tried_origin {
+            panic!("[error] => local branch names with 'origin/' prefix not supported");
+        }
+        try_reference = repo.resolve_reference_from_short_name(&format!("origin/{}", commitish));
+        reference = try_reference.unwrap();
+        if reference.is_branch() {
+            panic!("[error] => local branch names with 'origin/' prefix not supported");
+        }
+    }
+
+    let commit = reference.peel_to_commit().unwrap();
+    (Some(reference), commit)
 }
 
 /// Copy generated files to target folder
@@ -112,9 +170,9 @@ pub fn copy_files(src_dir: PathBuf, target_dir: PathBuf) {
 
     if !errors.is_empty() {
         for e in errors {
-            println!("[error] Error while copying compiled file: {}", e);
+            println!("[error] => Error while copying compiled file: {}", e);
         }
-        panic!("[error] Aborted.");
+        panic!("[error] => Aborted.");
     }
 }
 


### PR DESCRIPTION
Closes #660 

* Introduces a `find_reference_or_commit()` function to deal with tags, branches and commits together.
* Cleans up some of the function names and tries to make the code more readable.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [ ] Wrote tests
* [X] Updated CHANGELOG.md
