### PR TITLE
Fix clippy errors/warnings when upgrading to Rust 1.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### BREAKING CHANGES
 
+* `[tendermint]` The `tendermint::block::CommitSig` enum's members have been
+  renamed to be consistent with Rust's naming conventions (e.g.
+  `BlockIDFlagAbsent` is now renamed to `BlockIdFlagAbsent`).
 * `[tendermint-rpc]` The `SubscriptionClient` trait now requires a `close`
   method, since it assumes that subscription clients will, in general, use
   long-running connections. This should not, however, break any downstream
@@ -11,6 +14,10 @@
   hopefully have minimal impact on projects using the code, but it might
   require some minor code changes in some cases - see the crate docs for more
   details ([#820])
+* `[tendermint-rpc]` The `event::EventData::GenericJSONEvent` member has been
+  renamed to `event::EventData::GenericJsonEvent`.
+* `[tendermint-testgen]` The `TMLightBlock` data structure has been renamed to
+  `TmLightBlock` to be consistent with Rust's naming conventions.
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### BREAKING CHANGES
 
 * `[tendermint]` The `tendermint::block::CommitSig` enum's members have been
-  renamed to be consistent with Rust's naming conventions (e.g.
-  `BlockIDFlagAbsent` is now renamed to `BlockIdFlagAbsent`).
+  renamed to be consistent with Rust's naming conventions. For example,
+  `BlockIDFlagAbsent` is now renamed to `BlockIdFlagAbsent` ([#839])
 * `[tendermint-rpc]` The `SubscriptionClient` trait now requires a `close`
   method, since it assumes that subscription clients will, in general, use
   long-running connections. This should not, however, break any downstream
@@ -15,9 +15,9 @@
   require some minor code changes in some cases - see the crate docs for more
   details ([#820])
 * `[tendermint-rpc]` The `event::EventData::GenericJSONEvent` member has been
-  renamed to `event::EventData::GenericJsonEvent`.
+  renamed to `event::EventData::GenericJsonEvent` ([#839])
 * `[tendermint-testgen]` The `TMLightBlock` data structure has been renamed to
-  `TmLightBlock` to be consistent with Rust's naming conventions.
+  `TmLightBlock` to be consistent with Rust's naming conventions ([#839])
 
 ### FEATURES
 
@@ -38,6 +38,7 @@
 [#794]: https://github.com/informalsystems/tendermint-rs/pull/794
 [#812]: https://github.com/informalsystems/tendermint-rs/pull/812
 [#820]: https://github.com/informalsystems/tendermint-rs/pull/820
+[#839]: https://github.com/informalsystems/tendermint-rs/pull/839
 
 ## v0.18.1
 

--- a/light-client/src/operations/commit_validator.rs
+++ b/light-client/src/operations/commit_validator.rs
@@ -89,11 +89,11 @@ impl CommitValidator for ProdCommitValidator {
     ) -> Result<(), VerificationError> {
         for commit_sig in signed_header.commit.signatures.iter() {
             let validator_address = match commit_sig {
-                CommitSig::BlockIDFlagAbsent => continue,
-                CommitSig::BlockIDFlagCommit {
+                CommitSig::BlockIdFlagAbsent => continue,
+                CommitSig::BlockIdFlagCommit {
                     validator_address, ..
                 } => validator_address,
-                CommitSig::BlockIDFlagNil {
+                CommitSig::BlockIdFlagNil {
                     validator_address, ..
                 } => validator_address,
             };

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -190,7 +190,7 @@ fn non_absent_vote(
     commit: &Commit,
 ) -> Option<Vote> {
     let (validator_address, timestamp, signature, block_id) = match commit_sig {
-        CommitSig::BlockIDFlagAbsent { .. } => return None,
+        CommitSig::BlockIdFlagAbsent { .. } => return None,
         CommitSig::BlockIdFlagCommit {
             validator_address,
             timestamp,

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -191,7 +191,7 @@ fn non_absent_vote(
 ) -> Option<Vote> {
     let (validator_address, timestamp, signature, block_id) = match commit_sig {
         CommitSig::BlockIDFlagAbsent { .. } => return None,
-        CommitSig::BlockIDFlagCommit {
+        CommitSig::BlockIdFlagCommit {
             validator_address,
             timestamp,
             signature,
@@ -201,7 +201,7 @@ fn non_absent_vote(
             signature,
             Some(commit.block_id),
         ),
-        CommitSig::BlockIDFlagNil {
+        CommitSig::BlockIdFlagNil {
             validator_address,
             timestamp,
             signature,

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -302,7 +302,7 @@ mod tests {
     use tendermint::Time;
 
     use tendermint_testgen::{
-        light_block::{LightBlock as TestgenLightBlock, TMLightBlock},
+        light_block::{LightBlock as TestgenLightBlock, TmLightBlock},
         Commit, Generator, Header, Validator, ValidatorSet,
     };
 
@@ -315,8 +315,8 @@ mod tests {
     use tendermint::block::CommitSig;
     use tendermint::validator::Set;
 
-    impl From<TMLightBlock> for LightBlock {
-        fn from(lb: TMLightBlock) -> Self {
+    impl From<TmLightBlock> for LightBlock {
+        fn from(lb: TmLightBlock) -> Self {
             LightBlock {
                 signed_header: lb.signed_header,
                 validators: lb.validators,

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(result_err.err().unwrap(), error);
 
         // 4. commit.BlockIdFlagAbsent - should be "Ok"
-        bad_sigs.push(CommitSig::BlockIDFlagAbsent);
+        bad_sigs.push(CommitSig::BlockIdFlagAbsent);
         signed_header.commit.signatures = bad_sigs;
         result_ok = vp.valid_commit(&signed_header, &val_set, &commit_validator);
         assert!(result_ok.is_ok());

--- a/light-client/src/store/sled.rs
+++ b/light-client/src/store/sled.rs
@@ -97,7 +97,7 @@ impl LightStore for SledStore {
 mod tests {
     use super::*;
     use tempdir::TempDir;
-    use tendermint_testgen::{light_block::TMLightBlock as TGLightBlock, Generator, LightChain};
+    use tendermint_testgen::{light_block::TmLightBlock as TGLightBlock, Generator, LightChain};
 
     #[test]
     fn highest_returns_latest_block() {

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -177,8 +177,7 @@ impl Supervisor {
     /// Return latest trusted status summary.
     fn latest_status(&mut self) -> LatestStatus {
         let latest_trusted = self.peers.primary().latest_trusted();
-        let mut connected_nodes: Vec<PeerId> = Vec::new();
-        connected_nodes.push(self.peers.primary_id());
+        let mut connected_nodes = vec![self.peers.primary_id()];
         connected_nodes.append(&mut self.peers.witnesses_ids().iter().copied().collect());
 
         match latest_trusted {

--- a/light-client/tests/backward.rs
+++ b/light-client/tests/backward.rs
@@ -20,7 +20,7 @@ use tendermint_light_client::{
 };
 
 use tendermint_testgen::{
-    light_block::{default_peer_id, TMLightBlock as TGLightBlock},
+    light_block::{default_peer_id, TmLightBlock as TGLightBlock},
     Generator, LightChain,
 };
 

--- a/light-client/tests/model_based.rs
+++ b/light-client/tests/model_based.rs
@@ -14,11 +14,11 @@ use tendermint_light_client::{
 };
 use tendermint_testgen::light_block::default_peer_id;
 use tendermint_testgen::{
-    apalache::*, jsonatr::*, light_block::TMLightBlock, validator::generate_validators, Command,
+    apalache::*, jsonatr::*, light_block::TmLightBlock, validator::generate_validators, Command,
     Generator, LightBlock as TestgenLightBlock, TestEnv, Tester, Validator, Vote,
 };
 
-fn testgen_to_lb(tm_lb: TMLightBlock) -> LightBlock {
+fn testgen_to_lb(tm_lb: TmLightBlock) -> LightBlock {
     LightBlock {
         signed_header: tm_lb.signed_header,
         validators: tm_lb.validators,

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -254,7 +254,7 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
         chunk: &[u8],
         sealed_frame: &mut [u8; TAG_SIZE + TOTAL_FRAME_SIZE],
     ) -> Result<()> {
-        debug_assert!(chunk.len() > 0, "chunk is empty");
+        debug_assert!(!chunk.is_empty(), "chunk is empty");
         debug_assert!(
             chunk.len() <= TOTAL_FRAME_SIZE - DATA_LEN_SIZE,
             "chunk is too big: {}! max: {}",
@@ -375,7 +375,7 @@ where
     // CONTRACT: data smaller than DATA_MAX_SIZE is read atomically.
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let mut n = 0usize;
-        let mut data_copy = &data[..];
+        let mut data_copy = data;
         while !data_copy.is_empty() {
             let chunk: &[u8];
             if DATA_MAX_SIZE < data.len() {
@@ -510,8 +510,6 @@ mod tests {
 #[cfg(test)]
 mod test {
     use std::thread;
-
-    use pipe;
 
     use super::*;
 

--- a/p2p/src/secret_connection/protocol.rs
+++ b/p2p/src/secret_connection/protocol.rs
@@ -66,9 +66,7 @@ impl Version {
             //
             // Note: this is not regular protobuf encoding but raw length prefixed amino encoding;
             // amino prefixes with the total length, and the raw bytes array's length, too:
-            let mut buf = Vec::new();
-            buf.push(PUBLIC_KEY_SIZE as u8 + 1);
-            buf.push(PUBLIC_KEY_SIZE as u8);
+            let mut buf = vec![PUBLIC_KEY_SIZE as u8 + 1, PUBLIC_KEY_SIZE as u8];
             buf.extend_from_slice(eph_pubkey.as_bytes());
             buf
         }

--- a/rpc/src/event.rs
+++ b/rpc/src/event.rs
@@ -54,7 +54,7 @@ pub enum EventData {
         #[serde(rename = "TxResult")]
         tx_result: TxInfo,
     },
-    GenericJSONEvent(serde_json::Value),
+    GenericJsonEvent(serde_json::Value),
 }
 
 /// Transaction result info.

--- a/tendermint/src/abci/gas.rs
+++ b/tendermint/src/abci/gas.rs
@@ -51,8 +51,8 @@ impl FromStr for Gas {
 
 impl<'de> Deserialize<'de> for Gas {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))?)
+        Self::from_str(&String::deserialize(deserializer)?)
+            .map_err(|e| D::Error::custom(format!("{}", e)))
     }
 }
 

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -120,7 +120,7 @@ impl FromStr for Id {
             .or_else(|_| hex::decode(s))
             .map_err(|_| Kind::Parse.context("account id decode"))?;
 
-        Ok(bytes.try_into()?)
+        bytes.try_into()
     }
 }
 

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -12,9 +12,9 @@ use tendermint_proto::types::CommitSig as RawCommitSig;
 #[derive(Clone, Debug, PartialEq)]
 pub enum CommitSig {
     /// no vote was received from a validator.
-    BlockIDFlagAbsent,
+    BlockIdFlagAbsent,
     /// voted for the Commit.BlockID.
-    BlockIDFlagCommit {
+    BlockIdFlagCommit {
         /// Validator address
         validator_address: account::Id,
         /// Timestamp of vote
@@ -23,7 +23,7 @@ pub enum CommitSig {
         signature: Signature,
     },
     /// voted for nil.
-    BlockIDFlagNil {
+    BlockIdFlagNil {
         /// Validator address
         validator_address: account::Id,
         /// Timestamp of vote
@@ -37,10 +37,10 @@ impl CommitSig {
     /// Get the address of this validator if a vote was received.
     pub fn validator_address(&self) -> Option<account::Id> {
         match self {
-            Self::BlockIDFlagCommit {
+            Self::BlockIdFlagCommit {
                 validator_address, ..
             } => Some(*validator_address),
-            Self::BlockIDFlagNil {
+            Self::BlockIdFlagNil {
                 validator_address, ..
             } => Some(*validator_address),
             _ => None,
@@ -49,17 +49,17 @@ impl CommitSig {
 
     /// Whether this signature is absent (no vote was received from validator)
     pub fn is_absent(&self) -> bool {
-        self == &Self::BlockIDFlagAbsent
+        self == &Self::BlockIdFlagAbsent
     }
 
     /// Whether this signature is a commit  (validator voted for the Commit.BlockId)
     pub fn is_commit(&self) -> bool {
-        matches!(self, Self::BlockIDFlagCommit { .. })
+        matches!(self, Self::BlockIdFlagCommit { .. })
     }
 
     /// Whether this signature is nil (validator voted for nil)
     pub fn is_nil(&self) -> bool {
-        matches!(self, Self::BlockIDFlagNil { .. })
+        matches!(self, Self::BlockIdFlagNil { .. })
     }
 }
 
@@ -82,7 +82,7 @@ impl TryFrom<RawCommitSig> for CommitSig {
             if !value.signature.is_empty() {
                 return Err(Kind::InvalidSignature.into());
             }
-            return Ok(CommitSig::BlockIDFlagAbsent);
+            return Ok(CommitSig::BlockIdFlagAbsent);
         }
         if value.block_id_flag == BlockIdFlag::Commit.to_i32().unwrap() {
             if value.signature.is_empty() {
@@ -93,7 +93,7 @@ impl TryFrom<RawCommitSig> for CommitSig {
             if value.validator_address.is_empty() {
                 return Err(Kind::InvalidValidatorAddress.into());
             }
-            return Ok(CommitSig::BlockIDFlagCommit {
+            return Ok(CommitSig::BlockIdFlagCommit {
                 validator_address: value.validator_address.try_into()?,
                 timestamp: value.timestamp.ok_or(Kind::NoTimestamp)?.try_into()?,
                 signature: value.signature.try_into()?,
@@ -108,7 +108,7 @@ impl TryFrom<RawCommitSig> for CommitSig {
             if value.validator_address.is_empty() {
                 return Err(Kind::InvalidValidatorAddress.into());
             }
-            return Ok(CommitSig::BlockIDFlagNil {
+            return Ok(CommitSig::BlockIdFlagNil {
                 validator_address: value.validator_address.try_into()?,
                 timestamp: value.timestamp.ok_or(Kind::NoTimestamp)?.try_into()?,
                 signature: value.signature.try_into()?,
@@ -121,13 +121,13 @@ impl TryFrom<RawCommitSig> for CommitSig {
 impl From<CommitSig> for RawCommitSig {
     fn from(commit: CommitSig) -> RawCommitSig {
         match commit {
-            CommitSig::BlockIDFlagAbsent => RawCommitSig {
+            CommitSig::BlockIdFlagAbsent => RawCommitSig {
                 block_id_flag: BlockIdFlag::Absent.to_i32().unwrap(),
                 validator_address: Vec::new(),
                 timestamp: None,
                 signature: Vec::new(),
             },
-            CommitSig::BlockIDFlagNil {
+            CommitSig::BlockIdFlagNil {
                 validator_address,
                 timestamp,
                 signature,
@@ -137,7 +137,7 @@ impl From<CommitSig> for RawCommitSig {
                 timestamp: Some(timestamp.into()),
                 signature: signature.into(),
             },
-            CommitSig::BlockIDFlagCommit {
+            CommitSig::BlockIdFlagCommit {
                 validator_address,
                 timestamp,
                 signature,

--- a/tendermint/src/block/header.rs
+++ b/tendermint/src/block/header.rs
@@ -166,31 +166,28 @@ impl Header {
         // https://github.com/tendermint/tendermint/blob/134fe2896275bb926b49743c1e25493f6b24cc31/types/block.go#L393
         // https://github.com/tendermint/tendermint/blob/134fe2896275bb926b49743c1e25493f6b24cc31/types/encoding_helper.go#L9:6
 
-        let mut fields_bytes: Vec<Vec<u8>> = Vec::with_capacity(14);
-        fields_bytes.push(self.version.encode_vec().unwrap());
-        fields_bytes.push(self.chain_id.encode_vec().unwrap());
-        fields_bytes.push(self.height.encode_vec().unwrap());
-        fields_bytes.push(self.time.encode_vec().unwrap());
-        fields_bytes.push(self.last_block_id.unwrap_or_default().encode_vec().unwrap());
-        fields_bytes.push(
+        let fields_bytes = vec![
+            self.version.encode_vec().unwrap(),
+            self.chain_id.encode_vec().unwrap(),
+            self.height.encode_vec().unwrap(),
+            self.time.encode_vec().unwrap(),
+            self.last_block_id.unwrap_or_default().encode_vec().unwrap(),
             self.last_commit_hash
                 .unwrap_or_default()
                 .encode_vec()
                 .unwrap(),
-        );
-        fields_bytes.push(self.data_hash.unwrap_or_default().encode_vec().unwrap());
-        fields_bytes.push(self.validators_hash.encode_vec().unwrap());
-        fields_bytes.push(self.next_validators_hash.encode_vec().unwrap());
-        fields_bytes.push(self.consensus_hash.encode_vec().unwrap());
-        fields_bytes.push(self.app_hash.encode_vec().unwrap());
-        fields_bytes.push(
+            self.data_hash.unwrap_or_default().encode_vec().unwrap(),
+            self.validators_hash.encode_vec().unwrap(),
+            self.next_validators_hash.encode_vec().unwrap(),
+            self.consensus_hash.encode_vec().unwrap(),
+            self.app_hash.encode_vec().unwrap(),
             self.last_results_hash
                 .unwrap_or_default()
                 .encode_vec()
                 .unwrap(),
-        );
-        fields_bytes.push(self.evidence_hash.unwrap_or_default().encode_vec().unwrap());
-        fields_bytes.push(self.proposer_address.encode_vec().unwrap());
+            self.evidence_hash.unwrap_or_default().encode_vec().unwrap(),
+            self.proposer_address.encode_vec().unwrap(),
+        ];
 
         Hash::Sha256(simple_hash_from_byte_vectors(fields_bytes))
     }

--- a/tendermint/src/block/height.rs
+++ b/tendermint/src/block/height.rs
@@ -109,8 +109,8 @@ impl FromStr for Height {
 
 impl<'de> Deserialize<'de> for Height {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))?)
+        Self::from_str(&String::deserialize(deserializer)?)
+            .map_err(|e| D::Error::custom(format!("{}", e)))
     }
 }
 

--- a/tendermint/src/block/round.rs
+++ b/tendermint/src/block/round.rs
@@ -97,8 +97,8 @@ impl FromStr for Round {
 
 impl<'de> Deserialize<'de> for Round {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))?)
+        Self::from_str(&String::deserialize(deserializer)?)
+            .map_err(|e| D::Error::custom(format!("{}", e)))
     }
 }
 

--- a/tendermint/src/config.rs
+++ b/tendermint/src/config.rs
@@ -221,7 +221,7 @@ impl fmt::Display for LogLevel {
 impl<'de> Deserialize<'de> for LogLevel {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let levels = String::deserialize(deserializer)?;
-        Ok(Self::from_str(&levels).map_err(|e| D::Error::custom(format!("{}", e)))?)
+        Self::from_str(&levels).map_err(|e| D::Error::custom(format!("{}", e)))
     }
 }
 

--- a/tendermint/src/genesis.rs
+++ b/tendermint/src/genesis.rs
@@ -40,9 +40,9 @@ where
     let value_string = String::deserialize(deserializer)?;
     let value_datetime = DateTime::parse_from_rfc3339(value_string.as_str())
         .map_err(|e| D::Error::custom(format!("{}", e)))?;
-    Ok(Time::try_from(Timestamp {
+    Time::try_from(Timestamp {
         seconds: value_datetime.timestamp(),
         nanos: value_datetime.timestamp_subsec_nanos() as i32,
     })
-    .map_err(|e| D::Error::custom(format!("{}", e)))?)
+    .map_err(|e| D::Error::custom(format!("{}", e)))
 }

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -325,7 +325,7 @@ pub struct Update {
 /// then convert to `tendermint::PublicKey` in `deserialize_public_key` below.
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
-enum PK {
+enum Pk {
     /// Ed25519 keys
     #[serde(rename = "ed25519")]
     Ed25519(String),
@@ -335,8 +335,8 @@ fn deserialize_public_key<'de, D>(deserializer: D) -> Result<PublicKey, D::Error
 where
     D: Deserializer<'de>,
 {
-    match &PK::deserialize(deserializer)? {
-        PK::Ed25519(base64_value) => {
+    match &Pk::deserialize(deserializer)? {
+        Pk::Ed25519(base64_value) => {
             let bytes =
                 base64::decode(base64_value).map_err(|e| D::Error::custom(format!("{}", e)))?;
 

--- a/testgen/src/commit.rs
+++ b/testgen/src/commit.rs
@@ -129,13 +129,13 @@ impl Generator<block::Commit> for Commit {
         let vote_to_sig = |v: &Vote| -> Result<block::CommitSig, SimpleError> {
             let vote = v.generate()?;
             if vote.block_id == None {
-                Ok(block::CommitSig::BlockIDFlagNil {
+                Ok(block::CommitSig::BlockIdFlagNil {
                     validator_address: vote.validator_address,
                     timestamp: vote.timestamp.unwrap(),
                     signature: vote.signature,
                 })
             } else {
-                Ok(block::CommitSig::BlockIDFlagCommit {
+                Ok(block::CommitSig::BlockIdFlagCommit {
                     validator_address: vote.validator_address,
                     timestamp: vote.timestamp.unwrap(),
                     signature: vote.signature,
@@ -148,7 +148,7 @@ impl Generator<block::Commit> for Commit {
                 .find(|&vote| vote.validator.as_ref().unwrap() == val);
             match vote {
                 Some(vote) => vote_to_sig(vote),
-                None => Ok(block::CommitSig::BlockIDFlagAbsent),
+                None => Ok(block::CommitSig::BlockIdFlagAbsent),
             }
         };
         let sigs = all_vals
@@ -204,7 +204,7 @@ mod tests {
 
         for (i, sig) in block_commit.signatures.iter().enumerate() {
             match sig {
-                block::CommitSig::BlockIDFlagCommit {
+                block::CommitSig::BlockIdFlagCommit {
                     validator_address: _,
                     timestamp: _,
                     signature,

--- a/testgen/src/light_block.rs
+++ b/testgen/src/light_block.rs
@@ -17,11 +17,12 @@ use tendermint::{block::signed_header::SignedHeader, Hash};
 /// Cf. <https://github.com/informalsystems/tendermint-rs/issues/605>
 /// TODO: fix redundant code without introducing cyclic dependency.
 ///
-/// To convert `TMLightBlock` to the Domain type `LightBlock` used in light-client crate
+/// To convert `TmLightBlock` to the Domain type `LightBlock` used in light-client crate
 /// You'll need to implement the `From` trait like below:
 ///
-/// impl From<TMLightBlock> for LightBlock {
-///     fn from(tm_lb: TMLightBlock) -> Self {
+/// ```rust,ignore
+/// impl From<TmLightBlock> for LightBlock {
+///     fn from(tm_lb: TmLightBlock) -> Self {
 ///         Self {
 ///             signed_header: tm_lb.signed_header,
 ///             validators: tm_lb.validators,
@@ -30,8 +31,9 @@ use tendermint::{block::signed_header::SignedHeader, Hash};
 ///         }
 ///     }
 /// }
+/// ```
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct TMLightBlock {
+pub struct TmLightBlock {
     /// Header and commit of this block
     pub signed_header: SignedHeader,
     /// Validator set at the block height
@@ -161,7 +163,7 @@ impl std::str::FromStr for LightBlock {
     }
 }
 
-impl Generator<TMLightBlock> for LightBlock {
+impl Generator<TmLightBlock> for LightBlock {
     fn merge_with_default(self, default: Self) -> Self {
         Self {
             header: self.header.or(default.header),
@@ -172,7 +174,7 @@ impl Generator<TMLightBlock> for LightBlock {
         }
     }
 
-    fn generate(&self) -> Result<TMLightBlock, SimpleError> {
+    fn generate(&self) -> Result<TmLightBlock, SimpleError> {
         let header = match &self.header {
             None => bail!("header is missing"),
             Some(h) => h,
@@ -204,7 +206,7 @@ impl Generator<TMLightBlock> for LightBlock {
             None => default_peer_id(),
         };
 
-        let light_block = TMLightBlock {
+        let light_block = TmLightBlock {
             signed_header,
             validators,
             next_validators,
@@ -215,7 +217,7 @@ impl Generator<TMLightBlock> for LightBlock {
     }
 }
 
-/// A helper function to generate SignedHeader used by TMLightBlock
+/// A helper function to generate SignedHeader used by TmLightBlock
 pub fn generate_signed_header(
     raw_header: &Header,
     raw_commit: &Commit,

--- a/testgen/src/validator.rs
+++ b/testgen/src/validator.rs
@@ -119,11 +119,10 @@ impl Generator<validator::Info> for Validator {
 
 /// A helper function to generate multiple validators at once.
 pub fn generate_validators(vals: &[Validator]) -> Result<Vec<validator::Info>, SimpleError> {
-    let sorted = sort_validators(vals);
-    Ok(sorted
+    sort_validators(vals)
         .iter()
         .map(|v| v.generate())
-        .collect::<Result<Vec<validator::Info>, SimpleError>>()?)
+        .collect::<Result<Vec<validator::Info>, SimpleError>>()
 }
 
 /// A helper function to sort validators according to the Tendermint specs.


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

Rust's [1.51 release](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html) brought with it a number of new clippy errors and warnings. This PR attempts to address the bulk of them.

Unfortunately this results in some breaking changes to data structures' names, because they were improperly named up to now according to Rust's API guidelines.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
