### PR TITLE
tendermint: Add TryFrom for node::Id from PublicKey

### DIFF
--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -20,6 +20,10 @@ pub enum Kind {
     #[error("invalid key")]
     InvalidKey,
 
+    /// Unsupported public key type.
+    #[error("unsupported key type")]
+    UnsupportedKeyType,
+
     /// Input/output error
     #[error("I/O error")]
     Io,


### PR DESCRIPTION
Convenience to obtain a `node::Id` from a PublicKey, which is especially
useful in the context p2p and protocols built on top of it as the main
reference a peer is catalogued by is the `node::Id`.
