### PR TITLE
Bump `k256` crate dependency to v0.8

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -39,8 +39,6 @@ bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 ed25519 = "1"
 ed25519-dalek = { version = "1", features = ["serde"] }
-# TODO(thane): Remove once https://github.com/myrrlyn/funty/issues/3 is fixed
-funty = "=1.1.0"
 futures = "0.3"
 num-traits = "0.2"
 once_cell = "1.3"
@@ -60,7 +58,7 @@ toml = { version = "0.5" }
 url = { version = "2.2" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
-k256 = { version = "0.7", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.8", optional = true, features = ["ecdsa"] }
 ripemd160 = { version = "0.9", optional = true }
 
 [features]


### PR DESCRIPTION
Bumps `k256` to the latest release.

It seems like some refactoring of the public keys might be in order at this point, but I decided to start with a simple version bump.

I could also potentially add NIST P-256 support with the `p256` crate too.