### PR TITLE
Update the TLA specs used in MBT with the current Apalache type annotations

### DIFF
--- a/light-client/tests/support/model_based/Blockchain_003_draft.tla
+++ b/light-client/tests/support/model_based/Blockchain_003_draft.tla
@@ -10,6 +10,11 @@ EXTENDS Integers, FiniteSets
 
 Min(a, b) == IF a < b THEN a ELSE b
 
+\* @typeAlias: BLOCKHEADER = [hight: Int, time: Int, lastCommit: Set(Str), VS: Set(Str), NextVS: Set(Str)];
+\* @typeAlias: BLOCKCHAIN = Int -> BLOCKHEADER;
+\* @typeAlias: BLOCK = [header: BLOCKHEADER, Commits: Set(Str)];
+BCTypeAliases == TRUE
+
 CONSTANT
   (* @type: Set(Str);
      A set of all nodes that can act as validators (correct and faulty). *)
@@ -26,7 +31,7 @@ Heights == 1..ULTIMATE_HEIGHT   (* possible heights *)
 (* A commit is just a set of nodes who have committed the block *)
 Commits == SUBSET AllNodes
 
-(* @typeAlias: BLOCKHEADER = [hight: Int, time: Int, lastCommit: Set(Str), VS: Set(Str), NextVS: Set(Str)];
+(* 
    The set of all block headers that can be on the blockchain.
    This is a simplified version of the Block data structure in the actual implementation. *)
 BlockHeaders ==
@@ -45,16 +50,14 @@ BlockHeaders ==
       \* the validators of the next block. We store the next validators instead of the hash.
   ]
 
-(* @typeAlias: BLOCK = [header: BLOCKHEADER, Commits: Set(Str)];
-   A signed header is just a header together with a set of commits *)
+(* A signed header is just a header together with a set of commits *)
 LightBlocks == [header: BlockHeaders, Commits: Commits]
 
 VARIABLES
     (* @type: Int;
        the current global time in integer units *)
     now,
-    (* @typeAlias: BLOCKCHAIN = Int -> BLOCKHEADER;
-       @type: BLOCKCHAIN;
+    (* @type: BLOCKCHAIN;
        A sequence of BlockHeaders, which gives us a bird view of the blockchain.
        The Int is the headers position in the sequence. *)
     blockchain,

--- a/light-client/tests/support/model_based/LightTests.tla
+++ b/light-client/tests/support/model_based/LightTests.tla
@@ -9,15 +9,13 @@ EXTENDS Lightclient_003_draft
    - verdict: the light client verdict in the previous state
 *)
 VARIABLE
+  \* @type: Int -> [verified: BLOCK, current: BLOCK, now: Int, verdict: Str];
   history
-
-(* APALACHE annotations *)
-a <: b == a \* type annotation
 
 \* This predicate extends the LightClient Init predicate with history tracking
 InitTest ==
   /\ Init
-  /\ history = [ n \in {0} <: {Int} |->
+  /\ history = [ n \in {0} |->
      [ verified |-> prevVerified, current |-> prevCurrent, now |-> prevNow, verdict |-> prevVerdict ]]
 
 \* This predicate extends the LightClient Next predicate with history tracking
@@ -94,7 +92,7 @@ TestNonMonotonicHeight ==
        /\ history[s].current.header.time > history[s].verified.header.time
        /\ history[s].current.header.time < history[s].now
        /\ history[s].verified.header.time + TRUSTING_PERIOD > history[s].now
-       /\ history[s].current.Commits /= ({} <: {STRING})
+       /\ history[s].current.Commits /= {}
        /\ history[s].current.Commits \subseteq  history[s].current.header.VS
 
 (*
@@ -103,8 +101,8 @@ please refer issue: https://github.com/informalsystems/tendermint-rs/issues/659
 TestEmptyCommitEmptyValset ==
     /\ \E s \in DOMAIN history :
        \* this is wrong
-       /\ history[s].current.Commits = ({} <: {STRING})
-       /\ ValSet(s) = ({} <: {STRING})
+       /\ history[s].current.Commits = {}
+       /\ ValSet(s) = {}
        \* everything else is correct
        /\ history[s].current.header /= history[s].verified.header
        /\ history[s].current.header.height > history[s].verified.header.height
@@ -115,8 +113,8 @@ TestEmptyCommitEmptyValset ==
 TestEmptyCommitNonEmptyValset ==
     /\ \E s \in DOMAIN history :
        \* this is wrong
-       /\ history[s].current.Commits = ({} <: {STRING})
-       /\ ValSet(s) /= ({} <: {STRING})
+       /\ history[s].current.Commits = {}
+       /\ ValSet(s) /= {}
        \* everything else is correct
        /\ history[s].current.header /= history[s].verified.header
        /\ history[s].current.header.height > history[s].verified.header.height
@@ -132,7 +130,7 @@ TestLessThanTwoThirdsCommit ==
            TVS == history[s].verified.header.VS
        IN
        /\ history[s].current.header.height > history[s].verified.header.height + 1
-       /\ CMS /= ({} <: {STRING})
+       /\ CMS /= {}
        /\ CMS \subseteq UVS
        /\ 3 * Cardinality(CMS) < 2 * Cardinality(UVS)
        /\ 3 * Cardinality(CMS \intersect TVS) < Cardinality(TVS)
@@ -159,8 +157,8 @@ TestUntrustedBeforeTrusted ==
         IN
         /\ history[s].current.header.time < history[s].verified.header.time
         /\ history[s].now < history[s].verified.header.time + TRUSTING_PERIOD
-        /\ CMS /= ({} <: {STRING})
-        /\ UVS /= ({} <: {STRING})
+        /\ CMS /= {}
+        /\ UVS /= {}
         /\ Cardinality(CMS) < Cardinality(UVS)
 
 \* Test an execution where a header is outside the trusting period
@@ -221,7 +219,7 @@ TestValsetChangesFully ==
     /\ \E s1, s2 \in DOMAIN history :
         /\ s2 = s1 + 1
         /\ Cardinality(ValSet(s1)) >= 2
-        /\ ValSet(s1) \intersect ValSet(s2) = ({} <: {STRING})
+        /\ ValSet(s1) \intersect ValSet(s2) = {}
 
 TestLessThanThirdValsetChanges ==
     /\ Cardinality(DOMAIN fetchedLightBlocks) = TARGET_HEIGHT

--- a/light-client/tests/support/model_based/MC4_4_faulty.tla
+++ b/light-client/tests/support/model_based/MC4_4_faulty.tla
@@ -6,10 +6,40 @@ TARGET_HEIGHT == 4
 TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 IS_PRIMARY_CORRECT == FALSE
 
+\* @typeAlias: BLOCKHEADER = [height: Int, time: Int, lastCommit: Set(Str), VS: Set(Str), NextVS: Set(Str)];
+\* @typeAlias: BLOCK = [header: BLOCKHEADER, Commits: Set(Str)];
+\* @typeAlias: BLOCKSTATUS = Int -> Str;
+\* @typeAlias: BLOCKS = Int -> BLOCK;
+MC4TypeAliases == TRUE
+
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
-  nprobes, now, blockchain, Faulty,
-  prevVerified, prevCurrent, prevNow, prevVerdict,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> BLOCK;
+  fetchedLightBlocks,
+  \* @type: BLOCKSTATUS;
+  lightBlockStatus,
+  \* @type: BLOCK;
+  latestVerified,
+  \* @type: Int;
+  nprobes,
+  \* @type: Int;
+  now,
+  \* @type: Int -> BLOCKHEADER;
+  blockchain,
+  \* @type: Set(Str);
+  Faulty,
+  \* @type: BLOCKHEADER;
+  prevVerified,
+  \* @type: BLOCK;
+  prevCurrent,
+  \* @type: Int;
+  prevNow,
+  \* @type: Str;
+  prevVerdict,
+  \* @type: Int -> [verified: BLOCK, current: BLOCK, now: Int, verdict: Str];
   history
 
 INSTANCE LightTests


### PR DESCRIPTION
In order to make use of the latest Apalache for MBT, we need to update the typing to use the current annotation practice.

Discussed with @andrey-kuprianov and @konnov via Slack.