### PR TITLE
Minor fix doc for tests breaking nightly build

### DIFF
--- a/pbt-gen/src/time.rs
+++ b/pbt-gen/src/time.rs
@@ -15,7 +15,7 @@ pub const MAX_NANO_SECS: u32 = 999_999_999u32;
 /// See <https://github.com/chronotope/chrono/issues/537>.
 ///
 /// ```
-/// use pbt_gen;
+/// use tendermint_pbt_gen as pbt_gen;
 ///
 /// assert_eq!(pbt_gen::time::min_time().to_string(), "1653-02-10 06:13:21 UTC".to_string());
 /// ```
@@ -29,7 +29,7 @@ pub fn min_time() -> DateTime<Utc> {
 /// See <https://github.com/chronotope/chrono/issues/537>.
 ///
 /// ```
-/// use pbt_gen;
+/// use tendermint_pbt_gen as pbt_gen;
 ///
 /// assert_eq!(pbt_gen::time::max_time().to_string(), "5138-11-16 09:46:39 UTC".to_string());
 /// ```
@@ -62,7 +62,7 @@ prop_compose! {
     ///
     /// ```
     /// use chrono::{TimeZone, Utc};
-    /// use pbt_gen;
+    /// use tendermint_pbt_gen as pbt_gen;
     /// use proptest::prelude::*;
     ///
     /// proptest!{


### PR DESCRIPTION
Just a minor thing that seems to have come up that's breaking nightly. See [here](https://github.com/informalsystems/tendermint-rs/pull/837/checks?check_run_id=2193285587).

Not sure if there's a way around this in doc tests?

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
