### PR TITLE
Property based tests of Time

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -64,3 +64,7 @@ ripemd160 = { version = "0.9", optional = true }
 
 [features]
 secp256k1 = ["k256", "ripemd160"]
+
+[dev-dependencies]
+
+proptest = "0.10.1"

--- a/tendermint/proptest-regressions/time.txt
+++ b/tendermint/proptest-regressions/time.txt
@@ -4,6 +4,5 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc df3f2e8354a952437423936d0fc0139283de652c29c1b00c4d096a8f87effe03 # shrinks to _t = 0
 cc 6bf48a103ccd51a09c319919110535dbf28d553639097516652cab3f5b1b89e5 # shrinks to time = Time(0000-01-01T01:00:00Z)
 cc 1a7792654a4240e600d8bb6ccce9d0c036e1cb3f2667af1f50bbaf993163c3af # shrinks to stamp = "0000-02-30T00:00:00-00:00"

--- a/tendermint/proptest-regressions/time.txt
+++ b/tendermint/proptest-regressions/time.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc df3f2e8354a952437423936d0fc0139283de652c29c1b00c4d096a8f87effe03 # shrinks to _t = 0
+cc 6bf48a103ccd51a09c319919110535dbf28d553639097516652cab3f5b1b89e5 # shrinks to time = Time(0000-01-01T01:00:00Z)

--- a/tendermint/proptest-regressions/time.txt
+++ b/tendermint/proptest-regressions/time.txt
@@ -4,5 +4,4 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc 6bf48a103ccd51a09c319919110535dbf28d553639097516652cab3f5b1b89e5 # shrinks to time = Time(0000-01-01T01:00:00Z)
-cc 1a7792654a4240e600d8bb6ccce9d0c036e1cb3f2667af1f50bbaf993163c3af # shrinks to stamp = "0000-02-30T00:00:00-00:00"
+cc 7dcafc2d86a88d57fde70fe8b6dfbe9359a4d470b04fcd4bf3a7b0f05c2274a0 # shrinks to time = Time(1970-01-01T00:00:01Z)

--- a/tendermint/proptest-regressions/time.txt
+++ b/tendermint/proptest-regressions/time.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc df3f2e8354a952437423936d0fc0139283de652c29c1b00c4d096a8f87effe03 # shrinks to _t = 0
 cc 6bf48a103ccd51a09c319919110535dbf28d553639097516652cab3f5b1b89e5 # shrinks to time = Time(0000-01-01T01:00:00Z)
+cc 1a7792654a4240e600d8bb6ccce9d0c036e1cb3f2667af1f50bbaf993163c3af # shrinks to stamp = "0000-02-30T00:00:00-00:00"

--- a/tendermint/proptest-regressions/time.txt
+++ b/tendermint/proptest-regressions/time.txt
@@ -5,3 +5,5 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 7dcafc2d86a88d57fde70fe8b6dfbe9359a4d470b04fcd4bf3a7b0f05c2274a0 # shrinks to time = Time(1970-01-01T00:00:01Z)
+cc 9f588cd1ad2e3715e8f3cae1b2e2738bef53f9f75c582e4e9e0f2b887328e6c2 # shrinks to time = Time(2262-04-11T23:47:17Z)
+cc 6e17ffd49bafd6f5e8ddabc01784b27eea9c5213235aaca28f78607b1906f819 # shrinks to stamp = "0000-01-01T00:00:00-00:00"

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -185,7 +185,7 @@ mod tests {
             // map the JSON `encoded_time` to back to the inital `time`.
             let encoded_time = serde_json::to_value(&time).unwrap();
             let decoded_time = serde_json::from_value(encoded_time.clone()).unwrap();
-            assert_eq!(time, decoded_time);
+            prop_assert_eq!(time, decoded_time);
         }
     }
 

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -321,7 +321,7 @@ mod tests {
             // map the JSON `encoded_time` to back to the inital `time`.
             let time: Time = datetime.into();
             let json_encoded_time = serde_json::to_value(&time).unwrap();
-            let decoded_time: Time = serde_json::from_value(json_encoded_time.clone()).unwrap();
+            let decoded_time: Time = serde_json::from_value(json_encoded_time).unwrap();
             prop_assert_eq!(time, decoded_time);
         }
 
@@ -338,7 +338,7 @@ mod tests {
             // range. Tho we do incidentally test the inversion as well.
             let time: Time = stamp.parse().unwrap();
             let json_encoded_time = serde_json::to_value(&time).unwrap();
-            let decoded_time: Time = serde_json::from_value(json_encoded_time.clone()).unwrap();
+            let decoded_time: Time = serde_json::from_value(json_encoded_time).unwrap();
             prop_assert_eq!(time, decoded_time);
         }
     }

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -327,12 +327,15 @@ mod tests {
 
         #[test]
         fn serde_of_rfc3339_timestamps_is_safe(
-            stamp in arb_rfc3339_timestamp().boxed().prop_union(particular_rfc3339_timestamps().boxed())
+            stamp in prop_oneof![
+                arb_rfc3339_timestamp(),
+                particular_rfc3339_timestamps(),
+            ]
         ) {
             // ser/de of rfc3339 timestamps is safe if it never panics.
             // This differes from the the inverse test in that we are testing on
             // arbitrarily generated textual timestamps, rather than times in a
-            // range.
+            // range. Tho we do incidentally test the inversion as well.
             let time: Time = stamp.parse().unwrap();
             let json_encoded_time = serde_json::to_value(&time).unwrap();
             let decoded_time: Time = serde_json::from_value(json_encoded_time.clone()).unwrap();


### PR DESCRIPTION
This is an initial effort towards adding an extensible foundation for PBT, as per #303.

The main intents of this contribution are:

- Evaluate whether PBT will add value to our test harness.
- Begin to establish a library of combinators for generating elementary arbitrary values (it is no accident that we begin with a combinators for time).

## Summary

- Add generators for arbitrary RFC3339 timestamps (as strings) and `DateTime<Utc>` structs (including within a specified range). These will be generally useful in PBT tests, any time we need to construct objects that contain time structs or timestamps. In a followup, I expect these strategies will be moved into their own library that can be used in different tests, which will considerably reduce the the amount of code in the test here. So the amount of code added to support this test is not particular to this alone, but is an investment in PBT more generally (I also expect generation of times will be one of the more involved constructions).
- Fixed the conversion `From` for `Time` to `SystemTime` to prevent panics on older dates. See  f19a6b1 for details.
 
 ---

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG.md
