### PR TITLE
Source-based coverage

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,6 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-output-type: lcov
-output-file: ./lcov.info
-prefix-dir: /home/user/build/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,14 +153,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: nightly
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clean
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
+      - run: cargo test --lib -p tendermint-abci -p tendermint-light-client -p tendermint-light-node -p tendermint-p2p -p tendermint-proto -p tendermint-rpc -p tendermint -p tendermint-testgen -p tendermint-pbt-gen --all-features
         env:
           RUSTFLAGS: '-Zinstrument-coverage'
       - name: Install grcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,9 @@ jobs:
           profile: minimal
           toolchain: nightly-2021-03-25
           override: true
-      - run: cargo test --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test-all-features
         env:
           RUSTFLAGS: '-Zinstrument-coverage'
           LLVM_PROFILE_FILE: '%m.profraw'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-03-25
           override: true
       - run: cargo test --all-features
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
           curl -L https://github.com/mozilla/grcov/releases/download/v0.6.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
       - name: Run grcov
         run: |
-          ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --ignore-not-existing
+          ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --branch --ignore-not-existing
       - name: Upload to Codecov
         run: |
           bash <(curl -s https://codecov.io/bash) -f ./lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           command: test-all-features
           args: --manifest-path tools/kvstore-test/Cargo.toml
+        timeout-minutes: 30
 
   nightly-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2020-12-10
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -162,13 +162,14 @@ jobs:
         with:
           command: test-all-features
         env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"
-      - uses: actions-rs/grcov@v0.1
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ steps.coverage.outputs.report }}
-          yml: ./codecov.yml
-          fail_ci_if_error: true
+          RUSTFLAGS: '-Zinstrument-coverage'
+      - name: Install grcov
+        run: |
+          rustup component add llvm-tools-preview
+          curl -L https://github.com/mozilla/grcov/releases/download/v0.7.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      - name: Run grcov
+        run: |
+          ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --ignore-not-existing
+      - name: Upload to Codecov
+        run: |
+          bash <(curl -s https://codecov.io/bash) -f ./lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - run: cargo test --lib -p tendermint-abci -p tendermint-light-client -p tendermint-light-node -p tendermint-p2p -p tendermint-proto -p tendermint-rpc -p tendermint -p tendermint-testgen -p tendermint-pbt-gen --all-features
+      - run: cargo test --lib --all-features
         env:
           RUSTFLAGS: '-Zinstrument-coverage'
       - name: Install grcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - run: cargo test --lib --all-features
+      - run: cargo test --all-features
         env:
           RUSTFLAGS: '-Zinstrument-coverage'
       - name: Install grcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,6 +159,7 @@ jobs:
       - run: cargo test --all-features
         env:
           RUSTFLAGS: '-Zinstrument-coverage'
+          LLVM_PROFILE_FILE: '%m.profraw'
       - name: Install grcov
         run: |
           rustup component add llvm-tools-preview

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-12-10
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Install grcov
         run: |
           rustup component add llvm-tools-preview
-          curl -L https://github.com/mozilla/grcov/releases/download/v0.7.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
+          curl -L https://github.com/mozilla/grcov/releases/download/v0.6.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
       - name: Run grcov
         run: |
           ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --ignore-not-existing


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

With this PR, we start tracking coverage using LLVM's source-based coverage: https://blog.rust-lang.org/inside-rust/2020/11/12/source-based-code-coverage.html

- pin nightly version to avoid spurious errors (it's unlikely we need to bump this often, unless we need new compiler features)
- pin grcov version to avoid https://github.com/mozilla/grcov/issues/555
- set `LLVM_PROFILE_FILE="%m.profraw"` to avoid overwrites of coverage data (which occur when several test binaries are run for the same crate): https://github.com/rust-lang/rust/issues/79899
  - maybe the 30% coverage decreases (https://github.com/informalsystems/tendermint-rs/pull/839#issuecomment-807115109 and https://github.com/informalsystems/tendermint-rs/issues/252#issuecomment-805623519) are due to something like this

With this, coverage is at 67.7%, which seems to be an all-time high 😄 

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
