### PR TITLE
Unpin Tokio version and fix docs test in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         env:
-          RUSTFLAGS: "--cfg docsrs"
+          RUSTDOCFLAGS: "--cfg docsrs"
         with:
           command: doc
           args: --all-features

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -51,8 +51,7 @@ serde_derive = "1.0.106"
 sled = { version = "0.34.3", optional = true }
 static_assertions = "1.1.0"
 thiserror = "1.0.15"
-# TODO(thane): Unpin this version once Tokio fixes the documentation compiling problem in v1.7+.
-tokio = { version = "~1.6.2", features = ["rt"], optional = true }
+tokio = { version = "1.0", features = ["rt"], optional = true }
 
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -86,8 +86,7 @@ hyper = { version = "0.14", optional = true, features = ["client", "http1", "htt
 hyper-proxy = { version = "0.9", optional = true }
 hyper-rustls = { version = "0.22.1", optional = true }
 structopt = { version = "0.3", optional = true }
-# TODO(thane): Unpin this version once Tokio fixes the documentation compiling problem in v1.7+.
-tokio = { version = "~1.6.2", optional = true }
+tokio = { version = "1.0", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.2", optional = true }
 


### PR DESCRIPTION
Closes #911 

Seems like we were using the wrong environment variable in CI: https://github.com/tokio-rs/tokio/issues/3880#issuecomment-866056546

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
