### PR TITLE
p2p: Update crates' metadata to address clippy errors

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -5,6 +5,7 @@ authors     = ["Thane Thomson <thane@informal.systems>"]
 edition     = "2018"
 license     = "Apache-2.0"
 readme      = "README.md"
+categories  = ["cryptography::cryptocurrencies", "network-programming"]
 keywords    = ["abci", "blockchain", "bft", "consensus", "tendermint"]
 repository  = "https://github.com/informalsystems/tendermint-rs"
 description = """

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -9,6 +9,7 @@ edition     = "2018"
 license     = "Apache-2.0"
 readme      = "README.md"
 keywords    = ["blockchain", "bft", "consensus", "light-client", "tendermint"]
+categories  = ["cryptography::cryptocurrencies", "network-programming"]
 repository  = "https://github.com/informalsystems/tendermint-rs"
 description = """
     tendermint-light-client-js provides a lightweight, WASM-based interface to

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -5,6 +5,7 @@ edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"
 keywords   = ["blockchain", "bft", "consensus", "cosmos", "tendermint"]
+categories = ["cryptography::cryptocurrencies", "network-programming"]
 repository = "https://github.com/informalsystems/tendermint-rs"
 authors    = [
   "Sean Braithwaite <sean@informal.systems>",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,6 +7,7 @@ repository  = "https://github.com/informalsystems/tendermint-rs"
 homepage    = "https://tendermint.com"
 readme      = "README.md"
 keywords    = ["p2p", "tendermint", "cosmos"]
+categories  = ["cryptography::cryptocurrencies", "network-programming"]
 authors     = [
   "Tony Arcieri <tony@iqlusion.io>",
   "Ismail Khoffi <Ismail.Khoffi@gmail.com>"

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -3,6 +3,11 @@ name = "tendermint-pbt-gen"
 version = "0.19.0"
 authors = ["Shon Feder <shon@informal.systems>"]
 edition = "2018"
+license     = "Apache-2.0"
+readme      = "README.md"
+categories  = ["development-tools"]
+keywords    = ["tendermint", "property-based testing"]
+repository  = "https://github.com/informalsystems/tendermint-rs"
 description = """
             An internal crate providing proptest generators used across our
             crates and not depending on any code internal to those crates.

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -6,6 +6,8 @@ license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs"
 readme     = "README.md"
+keywords   = ["blockchain", "cosmos", "tendermint"]
+categories = ["cryptography::cryptocurrencies", "network-programming"]
 authors    = [
   "Sean Braithwaite <sean@informal.systems>",
   "Ethan Buchman <ethan@coinculture.info>",

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
-name = "tendermint-testgen"
-version = "0.19.0"
-authors = ["Andrey Kuprianov <andrey@informal.systems>", "Shivani Joshi <shivani@informal.systems>"]
-edition = "2018"
-readme  = "README.md"
-license    = "Apache-2.0"
-homepage   = "https://www.tendermint.com/"
-repository = "https://github.com/informalsystems/tendermint-rs/tree/master/testgen"
+name        = "tendermint-testgen"
+version     = "0.19.0"
+authors     = ["Andrey Kuprianov <andrey@informal.systems>", "Shivani Joshi <shivani@informal.systems>"]
+edition     = "2018"
+readme      = "README.md"
+license     = "Apache-2.0"
+homepage    = "https://www.tendermint.com/"
+repository  = "https://github.com/informalsystems/tendermint-rs/tree/master/testgen"
+keywords    = ["blockchain", "tendermint", "testing"]
+categories  = ["cryptography::cryptocurrencies", "development-tools"]
 description = """
     tendermint-testgen is a library and a small binary utility for generating 
     tendermint datastructures from minimal input (for testing purposes only).


### PR DESCRIPTION
At present, the code in #708 produces a number of clippy errors due to missing metadata in crates' `Cargo.toml` files, e.g.

```
error: package `tendermint-abci` is missing `package.categories` metadata
  |
  = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cargo_common_metadata
```

This adds the missing metadata and appeases clippy. We should just verify that the keywords/categories I've added here are appropriate.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
