### PR TITLE
Added cargo test-all-features

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,3 +2,4 @@
 build-all = "build --workspace --all-targets --"
 build-wasm-tendermint = "build -p tendermint --manifest-path tendermint/Cargo.toml --target wasm32-unknown-unknown --release --no-default-features --"
 build-wasm-light-client = "build -p tendermint-light-client --manifest-path light-client/Cargo.toml --target wasm32-unknown-unknown --release --no-default-features --"
+test-all-features = "test --all-features --no-fail-fast"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast -p tendermint
+          command: test-all-features
+          args: -p tendermint
   tendermint-rpc:
     runs-on: ubuntu-latest
     steps:
@@ -43,8 +43,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast -p tendermint-rpc
+          command: test-all-features
+          args: -p tendermint-rpc
   tendermint-proto:
     runs-on: ubuntu-latest
     steps:
@@ -55,8 +55,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast -p tendermint-proto
+          command: test-all-features
+          args: -p tendermint-proto
   tendermint-light-client:
     runs-on: ubuntu-latest
     steps:
@@ -67,8 +67,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast -p tendermint-light-client
+          command: test-all-features
+          args: -p tendermint-light-client
   tendermint-light-node:
     runs-on: ubuntu-latest
     steps:
@@ -79,8 +79,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast -p tendermint-light-node
+          command: test-all-features
+          args: -p tendermint-light-node
   tendermint-testgen:
     runs-on: ubuntu-latest
     steps:
@@ -91,8 +91,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast -p tendermint-testgen
+          command: test-all-features
+          args: -p tendermint-testgen
 
   tendermint-integration:
     runs-on: ubuntu-latest
@@ -151,8 +151,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: -p tendermint-rpc --no-fail-fast --all-features -- --ignored
+          command: test-all-features
+          args: -p tendermint-rpc -- --ignored
 
   integration-latest:
     runs-on: ubuntu-latest
@@ -189,8 +189,7 @@ jobs:
           command: clean
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast
+          command: test-all-features
         env:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"


### PR DESCRIPTION
Another harmonization effort for #723 : Made an alias for the `cargo test --all-features --no-fail-fast` command which parameters we usually use together. Now you can run `cargo test-all-features` with the same effect.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [X] Wrote tests
* [ ] Updated CHANGELOG.md
