### PR TITLE
light-client: Only require Tokio when `rpc-client` feature is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### IMPROVEMENTS:
+
+- `[light-client]` Only require Tokio when `rpc-client` feature is enabled ([#425])
+
+[#425]: https://github.com/informalsystems/tendermint-rs/issues/425
+
 ## v0.17.0-rc3
 
 *Nov 18, 2020*

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["rpc-client"]
-rpc-client = ["tendermint-rpc/http-client"]
+rpc-client = ["tokio", "tendermint-rpc/http-client"]
 secp256k1 = ["tendermint/secp256k1", "tendermint-rpc/secp256k1"]
 
 [dependencies]
@@ -41,7 +41,7 @@ serde_derive = "1.0.106"
 sled = "0.34.3"
 static_assertions = "1.1.0"
 thiserror = "1.0.15"
-tokio = "0.2.20"
+tokio = { version = "0.2.20", optional = true }
 
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen"}


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

Close: #425

We don't need Tokio when the `rpc-client` feature is not enabled, so let's only require it when this feature is enabled.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
