### PR TITLE
Bump `k256` crate dependency to v0.9; MSRV 1.51+

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -58,7 +58,7 @@ toml = { version = "0.5" }
 url = { version = "2.2" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
-k256 = { version = "0.8", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.9", optional = true, features = ["ecdsa"] }
 ripemd160 = { version = "0.9", optional = true }
 
 [features]


### PR DESCRIPTION
As discussed in #892.

This release makes `bitvec` an optional dependency (gated under the `bits` feature). Since tendermint-rs doesn't need it at all, it's disabled as per default. This eliminates some transitive dependencies, which I know have been a problem in the past (#816).

The internal implementation is now using const generics, so this crate has a MSRV of 1.51+.