### PR TITLE
Added tendermint docker config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,12 +94,11 @@ jobs:
           command: test
           args: --all-features --no-fail-fast -p tendermint-testgen
 
-  # Todo: Update the docker image version as soon as Tendermint Core v0.34 is released.
   tendermint-integration:
     runs-on: ubuntu-latest
     services:
       tendermint:
-        image: tendermint/tendermint:latest
+        image: informaldev/tendermint:0.34.0-d7d0ffea
         ports:
           - 26656:26656
           - 26657:26657
@@ -115,12 +114,11 @@ jobs:
           command: test
           args: -p tendermint --test integration --no-fail-fast -- --ignored
 
-  # Todo: Update the docker image version as soon as Tendermint Core v0.34 is released.
   tendermint-light-client-integration:
     runs-on: ubuntu-latest
     services:
       tendermint:
-        image: tendermint/tendermint:latest
+        image: informaldev/tendermint:0.34.0-d7d0ffea
         ports:
           - 26656:26656
           - 26657:26657
@@ -136,12 +134,11 @@ jobs:
           command: test
           args: -p tendermint-light-client --test integration --no-fail-fast -- --ignored
 
-  # Todo: Update the docker image version as soon as Tendermint Core v0.34 is released.
   tendermint-rpc-integration:
     runs-on: ubuntu-latest
     services:
       tendermint:
-        image: tendermint/tendermint:latest
+        image: informaldev/tendermint:0.34.0-d7d0ffea
         ports:
           - 26656:26656
           - 26657:26657

--- a/docker/tendermint-v0.34.0/.gitignore
+++ b/docker/tendermint-v0.34.0/.gitignore
@@ -1,0 +1,1 @@
+tendermint

--- a/docker/tendermint-v0.34.0/Dockerfile
+++ b/docker/tendermint-v0.34.0/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.12.1
+LABEL maintainer="hello@informal.systems"
+
+ENV TMHOME=/tendermint
+RUN apk --no-cache add jq bash && \
+    wget https://github.com/freshautomations/sconfig/releases/download/v0.1.0/sconfig_linux_amd64 \
+         -O /usr/bin/sconfig && \
+    chmod 755 /usr/bin/sconfig && \
+    addgroup tendermint && \
+    adduser -S -G tendermint tendermint -h "$TMHOME"
+USER tendermint
+WORKDIR $TMHOME
+
+EXPOSE 26656 26657 26660
+STOPSIGNAL SIGTERM
+
+ARG TENDERMINT=tendermint
+COPY $TENDERMINT /usr/bin/tendermint
+
+COPY entrypoint /usr/bin/entrypoint
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["node"]
+VOLUME [ "$TMHOME" ]

--- a/docker/tendermint-v0.34.0/entrypoint
+++ b/docker/tendermint-v0.34.0/entrypoint
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+if [ ! -d "${TMHOME}/config" ]; then
+
+	echo "Running tendermint init to create configuration."
+	/usr/bin/tendermint init
+
+  sconfig -s ${TMHOME}/config/config.toml \
+    proxy_app=${PROXY_APP:-kvstore} \
+    moniker=${MONIKER:-dockernode} \
+    consensus.timeout_commit=500ms \
+    rpc.laddr=tcp://0.0.0.0:26657 \
+    p2p.addr_book_strict=false \
+    instrumentation.prometheus=true
+
+  sconfig -s ${TMHOME}/config/genesis.json \
+    chain_id=${CHAIN_ID:-dockerchain} \
+    consensus_params.block.time_iota_ms=500
+
+fi
+
+exec /usr/bin/tendermint "$@"


### PR DESCRIPTION
Closes #702 .

Configuration to build tendermint docker images with default config. A few of these were built already with different versions of tendermint and uploaded to DockerHub here: https://hub.docker.com/repository/docker/informaldev/tendermint#

The integration tests were updated to run against a tendermint image close to "0.34.0-rc4" that was used in a previous Stargate testnet.

When upgrading Tendermint to be compatible with 034.0-rc5 (or later), we should also update these images to do proper integration testing.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
