### PR TITLE
tendermint: use k256::ecdsa::VerifyingKey as Secp256k1 key

### DIFF
--- a/.changelog/unreleased/improvements/900-secp256k1-public-keys.md
+++ b/.changelog/unreleased/improvements/900-secp256k1-public-keys.md
@@ -1,0 +1,4 @@
+* `[tendermint]` Changed `tendermint::public_key::Secp256k1` to be an alias
+  of `k256::ecdsa::VerifyingKey`
+  ([#900](https://github.com/informalsystems/tendermint-rs/pull/900))
+

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -94,7 +94,7 @@ impl Debug for Id {
 #[cfg(feature = "secp256k1")]
 impl From<Secp256k1> for Id {
     fn from(pk: Secp256k1) -> Id {
-        let sha_digest = Sha256::digest(pk.as_bytes());
+        let sha_digest = Sha256::digest(&pk.to_bytes());
         let ripemd_digest = Ripemd160::digest(&sha_digest[..]);
         let mut bytes = [0u8; LENGTH];
         bytes.copy_from_slice(&ripemd_digest[..LENGTH]);
@@ -184,7 +184,7 @@ mod tests {
         let id_bytes = Id::from_str(id_hex).expect("expected id_hex to decode properly");
 
         // get id for pubkey
-        let pubkey = Secp256k1::from_bytes(pubkey_bytes).unwrap();
+        let pubkey = Secp256k1::from_sec1_bytes(pubkey_bytes).unwrap();
         let id = Id::from(pubkey);
 
         assert_eq!(id_bytes.ct_eq(&id).unwrap_u8(), 1);

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -264,7 +264,7 @@ impl From<&Info> for SimpleValidator {
             )),
             #[cfg(feature = "secp256k1")]
             PublicKey::Secp256k1(pk) => Some(tendermint_proto::crypto::public_key::Sum::Secp256k1(
-                pk.as_bytes().to_vec(),
+                pk.to_bytes().to_vec(),
             )),
         };
         SimpleValidator {


### PR DESCRIPTION
See #873 for background.

This changes the type re-exported as `tendermint::public_key::Secp256k1` from a `k256::EncodedPoint` to a `k256::ecdsa::VerifyingKey`.

The main distinction this provides is validating the public key (i.e. making sure it provides a valid solution to the secp256k1 curve equation), whereas `EncodedPoint` provides no validation of the public key.

If there were ever a `Signature::Secp256k1` variant added, this would also make it easy to perform signature verification.