### PR TITLE
Add MessageExt trait with blanket implementation

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -202,3 +202,18 @@ where
         Self::decode_length_delimited(v)
     }
 }
+
+/// Convenience extension to Prost's [`Message`] trait.
+///
+/// [`Message`]: https://docs.rs/prost/*/prost/trait.Message.html
+pub trait MessageExt: Message + Sized {
+    /// Attempt to encode the message directly to a `Vec<u8>`.
+    fn to_vec(&self) -> Result<Vec<u8>, Error> {
+        let mut bytes = Vec::with_capacity(self.encoded_len());
+        self.encode(&mut bytes)
+            .map_err(|e| Kind::EncodeMessage.context(e))?;
+        Ok(bytes)
+    }
+}
+
+impl<M: Message> MessageExt for M {}

--- a/proto/tests/unit.rs
+++ b/proto/tests/unit.rs
@@ -1,7 +1,8 @@
+use prost::Message;
 use std::convert::TryFrom;
 use tendermint_proto::types::BlockId as RawBlockId;
 use tendermint_proto::types::PartSetHeader as RawPartSetHeader;
-use tendermint_proto::Protobuf;
+use tendermint_proto::{MessageExt, Protobuf};
 
 impl Protobuf<RawBlockId> for BlockId {}
 
@@ -108,4 +109,13 @@ pub fn protobuf_struct_conveniences_example() {
     );
     let new_domain_type = BlockId::decode_length_delimited_vec(&wire).unwrap();
     assert_eq!(my_domain_type, new_domain_type);
+}
+
+#[test]
+pub fn message_ext_example() {
+    let wire: Vec<u8> = vec![
+        10, 12, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33,
+    ];
+    let raw_block_id: RawBlockId = Message::decode(wire.as_ref()).unwrap();
+    assert_eq!(wire, raw_block_id.to_vec().unwrap());
 }


### PR DESCRIPTION
As discussed earlier with @tony-iqlusion, this would be useful in instances where users may want to convert a Prost `Message` directly to a `Vec<u8>`.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG.md
