### PR TITLE
Fix scheduled audit job in CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,8 +4,8 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
-    schedule:
-      - cron: "0 0 * * *"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   security_audit:


### PR DESCRIPTION
It appears as though the indentation of the scheduling config was off by one level, causing GitHub Actions to ignore it.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
