### PR TITLE
Remove kvstore-integration-latest test from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,28 +125,6 @@ jobs:
         env:
           RUST_LOG: debug
 
-  kvstore-integration-latest:
-    runs-on: ubuntu-latest
-    services:
-      tendermint:
-        image: tendermint/tendermint:latest
-        ports:
-          - 26656:26656
-          - 26657:26657
-          - 26660:26660
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        # Don't fail CI due to integration failures on unstable/unreleased versions
-        continue-on-error: true
-        with:
-          command: test-all-features
-          args: --manifest-path tools/kvstore-test/Cargo.toml
-
   nightly-coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #843 

The test's still most likely going to be valuable, but just not on each PR necessarily.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
