### PR TITLE
Release tendermint-p2p crate

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -1,0 +1,19 @@
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+
+See the [repo root] for build status, license, Rust version, etc.
+
+# tendermint-p2p
+
+The Tendermint P2P stack.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/tendermint-p2p.svg
+[crate-link]: https://crates.io/crates/tendermint-p2p
+[docs-image]: https://docs.rs/tendermint-p2p/badge.svg
+[docs-link]: https://docs.rs/tendermint-p2p/
+
+[//]: # (general links)
+
+[repo root]: https://github.com/informalsystems/tendermint-rs

--- a/p2p/src/secret_connection/protocol.rs
+++ b/p2p/src/secret_connection/protocol.rs
@@ -157,7 +157,7 @@ impl Version {
                     "malformed handshake message (protocol version mismatch?): {}",
                     e
                 );
-                return Report::new(Error::ProtocolError).wrap_err(message);
+                Report::new(Error::ProtocolError).wrap_err(message)
             })
         } else {
             self.decode_auth_signature_amino(bytes)


### PR DESCRIPTION
Follows on from #715. We need a `README.md` in the crate before we can publish to crates.io.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
