### PR TITLE
Add tendermint-p2p to release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ set -e
 # A space-separated list of all the crates we want to publish, in the order in
 # which they must be published. It's important to respect this order, since
 # each subsequent crate depends on one or more of the preceding ones.
-DEFAULT_CRATES="tendermint-proto tendermint tendermint-rpc tendermint-light-client tendermint-light-node tendermint-testgen"
+DEFAULT_CRATES="tendermint-proto tendermint tendermint-rpc tendermint-p2p tendermint-light-client tendermint-light-node tendermint-testgen"
 
 # Allows us to override the crates we want to publish.
 CRATES=${*:-${DEFAULT_CRATES}}


### PR DESCRIPTION
We realized that we didn't have the `tendermint-p2p` crate in our release script.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
