### PR TITLE
p2p: pin `flume` to v0.10.5

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -19,7 +19,7 @@ description = """
 chacha20poly1305 = "0.7"
 ed25519-dalek = "1"
 eyre = "0.6"
-flume = "0.10"
+flume = "=0.10.5" # workaround for https://github.com/zesterer/flume/issues/83
 hkdf = "0.10.0"
 merlin = "2"
 prost = "0.7"


### PR DESCRIPTION
It appears v0.10.6 does not build on stable Rust:

https://github.com/zesterer/flume/issues/83

This works around the issue