### PR TITLE
Example of property-based testing of the Vote structure

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -56,9 +56,13 @@ thiserror = "1"
 tendermint-proto = { version = "0.17.1", path = "../proto" }
 toml = { version = "0.5" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
+quickcheck = { version = "1.0" }
 
 k256 = { version = "0.7", optional = true, features = ["ecdsa"] }
 ripemd160 = { version = "0.9", optional = true }
+
+[dev-dependencies]
+quickcheck_macros = { version = "1.0" }
 
 [features]
 secp256k1 = ["k256", "ripemd160"]

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -17,6 +17,7 @@ use subtle_encoding::hex;
 
 #[cfg(feature = "secp256k1")]
 use crate::public_key::Secp256k1;
+use quickcheck::{Arbitrary, Gen};
 #[cfg(feature = "secp256k1")]
 use ripemd160::Ripemd160;
 use std::convert::TryFrom;
@@ -47,6 +48,16 @@ impl TryFrom<Vec<u8>> for Id {
 impl From<Id> for Vec<u8> {
     fn from(value: Id) -> Self {
         value.as_bytes().to_vec()
+    }
+}
+
+impl Arbitrary for Id {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut v = [0; LENGTH];
+        for i in 0..LENGTH {
+            v[i] = Arbitrary::arbitrary(g);
+        }
+        Self::new(v)
     }
 }
 

--- a/tendermint/src/block/height.rs
+++ b/tendermint/src/block/height.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Kind};
+use quickcheck::{Arbitrary, Gen};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryInto;
 use std::{
@@ -104,6 +105,12 @@ impl FromStr for Height {
             s.parse::<u64>()
                 .map_err(|_| Kind::Parse.context("height decode"))?,
         )
+    }
+}
+
+impl Arbitrary for Height {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self(Arbitrary::arbitrary(g))
     }
 }
 

--- a/tendermint/src/block/id.rs
+++ b/tendermint/src/block/id.rs
@@ -3,6 +3,7 @@ use crate::{
     error::{Error, Kind},
     hash::{Algorithm, Hash},
 };
+use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::{
@@ -119,6 +120,15 @@ impl From<Id> for RawCanonicalBlockId {
         RawCanonicalBlockId {
             hash: value.hash.as_bytes().to_vec(),
             part_set_header: Some(value.part_set_header.into()),
+        }
+    }
+}
+
+impl Arbitrary for Id {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self {
+            hash: Arbitrary::arbitrary(g),
+            part_set_header: Arbitrary::arbitrary(g),
         }
     }
 }

--- a/tendermint/src/block/parts.rs
+++ b/tendermint/src/block/parts.rs
@@ -4,6 +4,7 @@ use crate::hash::Algorithm;
 use crate::hash::SHA256_HASH_SIZE;
 use crate::Hash;
 use crate::{Error, Kind};
+use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use tendermint_proto::types::{
@@ -69,6 +70,15 @@ impl From<Header> for RawCanonicalPartSetHeader {
         RawCanonicalPartSetHeader {
             total: value.total,
             hash: value.hash.into(),
+        }
+    }
+}
+
+impl Arbitrary for Header {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self {
+            total: Arbitrary::arbitrary(g),
+            hash: Arbitrary::arbitrary(g),
         }
     }
 }

--- a/tendermint/src/block/round.rs
+++ b/tendermint/src/block/round.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Kind};
+use quickcheck::{Arbitrary, Gen};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryInto;
 use std::{
@@ -51,6 +52,12 @@ impl From<u16> for Round {
 impl From<u8> for Round {
     fn from(value: u8) -> Self {
         Round(value as u32)
+    }
+}
+
+impl Arbitrary for Round {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self(Arbitrary::arbitrary(g))
     }
 }
 

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -1,6 +1,7 @@
 //! Hash functions and their outputs
 
 use crate::error::{Error, Kind};
+use quickcheck::{Arbitrary, Gen};
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
@@ -50,6 +51,23 @@ impl From<Hash> for Vec<u8> {
             Hash::Sha256(s) => s.to_vec(),
             Hash::None => vec![],
         }
+    }
+}
+
+impl Arbitrary for Hash {
+    fn arbitrary(g: &mut Gen) -> Self {
+        // Todo: Test and clean up
+        //let mut arbitrary_g = Gen::new(SHA256_HASH_SIZE);
+        //if arbitrary_g.size() != SHA256_HASH_SIZE {
+        //    panic!("Redo the Hash Arbitrary trait generation with gen_range");
+        //}
+        let mut random_hash: [u8; SHA256_HASH_SIZE] = [0; SHA256_HASH_SIZE];
+        for i in 0..SHA256_HASH_SIZE {
+            random_hash[i] = Arbitrary::arbitrary(g);
+        }
+        g.choose(&[Hash::Sha256(random_hash), Hash::None])
+            .unwrap()
+            .to_owned()
     }
 }
 

--- a/tendermint/src/signature.rs
+++ b/tendermint/src/signature.rs
@@ -7,6 +7,7 @@ pub use signature::{Signer, Verifier};
 pub use k256::ecdsa::Signature as Secp256k1;
 
 use crate::{Error, Kind};
+use quickcheck::{Arbitrary, Gen};
 use std::convert::TryFrom;
 use tendermint_proto::Protobuf;
 
@@ -48,6 +49,21 @@ impl From<Signature> for Vec<u8> {
 impl Default for Signature {
     fn default() -> Self {
         Signature::None
+    }
+}
+
+impl Arbitrary for Signature {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut v = [0; ED25519_SIGNATURE_SIZE];
+        for i in 0..ED25519_SIGNATURE_SIZE {
+            v[i] = Arbitrary::arbitrary(g);
+        }
+        g.choose(&[
+            Signature::Ed25519(Ed25519Signature::new(v)),
+            Signature::None,
+        ])
+        .unwrap()
+        .to_owned()
     }
 }
 

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -5,7 +5,8 @@ use crate::error::{Error, Kind};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use std::convert::{Infallible, TryFrom};
+use quickcheck::{Arbitrary, Gen};
+use std::convert::{Infallible, TryFrom, TryInto};
 use std::fmt;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
@@ -46,6 +47,16 @@ impl From<Time> for Timestamp {
             seconds: prost_value.seconds,
             nanos: prost_value.nanos,
         }
+    }
+}
+
+impl Arbitrary for Time {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let t = Timestamp {
+            seconds: Arbitrary::arbitrary(g),
+            nanos: Arbitrary::arbitrary(g),
+        };
+        t.try_into().unwrap()
     }
 }
 

--- a/tendermint/src/vote/validator_index.rs
+++ b/tendermint/src/vote/validator_index.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Kind};
+use quickcheck::{Arbitrary, Gen};
 use std::convert::TryInto;
 use std::{
     convert::TryFrom,
@@ -59,6 +60,14 @@ impl From<ValidatorIndex> for usize {
             .value()
             .try_into()
             .expect("Integer overflow: system usize maximum smaller than i32 maximum")
+    }
+}
+
+impl Arbitrary for ValidatorIndex {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let u: u32 = Arbitrary::arbitrary(g);
+        // Todo: this should fail sometimes
+        u.try_into().unwrap()
     }
 }
 


### PR DESCRIPTION
This example shows how to test the Vote structure using `quickcheck`, the property-based testing tool.
Two properties of the Vote structure is tested:

1. Protobuf identity: All Vote structs should be encodable to a protobuf bytestream and then the same Vote struct should be decoded from the stream.
2. JSON identity: All Vote structs should be serializable as JSON structs and the same Vote struct should be deserialized from the string object.

You will see that three distinct errors are discovered by quickcheck:
1. `no timestamp` error: The Timestamp property of the struct is public and optional. A Vote struct can be created with `nil` timestamp but we do not accept protobuf streams with no Timestamp.
2. `No such local time` error: it is possible to create a Timestamp that is invalid (before the EPOCH).
3. `IntegerOverflow` error: the generation of ValidatorIndex creates bigger numbers in some cases than allowed in ValidatorIndex. ValidatorIndex should only allow being created using valid numbers.

You can see that implementing these property tests requires all involved structs to have the `Arbitrary` trait implemented. This is yet another trait that we need and we only use it in testing. Possibly we could annotate them properly so they don't end up in the release binary.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
