### PR TITLE
Bump `k256` crate dependency to v0.6

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -57,7 +57,7 @@ tendermint-proto = { version = "0.17.0-rc3", path = "../proto" }
 toml = { version = "0.5" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
-k256 = { version = "0.5", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.6", optional = true, features = ["ecdsa"] }
 ripemd160 = { version = "0.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/elliptic-curves/pull/253