### PR TITLE
Bump `k256` crate dependency to v0.7

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -57,7 +57,7 @@ tendermint-proto = { version = "0.17.0-rc3", path = "../proto" }
 toml = { version = "0.5" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
-k256 = { version = "0.6", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.7", optional = true, features = ["ecdsa"] }
 ripemd160 = { version = "0.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This is a minor bugfix release that required some breaking changes in the public API.

None of the bugs impact `tendermint-rs`, but it would be nice to ensure it's using the latest version before the final v0.17 release.

Release notes: https://github.com/RustCrypto/elliptic-curves/pull/261