### PR TITLE
testgen: Compute `last_block_id` hash when generating a light chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[tendermint, light-client]` Specify the proposer in the validator set of fetched light blocks ([#705])
 - `[tendermint-proto]` (Since v0.17.0-rc3) Upgrade protobuf definitions to Tendermint Go v0.34.0 ([#737])
 - `[tendermint]` Remove `total_voting_power` parameter from `validator::Set::new` ([#739])
+- `[testgen]` Compute `last_block_id` hash when generating a `LightChain` ([#745])
 
 [#425]: https://github.com/informalsystems/tendermint-rs/issues/425
 [#646]: https://github.com/informalsystems/tendermint-rs/pull/646
@@ -22,6 +23,7 @@
 [#705]: https://github.com/informalsystems/tendermint-rs/issues/705
 [#737]: https://github.com/informalsystems/tendermint-rs/pull/737
 [#739]: https://github.com/informalsystems/tendermint-rs/issues/739
+[#745]: https://github.com/informalsystems/tendermint-rs/issues/745
 
 ## v0.17.0-rc3
 

--- a/testgen/src/light_block.rs
+++ b/testgen/src/light_block.rs
@@ -5,10 +5,10 @@ use simple_error::*;
 use crate::helpers::parse_as;
 use crate::validator::generate_validators;
 use crate::{Commit, Generator, Header, Validator};
-use tendermint::block::signed_header::SignedHeader;
 use tendermint::node::Id as PeerId;
 use tendermint::validator;
 use tendermint::validator::Set as ValidatorSet;
+use tendermint::{block::signed_header::SignedHeader, Hash};
 
 /// A light block is the core data structure used by the light client.
 /// It records everything the light client needs to know about a block.
@@ -138,6 +138,14 @@ impl LightBlock {
             .as_ref()
             .expect("chain_id is missing")
             .to_string()
+    }
+
+    /// returns the last_block_id hash of LightBlock's header
+    pub fn last_block_id_hash(&self) -> Option<Hash> {
+        self.header
+            .as_ref()
+            .expect("header is missing")
+            .last_block_id_hash
     }
 }
 

--- a/testgen/src/light_chain.rs
+++ b/testgen/src/light_chain.rs
@@ -1,12 +1,32 @@
-use crate::light_block::LightBlock;
-use tendermint::block::Height;
+use crate::{light_block::LightBlock, Generator};
+use tendermint::block::{self, Height};
 use tendermint::chain::Info;
 
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 pub struct LightChain {
     pub info: Info,
     pub light_blocks: Vec<LightBlock>,
+}
+
+impl Default for LightChain {
+    fn default() -> Self {
+        let initial_block = LightBlock::new_default(1);
+
+        let id = initial_block.chain_id().parse().unwrap();
+        let height = initial_block.height().try_into().unwrap();
+
+        let info = Info {
+            id,
+            height,
+            // no last block id for the initial block
+            last_block_id: None,
+            // TODO: Not sure yet what this time means
+            time: None,
+        };
+
+        Self::new(info, vec![initial_block])
+    }
 }
 
 impl LightChain {
@@ -17,59 +37,55 @@ impl LightChain {
     // TODO: make this fn more usable
     // TODO: like how does someone generate a chain with different validators at each height
     pub fn default_with_length(num: u64) -> Self {
-        let testgen_light_block = LightBlock::new_default(1);
-        let mut light_blocks: Vec<LightBlock> = vec![testgen_light_block.clone()];
-
-        for _i in 2..num {
-            // add "next" light block to the vector
-            light_blocks.push(testgen_light_block.next());
+        let mut light_chain = Self::default();
+        for _i in 2..=num {
+            light_chain.advance_chain();
         }
-
-        let id = light_blocks[0].chain_id().parse().unwrap();
-        let height = Height::try_from(num).expect("failed to convert from u64 to Height");
-
-        let info = Info {
-            id,
-            height,
-            // TODO: figure how to add this
-            last_block_id: None,
-            // TODO: Not sure yet what this time means
-            time: None,
-        };
-        Self::new(info, light_blocks)
+        light_chain
     }
 
     /// expects at least one LightBlock in the Chain
-    pub fn advance_chain(&mut self) -> LightBlock {
+    pub fn advance_chain(&mut self) -> &LightBlock {
         let last_light_block = self
             .light_blocks
             .last()
             .expect("Cannot find testgen light block");
 
         let new_light_block = last_light_block.next();
-        self.light_blocks.push(new_light_block.clone());
 
         self.info.height = Height::try_from(new_light_block.height())
             .expect("failed to convert from u64 to Height");
 
-        new_light_block
+        let last_block_id_hash = new_light_block
+            .header
+            .as_ref()
+            .expect("missing header in new light block")
+            .generate()
+            .expect("failed to generate header")
+            .hash();
+
+        self.info.last_block_id = Some(block::Id {
+            hash: last_block_id_hash,
+            part_set_header: Default::default(),
+        });
+
+        self.light_blocks.push(new_light_block);
+        self.light_blocks.last().unwrap() // safe because of push above
     }
 
     /// fetches a block from LightChain at a certain height
     /// it returns None if a block does not exist for the target_height
-    pub fn block(&self, target_height: u64) -> Option<LightBlock> {
+    pub fn block(&self, target_height: u64) -> Option<&LightBlock> {
         self.light_blocks
-            .clone()
-            .into_iter()
+            .iter()
             .find(|lb| lb.height() == target_height)
     }
 
     /// fetches the latest block from LightChain
-    pub fn latest_block(&self) -> LightBlock {
+    pub fn latest_block(&self) -> &LightBlock {
         self.light_blocks
             .last()
             .expect("cannot find last light block")
-            .clone()
     }
 }
 
@@ -111,5 +127,51 @@ mod tests {
         light_chain.advance_chain();
         let second_block = light_chain.latest_block();
         assert_eq!(2, second_block.height());
+    }
+
+    #[test]
+    fn test_light_chain_with_length() {
+        const CHAIN_HEIGHT: u64 = 10;
+
+        let chain = LightChain::default_with_length(CHAIN_HEIGHT);
+
+        let blocks = chain
+            .light_blocks
+            .into_iter()
+            .flat_map(|lb| lb.generate())
+            .collect::<Vec<_>>();
+
+        // we have as many blocks as the height of the chain
+        assert_eq!(blocks.len(), chain.info.height.value() as usize);
+        assert_eq!(blocks.len(), CHAIN_HEIGHT as usize);
+
+        let first_block = blocks.first().unwrap();
+        let last_block = blocks.last().unwrap();
+
+        // the first block is at height 1
+        assert_eq!(first_block.signed_header.header.height.value(), 1);
+
+        // the first block does not have a last_block_id
+        assert!(first_block.signed_header.header.last_block_id.is_none());
+
+        // the last block is at the chain height
+        assert_eq!(last_block.signed_header.header.height, chain.info.height);
+
+        for i in 1..blocks.len() {
+            let prv = &blocks[i - 1];
+            let cur = &blocks[i];
+
+            // the height of the current block is the successor of the previous block
+            assert_eq!(
+                cur.signed_header.header.height.value(),
+                prv.signed_header.header.height.value() + 1
+            );
+
+            // the last_block_id hash is equal to the previous block's hash
+            assert_eq!(
+                cur.signed_header.header.last_block_id.map(|lbi| lbi.hash),
+                Some(prv.signed_header.header.hash())
+            );
+        }
     }
 }


### PR DESCRIPTION
Close #744
Close #745

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG.md
