### PR TITLE
build optimizations

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+build-all = "build --workspace --all-targets --"
+build-wasm-tendermint = "build -p tendermint --manifest-path tendermint/Cargo.toml --target wasm32-unknown-unknown --release --no-default-features --"
+build-wasm-light-client = "build -p tendermint-light-client --manifest-path light-client/Cargo.toml --target wasm32-unknown-unknown --release --no-default-features --"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --workspace --all-targets
+          command: build-all
 
-  # At the time of writing `--no-default-features` does not work with the `-p` flag, hence we avoid the Cargo GitHub Action.
   light-client-wasm:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +38,9 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - name: Build Tendermint for WASM
-        run: cd tendermint && cargo build --target wasm32-unknown-unknown --release --no-default-features
-      - name: Build Light Client for WASM
-        run: cd light-client && cargo build --target wasm32-unknown-unknown --release --no-default-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build-wasm-tendermint
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build-wasm-light-client


### PR DESCRIPTION
Small step toward #723 .

Introduces a few new cargo commands so that developers and the CI can easily run the same commands.
* `cargo build-all` == `cargo build --workspace --all-targets`
* `cargo build-wasm-tendermint` == (build tendermint with the wasm32-unknown-unknown target)
* `cargo build-wasm-light-client` == (build tendermint-light-client with the wasm32-unknown-unknown target)

This is a small example of how building and testing can be simplified between the developer and the CI. Further cases will come as I research the tools mentioned in #723.

Edit: it would be nice to have a simple `cargo build-wasm` command, but currently it's not possible, because the `--no-default-features` parameter cannot run in a virtual workspace, hence we need to add the `--manifest-path` parameter to point to the specific package's `Cargo.toml` as well as the `--package` parameter (describing the crate name) to point to the package that should be built.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
