### PR TITLE
Rebuild Protobuf data structures for Tendermint v0.34.9

### DIFF
--- a/.changelog/unreleased/improvements/871-rebuild-protobuf.md
+++ b/.changelog/unreleased/improvements/871-rebuild-protobuf.md
@@ -1,0 +1,3 @@
+* `[tendermint-proto]` Regenerate the Rust equivalents of the Tendermint
+  Protobuf structures for Tendermint v0.34.9
+  ([#871](https://github.com/informalsystems/tendermint-rs/issues/871))

--- a/proto/src/prost/google.protobuf.rs
+++ b/proto/src/prost/google.protobuf.rs
@@ -3,86 +3,87 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
-    pub file: ::std::vec::Vec<FileDescriptorProto>,
+    pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// e.g. "foo", "foo.bar", etc.
     #[prost(string, optional, tag="2")]
-    pub package: ::std::option::Option<std::string::String>,
+    pub package: ::core::option::Option<::prost::alloc::string::String>,
     /// Names of files imported by this file.
     #[prost(string, repeated, tag="3")]
-    pub dependency: ::std::vec::Vec<std::string::String>,
+    pub dependency: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Indexes of the public imported files in the dependency list above.
     #[prost(int32, repeated, packed="false", tag="10")]
-    pub public_dependency: ::std::vec::Vec<i32>,
+    pub public_dependency: ::prost::alloc::vec::Vec<i32>,
     /// Indexes of the weak imported files in the dependency list.
     /// For Google-internal migration only. Do not use.
     #[prost(int32, repeated, packed="false", tag="11")]
-    pub weak_dependency: ::std::vec::Vec<i32>,
+    pub weak_dependency: ::prost::alloc::vec::Vec<i32>,
     /// All top-level definitions in this file.
     #[prost(message, repeated, tag="4")]
-    pub message_type: ::std::vec::Vec<DescriptorProto>,
+    pub message_type: ::prost::alloc::vec::Vec<DescriptorProto>,
     #[prost(message, repeated, tag="5")]
-    pub enum_type: ::std::vec::Vec<EnumDescriptorProto>,
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
     #[prost(message, repeated, tag="6")]
-    pub service: ::std::vec::Vec<ServiceDescriptorProto>,
+    pub service: ::prost::alloc::vec::Vec<ServiceDescriptorProto>,
     #[prost(message, repeated, tag="7")]
-    pub extension: ::std::vec::Vec<FieldDescriptorProto>,
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
     #[prost(message, optional, tag="8")]
-    pub options: ::std::option::Option<FileOptions>,
+    pub options: ::core::option::Option<FileOptions>,
     /// This field contains optional information about the original source code.
     /// You may safely remove this entire field without harming runtime
     /// functionality of the descriptors -- the information is needed only by
     /// development tools.
     #[prost(message, optional, tag="9")]
-    pub source_code_info: ::std::option::Option<SourceCodeInfo>,
+    pub source_code_info: ::core::option::Option<SourceCodeInfo>,
     /// The syntax of the proto file.
     /// The supported values are "proto2" and "proto3".
     #[prost(string, optional, tag="12")]
-    pub syntax: ::std::option::Option<std::string::String>,
+    pub syntax: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub field: ::std::vec::Vec<FieldDescriptorProto>,
+    pub field: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="6")]
-    pub extension: ::std::vec::Vec<FieldDescriptorProto>,
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="3")]
-    pub nested_type: ::std::vec::Vec<DescriptorProto>,
+    pub nested_type: ::prost::alloc::vec::Vec<DescriptorProto>,
     #[prost(message, repeated, tag="4")]
-    pub enum_type: ::std::vec::Vec<EnumDescriptorProto>,
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
     #[prost(message, repeated, tag="5")]
-    pub extension_range: ::std::vec::Vec<descriptor_proto::ExtensionRange>,
+    pub extension_range: ::prost::alloc::vec::Vec<descriptor_proto::ExtensionRange>,
     #[prost(message, repeated, tag="8")]
-    pub oneof_decl: ::std::vec::Vec<OneofDescriptorProto>,
+    pub oneof_decl: ::prost::alloc::vec::Vec<OneofDescriptorProto>,
     #[prost(message, optional, tag="7")]
-    pub options: ::std::option::Option<MessageOptions>,
+    pub options: ::core::option::Option<MessageOptions>,
     #[prost(message, repeated, tag="9")]
-    pub reserved_range: ::std::vec::Vec<descriptor_proto::ReservedRange>,
+    pub reserved_range: ::prost::alloc::vec::Vec<descriptor_proto::ReservedRange>,
     /// Reserved field names, which may not be used by fields in the same message.
     /// A given name may only be reserved once.
     #[prost(string, repeated, tag="10")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: ::core::option::Option<i32>,
         /// Exclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
         #[prost(message, optional, tag="3")]
-        pub options: ::std::option::Option<super::ExtensionRangeOptions>,
+        pub options: ::core::option::Option<super::ExtensionRangeOptions>,
     }
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
@@ -91,62 +92,86 @@ pub mod descriptor_proto {
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: ::core::option::Option<i32>,
         /// Exclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int32, optional, tag="3")]
-    pub number: ::std::option::Option<i32>,
+    pub number: ::core::option::Option<i32>,
     #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
-    pub label: ::std::option::Option<i32>,
+    pub label: ::core::option::Option<i32>,
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
-    pub r#type: ::std::option::Option<i32>,
+    pub r#type: ::core::option::Option<i32>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this
     /// message are searched, then within the parent, on up to the root
     /// namespace).
     #[prost(string, optional, tag="6")]
-    pub type_name: ::std::option::Option<std::string::String>,
+    pub type_name: ::core::option::Option<::prost::alloc::string::String>,
     /// For extensions, this is the name of the type being extended.  It is
     /// resolved in the same manner as type_name.
     #[prost(string, optional, tag="2")]
-    pub extendee: ::std::option::Option<std::string::String>,
+    pub extendee: ::core::option::Option<::prost::alloc::string::String>,
     /// For numeric types, contains the original text representation of the value.
     /// For booleans, "true" or "false".
     /// For strings, contains the default text contents (not escaped in any way).
     /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
     /// TODO(kenton):  Base-64 encode?
     #[prost(string, optional, tag="7")]
-    pub default_value: ::std::option::Option<std::string::String>,
+    pub default_value: ::core::option::Option<::prost::alloc::string::String>,
     /// If set, gives the index of a oneof in the containing type's oneof_decl
     /// list.  This field is a member of that oneof.
     #[prost(int32, optional, tag="9")]
-    pub oneof_index: ::std::option::Option<i32>,
+    pub oneof_index: ::core::option::Option<i32>,
     /// JSON name of this field. The value is set by protocol compiler. If the
     /// user has set a "json_name" option on this field, that option's value
     /// will be used. Otherwise, it's deduced from the field's name by converting
     /// it to camelCase.
     #[prost(string, optional, tag="10")]
-    pub json_name: ::std::option::Option<std::string::String>,
+    pub json_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="8")]
-    pub options: ::std::option::Option<FieldOptions>,
+    pub options: ::core::option::Option<FieldOptions>,
+    /// If true, this is a proto3 "optional". When a proto3 field is optional, it
+    /// tracks presence regardless of field type.
+    ///
+    /// When proto3_optional is true, this field must be belong to a oneof to
+    /// signal to old proto3 clients that presence is tracked for this field. This
+    /// oneof is known as a "synthetic" oneof, and this field must be its sole
+    /// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+    /// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+    /// oneofs must be ordered after all "real" oneofs.
+    ///
+    /// For message fields, proto3_optional doesn't create any semantic change,
+    /// since non-repeated message fields always track presence. However it still
+    /// indicates the semantic detail of whether the user wrote "optional" or not.
+    /// This can be useful for round-tripping the .proto file. For consistency we
+    /// give message fields a synthetic oneof also, even though it is not required
+    /// to track presence. This is especially important because the parser can't
+    /// tell if a field is a message or an enum, so it must always create a
+    /// synthetic oneof.
+    ///
+    /// Proto2 optional fields do not set this flag, because they already indicate
+    /// optional with `LABEL_OPTIONAL`.
+    #[prost(bool, optional, tag="17")]
+    pub proto3_optional: ::core::option::Option<bool>,
 }
+/// Nested message and enum types in `FieldDescriptorProto`.
 pub mod field_descriptor_proto {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -197,29 +222,30 @@ pub mod field_descriptor_proto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="2")]
-    pub options: ::std::option::Option<OneofOptions>,
+    pub options: ::core::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub value: ::std::vec::Vec<EnumValueDescriptorProto>,
+    pub value: ::prost::alloc::vec::Vec<EnumValueDescriptorProto>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<EnumOptions>,
+    pub options: ::core::option::Option<EnumOptions>,
     /// Range of reserved numeric values. Reserved numeric values may not be used
     /// by enum values in the same enum declaration. Reserved ranges may not
     /// overlap.
     #[prost(message, repeated, tag="4")]
-    pub reserved_range: ::std::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
+    pub reserved_range: ::prost::alloc::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
     /// Reserved enum value names, which may not be reused. A given name may only
     /// be reserved once.
     #[prost(string, repeated, tag="5")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Nested message and enum types in `EnumDescriptorProto`.
 pub mod enum_descriptor_proto {
     /// Range of reserved numeric values. Reserved values may not be used by
     /// entries in the same enum. Reserved ranges may not overlap.
@@ -231,51 +257,51 @@ pub mod enum_descriptor_proto {
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: ::core::option::Option<i32>,
         /// Inclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
     }
 }
 /// Describes a value within an enum.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int32, optional, tag="2")]
-    pub number: ::std::option::Option<i32>,
+    pub number: ::core::option::Option<i32>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<EnumValueOptions>,
+    pub options: ::core::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub method: ::std::vec::Vec<MethodDescriptorProto>,
+    pub method: ::prost::alloc::vec::Vec<MethodDescriptorProto>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<ServiceOptions>,
+    pub options: ::core::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// Input and output type names.  These are resolved in the same way as
     /// FieldDescriptorProto.type_name, but must refer to a message type.
     #[prost(string, optional, tag="2")]
-    pub input_type: ::std::option::Option<std::string::String>,
+    pub input_type: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag="3")]
-    pub output_type: ::std::option::Option<std::string::String>,
+    pub output_type: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="4")]
-    pub options: ::std::option::Option<MethodOptions>,
+    pub options: ::core::option::Option<MethodOptions>,
     /// Identifies if client streams multiple client messages
     #[prost(bool, optional, tag="5", default="false")]
-    pub client_streaming: ::std::option::Option<bool>,
+    pub client_streaming: ::core::option::Option<bool>,
     /// Identifies if server streams multiple server messages
     #[prost(bool, optional, tag="6", default="false")]
-    pub server_streaming: ::std::option::Option<bool>,
+    pub server_streaming: ::core::option::Option<bool>,
 }
 // ===================================================================
 // Options
@@ -316,14 +342,14 @@ pub struct FileOptions {
     /// inappropriate because proto packages do not normally start with backwards
     /// domain names.
     #[prost(string, optional, tag="1")]
-    pub java_package: ::std::option::Option<std::string::String>,
+    pub java_package: ::core::option::Option<::prost::alloc::string::String>,
     /// If set, all the classes from the .proto file are wrapped in a single
     /// outer class with the given name.  This applies to both Proto1
     /// (equivalent to the old "--one_java_file" option) and Proto2 (where
     /// a .proto always translates to a single class, but you may want to
     /// explicitly choose the class name).
     #[prost(string, optional, tag="8")]
-    pub java_outer_classname: ::std::option::Option<std::string::String>,
+    pub java_outer_classname: ::core::option::Option<::prost::alloc::string::String>,
     /// If set true, then the Java code generator will generate a separate .java
     /// file for each top-level message, enum, and service defined in the .proto
     /// file.  Thus, these types will *not* be nested inside the outer class
@@ -331,10 +357,11 @@ pub struct FileOptions {
     /// generated to contain the file's getDescriptor() method as well as any
     /// top-level extensions defined in the file.
     #[prost(bool, optional, tag="10", default="false")]
-    pub java_multiple_files: ::std::option::Option<bool>,
+    pub java_multiple_files: ::core::option::Option<bool>,
     /// This option does nothing.
+    #[deprecated]
     #[prost(bool, optional, tag="20")]
-    pub java_generate_equals_and_hash: ::std::option::Option<bool>,
+    pub java_generate_equals_and_hash: ::core::option::Option<bool>,
     /// If set true, then the Java2 code generator will generate code that
     /// throws an exception whenever an attempt is made to assign a non-UTF-8
     /// byte sequence to a string field.
@@ -342,16 +369,16 @@ pub struct FileOptions {
     /// However, an extension field still accepts non-UTF-8 byte sequences.
     /// This option has no effect on when used with the lite runtime.
     #[prost(bool, optional, tag="27", default="false")]
-    pub java_string_check_utf8: ::std::option::Option<bool>,
+    pub java_string_check_utf8: ::core::option::Option<bool>,
     #[prost(enumeration="file_options::OptimizeMode", optional, tag="9", default="Speed")]
-    pub optimize_for: ::std::option::Option<i32>,
+    pub optimize_for: ::core::option::Option<i32>,
     /// Sets the Go package where structs generated from this .proto will be
     /// placed. If omitted, the Go package will be derived from the following:
     ///   - The basename of the package import path, if provided.
     ///   - Otherwise, the package statement in the .proto file, if present.
     ///   - Otherwise, the basename of the .proto file, without extension.
     #[prost(string, optional, tag="11")]
-    pub go_package: ::std::option::Option<std::string::String>,
+    pub go_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Should generic services be generated in each language?  "Generic" services
     /// are not specific to any particular RPC system.  They are generated by the
     /// main code generators in each language (without additional plugins).
@@ -363,60 +390,61 @@ pub struct FileOptions {
     /// these default to false.  Old code which depends on generic services should
     /// explicitly set them to true.
     #[prost(bool, optional, tag="16", default="false")]
-    pub cc_generic_services: ::std::option::Option<bool>,
+    pub cc_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="17", default="false")]
-    pub java_generic_services: ::std::option::Option<bool>,
+    pub java_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="18", default="false")]
-    pub py_generic_services: ::std::option::Option<bool>,
+    pub py_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="42", default="false")]
-    pub php_generic_services: ::std::option::Option<bool>,
+    pub php_generic_services: ::core::option::Option<bool>,
     /// Is this file deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for everything in the file, or it will be completely ignored; in the very
     /// least, this is a formalization for deprecating files.
     #[prost(bool, optional, tag="23", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// Enables the use of arenas for the proto messages in this file. This applies
     /// only to generated classes for C++.
-    #[prost(bool, optional, tag="31", default="false")]
-    pub cc_enable_arenas: ::std::option::Option<bool>,
+    #[prost(bool, optional, tag="31", default="true")]
+    pub cc_enable_arenas: ::core::option::Option<bool>,
     /// Sets the objective c class prefix which is prepended to all objective c
     /// generated classes from this .proto. There is no default.
     #[prost(string, optional, tag="36")]
-    pub objc_class_prefix: ::std::option::Option<std::string::String>,
+    pub objc_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Namespace for generated classes; defaults to the package.
     #[prost(string, optional, tag="37")]
-    pub csharp_namespace: ::std::option::Option<std::string::String>,
+    pub csharp_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// By default Swift generators will take the proto package and CamelCase it
     /// replacing '.' with underscore and use that to prefix the types/symbols
     /// defined. When this options is provided, they will use this value instead
     /// to prefix the types/symbols defined.
     #[prost(string, optional, tag="39")]
-    pub swift_prefix: ::std::option::Option<std::string::String>,
+    pub swift_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Sets the php class prefix which is prepended to all php generated classes
     /// from this .proto. Default is empty.
     #[prost(string, optional, tag="40")]
-    pub php_class_prefix: ::std::option::Option<std::string::String>,
+    pub php_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated classes. Default
     /// is empty. When this option is empty, the package name will be used for
     /// determining the namespace.
     #[prost(string, optional, tag="41")]
-    pub php_namespace: ::std::option::Option<std::string::String>,
+    pub php_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated metadata classes.
     /// Default is empty. When this option is empty, the proto file name will be
     /// used for determining the namespace.
     #[prost(string, optional, tag="44")]
-    pub php_metadata_namespace: ::std::option::Option<std::string::String>,
+    pub php_metadata_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the package of ruby generated classes. Default
     /// is empty. When this option is not set, the package name will be used for
     /// determining the ruby package.
     #[prost(string, optional, tag="45")]
-    pub ruby_package: ::std::option::Option<std::string::String>,
+    pub ruby_package: ::core::option::Option<::prost::alloc::string::String>,
     /// The parser stores options it doesn't recognize here.
     /// See the documentation for the "Options" section above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+/// Nested message and enum types in `FileOptions`.
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -453,18 +481,18 @@ pub struct MessageOptions {
     /// Because this is an option, the above two restrictions are not enforced by
     /// the protocol compiler.
     #[prost(bool, optional, tag="1", default="false")]
-    pub message_set_wire_format: ::std::option::Option<bool>,
+    pub message_set_wire_format: ::core::option::Option<bool>,
     /// Disables the generation of the standard "descriptor()" accessor, which can
     /// conflict with a field of the same name.  This is meant to make migration
     /// from proto1 easier; new code should avoid fields named "descriptor".
     #[prost(bool, optional, tag="2", default="false")]
-    pub no_standard_descriptor_accessor: ::std::option::Option<bool>,
+    pub no_standard_descriptor_accessor: ::core::option::Option<bool>,
     /// Is this message deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the message, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating messages.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// Whether the message is an automatically generated map entry type for the
     /// maps field.
     ///
@@ -487,10 +515,10 @@ pub struct MessageOptions {
     /// instead. The option should only be implicitly set by the proto compiler
     /// parser.
     #[prost(bool, optional, tag="7")]
-    pub map_entry: ::std::option::Option<bool>,
+    pub map_entry: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
@@ -499,14 +527,14 @@ pub struct FieldOptions {
     /// options below.  This option is not yet implemented in the open source
     /// release -- sorry, we'll try to include it in a future version!
     #[prost(enumeration="field_options::CType", optional, tag="1", default="String")]
-    pub ctype: ::std::option::Option<i32>,
+    pub ctype: ::core::option::Option<i32>,
     /// The packed option can be enabled for repeated primitive fields to enable
     /// a more efficient representation on the wire. Rather than repeatedly
     /// writing the tag and type for each element, the entire array is encoded as
     /// a single length-delimited blob. In proto3, only explicit setting it to
     /// false will avoid using packed encoding.
     #[prost(bool, optional, tag="2")]
-    pub packed: ::std::option::Option<bool>,
+    pub packed: ::core::option::Option<bool>,
     /// The jstype option determines the JavaScript type used for values of the
     /// field.  The option is permitted only for 64 bit integral and fixed types
     /// (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
@@ -519,7 +547,7 @@ pub struct FieldOptions {
     /// This option is an enum to permit additional types to be added, e.g.
     /// goog.math.Integer.
     #[prost(enumeration="field_options::JsType", optional, tag="6", default="JsNormal")]
-    pub jstype: ::std::option::Option<i32>,
+    pub jstype: ::core::option::Option<i32>,
     /// Should this field be parsed lazily?  Lazy applies only to message-type
     /// fields.  It means that when the outer message is initially parsed, the
     /// inner message's contents will not be parsed but instead stored in encoded
@@ -549,20 +577,21 @@ pub struct FieldOptions {
     /// check its required fields, regardless of whether or not the message has
     /// been parsed.
     #[prost(bool, optional, tag="5", default="false")]
-    pub lazy: ::std::option::Option<bool>,
+    pub lazy: ::core::option::Option<bool>,
     /// Is this field deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for accessors, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating fields.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// For Google-internal migration only. Do not use.
     #[prost(bool, optional, tag="10", default="false")]
-    pub weak: ::std::option::Option<bool>,
+    pub weak: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+/// Nested message and enum types in `FieldOptions`.
 pub mod field_options {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -587,23 +616,23 @@ pub mod field_options {
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
     #[prost(bool, optional, tag="2")]
-    pub allow_alias: ::std::option::Option<bool>,
+    pub allow_alias: ::core::option::Option<bool>,
     /// Is this enum deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the enum, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating enums.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
@@ -612,10 +641,10 @@ pub struct EnumValueOptions {
     /// for the enum value, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating enum values.
     #[prost(bool, optional, tag="1", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
@@ -629,10 +658,10 @@ pub struct ServiceOptions {
     /// for the service, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating services.
     #[prost(bool, optional, tag="33", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
@@ -646,13 +675,14 @@ pub struct MethodOptions {
     /// for the method, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating methods.
     #[prost(bool, optional, tag="33", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     #[prost(enumeration="method_options::IdempotencyLevel", optional, tag="34", default="IdempotencyUnknown")]
-    pub idempotency_level: ::std::option::Option<i32>,
+    pub idempotency_level: ::core::option::Option<i32>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+/// Nested message and enum types in `MethodOptions`.
 pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
@@ -676,22 +706,23 @@ pub mod method_options {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
-    pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
+    pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
     /// The value of the uninterpreted option, in whatever type the tokenizer
     /// identified it as during parsing. Exactly one of these should be set.
     #[prost(string, optional, tag="3")]
-    pub identifier_value: ::std::option::Option<std::string::String>,
+    pub identifier_value: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(uint64, optional, tag="4")]
-    pub positive_int_value: ::std::option::Option<u64>,
+    pub positive_int_value: ::core::option::Option<u64>,
     #[prost(int64, optional, tag="5")]
-    pub negative_int_value: ::std::option::Option<i64>,
+    pub negative_int_value: ::core::option::Option<i64>,
     #[prost(double, optional, tag="6")]
-    pub double_value: ::std::option::Option<f64>,
-    #[prost(bytes, optional, tag="7")]
-    pub string_value: ::std::option::Option<std::vec::Vec<u8>>,
+    pub double_value: ::core::option::Option<f64>,
+    #[prost(bytes="vec", optional, tag="7")]
+    pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[prost(string, optional, tag="8")]
-    pub aggregate_value: ::std::option::Option<std::string::String>,
+    pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Nested message and enum types in `UninterpretedOption`.
 pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
     /// a dot-separated name.  is_extension is true iff a segment represents an
@@ -701,7 +732,7 @@ pub mod uninterpreted_option {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
-        pub name_part: std::string::String,
+        pub name_part: ::prost::alloc::string::String,
         #[prost(bool, required, tag="2")]
         pub is_extension: bool,
     }
@@ -757,8 +788,9 @@ pub struct SourceCodeInfo {
     ///   ignore those that it doesn't understand, as more types of locations could
     ///   be recorded in the future.
     #[prost(message, repeated, tag="1")]
-    pub location: ::std::vec::Vec<source_code_info::Location>,
+    pub location: ::prost::alloc::vec::Vec<source_code_info::Location>,
 }
+/// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Location {
@@ -786,14 +818,14 @@ pub mod source_code_info {
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
         #[prost(int32, repeated, tag="1")]
-        pub path: ::std::vec::Vec<i32>,
+        pub path: ::prost::alloc::vec::Vec<i32>,
         /// Always has exactly three or four elements: start line, start column,
         /// end line (optional, otherwise assumed same as start line), end column.
         /// These are packed into a single field for efficiency.  Note that line
         /// and column numbers are zero-based -- typically you will want to add
         /// 1 to each before displaying to a user.
         #[prost(int32, repeated, tag="2")]
-        pub span: ::std::vec::Vec<i32>,
+        pub span: ::prost::alloc::vec::Vec<i32>,
         /// If this SourceCodeInfo represents a complete declaration, these are any
         /// comments appearing before and after the declaration which appear to be
         /// attached to the declaration.
@@ -842,11 +874,11 @@ pub mod source_code_info {
         ///
         ///   // ignored detached comments.
         #[prost(string, optional, tag="3")]
-        pub leading_comments: ::std::option::Option<std::string::String>,
+        pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(string, optional, tag="4")]
-        pub trailing_comments: ::std::option::Option<std::string::String>,
+        pub trailing_comments: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(string, repeated, tag="6")]
-        pub leading_detached_comments: ::std::vec::Vec<std::string::String>,
+        pub leading_detached_comments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
 }
 /// Describes the relationship between generated code and its original source
@@ -857,26 +889,27 @@ pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
     #[prost(message, repeated, tag="1")]
-    pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
+    pub annotation: ::prost::alloc::vec::Vec<generated_code_info::Annotation>,
 }
+/// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
         #[prost(int32, repeated, tag="1")]
-        pub path: ::std::vec::Vec<i32>,
+        pub path: ::prost::alloc::vec::Vec<i32>,
         /// Identifies the filesystem path to the original source .proto.
         #[prost(string, optional, tag="2")]
-        pub source_file: ::std::option::Option<std::string::String>,
+        pub source_file: ::core::option::Option<::prost::alloc::string::String>,
         /// Identifies the starting offset in bytes in the generated code
         /// that relates to the identified object.
         #[prost(int32, optional, tag="3")]
-        pub begin: ::std::option::Option<i32>,
+        pub begin: ::core::option::Option<i32>,
         /// Identifies the ending offset in bytes in the generated code that
         /// relates to the identified offset. The end offset should be one past
         /// the last relevant byte (so the length of the text = end - begin).
         #[prost(int32, optional, tag="4")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
     }
 }

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -8,8 +8,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Request {
     #[prost(oneof="request::Value", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15")]
-    pub value: ::std::option::Option<request::Value>,
+    pub value: ::core::option::Option<request::Value>,
 }
+/// Nested message and enum types in `Request`.
 pub mod request {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -48,7 +49,7 @@ pub mod request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestEcho {
     #[prost(string, tag="1")]
-    pub message: std::string::String,
+    pub message: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestFlush {
@@ -56,7 +57,7 @@ pub struct RequestFlush {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestInfo {
     #[prost(string, tag="1")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
     #[prost(uint64, tag="2")]
     pub block_version: u64,
     #[prost(uint64, tag="3")]
@@ -66,31 +67,31 @@ pub struct RequestInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestSetOption {
     #[prost(string, tag="1")]
-    pub key: std::string::String,
+    pub key: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
-    pub value: std::string::String,
+    pub value: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestInitChain {
     #[prost(message, optional, tag="1")]
-    pub time: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub time: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="2")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub consensus_params: ::std::option::Option<ConsensusParams>,
+    pub consensus_params: ::core::option::Option<ConsensusParams>,
     #[prost(message, repeated, tag="4")]
-    pub validators: ::std::vec::Vec<ValidatorUpdate>,
-    #[prost(bytes, tag="5")]
-    pub app_state_bytes: std::vec::Vec<u8>,
+    pub validators: ::prost::alloc::vec::Vec<ValidatorUpdate>,
+    #[prost(bytes="vec", tag="5")]
+    pub app_state_bytes: ::prost::alloc::vec::Vec<u8>,
     #[prost(int64, tag="6")]
     pub initial_height: i64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestQuery {
-    #[prost(bytes, tag="1")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag="2")]
-    pub path: std::string::String,
+    pub path: ::prost::alloc::string::String,
     #[prost(int64, tag="3")]
     pub height: i64,
     #[prost(bool, tag="4")]
@@ -98,26 +99,26 @@ pub struct RequestQuery {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestBeginBlock {
-    #[prost(bytes, tag="1")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="2")]
-    pub header: ::std::option::Option<super::types::Header>,
+    pub header: ::core::option::Option<super::types::Header>,
     #[prost(message, optional, tag="3")]
-    pub last_commit_info: ::std::option::Option<LastCommitInfo>,
+    pub last_commit_info: ::core::option::Option<LastCommitInfo>,
     #[prost(message, repeated, tag="4")]
-    pub byzantine_validators: ::std::vec::Vec<Evidence>,
+    pub byzantine_validators: ::prost::alloc::vec::Vec<Evidence>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestCheckTx {
-    #[prost(bytes, tag="1")]
-    pub tx: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub tx: ::prost::alloc::vec::Vec<u8>,
     #[prost(enumeration="CheckTxType", tag="2")]
     pub r#type: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestDeliverTx {
-    #[prost(bytes, tag="1")]
-    pub tx: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub tx: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestEndBlock {
@@ -136,10 +137,10 @@ pub struct RequestListSnapshots {
 pub struct RequestOfferSnapshot {
     /// snapshot offered by peers
     #[prost(message, optional, tag="1")]
-    pub snapshot: ::std::option::Option<Snapshot>,
+    pub snapshot: ::core::option::Option<Snapshot>,
     /// light client-verified app hash for snapshot height
-    #[prost(bytes, tag="2")]
-    pub app_hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub app_hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// loads a snapshot chunk
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -156,10 +157,10 @@ pub struct RequestLoadSnapshotChunk {
 pub struct RequestApplySnapshotChunk {
     #[prost(uint32, tag="1")]
     pub index: u32,
-    #[prost(bytes, tag="2")]
-    pub chunk: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub chunk: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag="3")]
-    pub sender: std::string::String,
+    pub sender: ::prost::alloc::string::String,
 }
 //----------------------------------------
 // Response types
@@ -167,8 +168,9 @@ pub struct RequestApplySnapshotChunk {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Response {
     #[prost(oneof="response::Value", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16")]
-    pub value: ::std::option::Option<response::Value>,
+    pub value: ::core::option::Option<response::Value>,
 }
+/// Nested message and enum types in `Response`.
 pub mod response {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -210,32 +212,32 @@ pub mod response {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseException {
     #[prost(string, tag="1")]
-    pub error: std::string::String,
+    pub error: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseEcho {
     #[prost(string, tag="1")]
-    pub message: std::string::String,
+    pub message: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseFlush {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseInfo {
     #[prost(string, tag="1")]
-    pub data: std::string::String,
+    pub data: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
     #[prost(uint64, tag="3")]
     #[serde(with = "crate::serializers::from_str")]
     pub app_version: u64,
     #[prost(int64, tag="4")]
     #[serde(with = "crate::serializers::from_str")]
     pub last_block_height: i64,
-    #[prost(bytes, tag="5")]
+    #[prost(bytes="vec", tag="5")]
     #[serde(skip_serializing_if = "Vec::is_empty", with = "serde_bytes")]
-    pub last_block_app_hash: std::vec::Vec<u8>,
+    pub last_block_app_hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// nondeterministic
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -244,18 +246,18 @@ pub struct ResponseSetOption {
     pub code: u32,
     /// bytes data = 2;
     #[prost(string, tag="3")]
-    pub log: std::string::String,
+    pub log: ::prost::alloc::string::String,
     #[prost(string, tag="4")]
-    pub info: std::string::String,
+    pub info: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseInitChain {
     #[prost(message, optional, tag="1")]
-    pub consensus_params: ::std::option::Option<ConsensusParams>,
+    pub consensus_params: ::core::option::Option<ConsensusParams>,
     #[prost(message, repeated, tag="2")]
-    pub validators: ::std::vec::Vec<ValidatorUpdate>,
-    #[prost(bytes, tag="3")]
-    pub app_hash: std::vec::Vec<u8>,
+    pub validators: ::prost::alloc::vec::Vec<ValidatorUpdate>,
+    #[prost(bytes="vec", tag="3")]
+    pub app_hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseQuery {
@@ -265,97 +267,99 @@ pub struct ResponseQuery {
     ///
     /// nondeterministic
     #[prost(string, tag="3")]
-    pub log: std::string::String,
+    pub log: ::prost::alloc::string::String,
     /// nondeterministic
     #[prost(string, tag="4")]
-    pub info: std::string::String,
+    pub info: ::prost::alloc::string::String,
     #[prost(int64, tag="5")]
     pub index: i64,
-    #[prost(bytes, tag="6")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag="7")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="6")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="7")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="8")]
-    pub proof_ops: ::std::option::Option<super::crypto::ProofOps>,
+    pub proof_ops: ::core::option::Option<super::crypto::ProofOps>,
     #[prost(int64, tag="9")]
     pub height: i64,
     #[prost(string, tag="10")]
-    pub codespace: std::string::String,
+    pub codespace: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseBeginBlock {
     #[prost(message, repeated, tag="1")]
-    pub events: ::std::vec::Vec<Event>,
+    pub events: ::prost::alloc::vec::Vec<Event>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseCheckTx {
     #[prost(uint32, tag="1")]
     pub code: u32,
-    #[prost(bytes, tag="2")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     /// nondeterministic
     #[prost(string, tag="3")]
-    pub log: std::string::String,
+    pub log: ::prost::alloc::string::String,
     /// nondeterministic
     #[prost(string, tag="4")]
-    pub info: std::string::String,
+    pub info: ::prost::alloc::string::String,
     #[prost(int64, tag="5")]
     pub gas_wanted: i64,
     #[prost(int64, tag="6")]
     pub gas_used: i64,
     #[prost(message, repeated, tag="7")]
-    pub events: ::std::vec::Vec<Event>,
+    pub events: ::prost::alloc::vec::Vec<Event>,
     #[prost(string, tag="8")]
-    pub codespace: std::string::String,
+    pub codespace: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseDeliverTx {
     #[prost(uint32, tag="1")]
     pub code: u32,
-    #[prost(bytes, tag="2")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     /// nondeterministic
     #[prost(string, tag="3")]
-    pub log: std::string::String,
+    pub log: ::prost::alloc::string::String,
     /// nondeterministic
     #[prost(string, tag="4")]
-    pub info: std::string::String,
+    pub info: ::prost::alloc::string::String,
     #[prost(int64, tag="5")]
     pub gas_wanted: i64,
     #[prost(int64, tag="6")]
     pub gas_used: i64,
+    /// nondeterministic
     #[prost(message, repeated, tag="7")]
-    pub events: ::std::vec::Vec<Event>,
+    pub events: ::prost::alloc::vec::Vec<Event>,
     #[prost(string, tag="8")]
-    pub codespace: std::string::String,
+    pub codespace: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseEndBlock {
     #[prost(message, repeated, tag="1")]
-    pub validator_updates: ::std::vec::Vec<ValidatorUpdate>,
+    pub validator_updates: ::prost::alloc::vec::Vec<ValidatorUpdate>,
     #[prost(message, optional, tag="2")]
-    pub consensus_param_updates: ::std::option::Option<ConsensusParams>,
+    pub consensus_param_updates: ::core::option::Option<ConsensusParams>,
     #[prost(message, repeated, tag="3")]
-    pub events: ::std::vec::Vec<Event>,
+    pub events: ::prost::alloc::vec::Vec<Event>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseCommit {
     /// reserve 1
-    #[prost(bytes, tag="2")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     #[prost(int64, tag="3")]
     pub retain_height: i64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseListSnapshots {
     #[prost(message, repeated, tag="1")]
-    pub snapshots: ::std::vec::Vec<Snapshot>,
+    pub snapshots: ::prost::alloc::vec::Vec<Snapshot>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseOfferSnapshot {
     #[prost(enumeration="response_offer_snapshot::Result", tag="1")]
     pub result: i32,
 }
+/// Nested message and enum types in `ResponseOfferSnapshot`.
 pub mod response_offer_snapshot {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -376,8 +380,8 @@ pub mod response_offer_snapshot {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseLoadSnapshotChunk {
-    #[prost(bytes, tag="1")]
-    pub chunk: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub chunk: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseApplySnapshotChunk {
@@ -385,11 +389,12 @@ pub struct ResponseApplySnapshotChunk {
     pub result: i32,
     /// Chunks to refetch and reapply
     #[prost(uint32, repeated, tag="2")]
-    pub refetch_chunks: ::std::vec::Vec<u32>,
+    pub refetch_chunks: ::prost::alloc::vec::Vec<u32>,
     /// Chunk senders to reject and ban
     #[prost(string, repeated, tag="3")]
-    pub reject_senders: ::std::vec::Vec<std::string::String>,
+    pub reject_senders: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Nested message and enum types in `ResponseApplySnapshotChunk`.
 pub mod response_apply_snapshot_chunk {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -416,13 +421,13 @@ pub mod response_apply_snapshot_chunk {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusParams {
     #[prost(message, optional, tag="1")]
-    pub block: ::std::option::Option<BlockParams>,
+    pub block: ::core::option::Option<BlockParams>,
     #[prost(message, optional, tag="2")]
-    pub evidence: ::std::option::Option<super::types::EvidenceParams>,
+    pub evidence: ::core::option::Option<super::types::EvidenceParams>,
     #[prost(message, optional, tag="3")]
-    pub validator: ::std::option::Option<super::types::ValidatorParams>,
+    pub validator: ::core::option::Option<super::types::ValidatorParams>,
     #[prost(message, optional, tag="4")]
-    pub version: ::std::option::Option<super::types::VersionParams>,
+    pub version: ::core::option::Option<super::types::VersionParams>,
 }
 /// BlockParams contains limits on the block size.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -439,7 +444,7 @@ pub struct LastCommitInfo {
     #[prost(int32, tag="1")]
     pub round: i32,
     #[prost(message, repeated, tag="2")]
-    pub votes: ::std::vec::Vec<VoteInfo>,
+    pub votes: ::prost::alloc::vec::Vec<VoteInfo>,
 }
 /// Event allows application developers to attach additional information to
 /// ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
@@ -447,17 +452,17 @@ pub struct LastCommitInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Event {
     #[prost(string, tag="1")]
-    pub r#type: std::string::String,
+    pub r#type: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="2")]
-    pub attributes: ::std::vec::Vec<EventAttribute>,
+    pub attributes: ::prost::alloc::vec::Vec<EventAttribute>,
 }
 /// EventAttribute is a single key-value pair, associated with an event.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventAttribute {
-    #[prost(bytes, tag="1")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag="2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     /// nondeterministic
     #[prost(bool, tag="3")]
     pub index: bool,
@@ -471,10 +476,10 @@ pub struct TxResult {
     pub height: i64,
     #[prost(uint32, tag="2")]
     pub index: u32,
-    #[prost(bytes, tag="3")]
-    pub tx: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub tx: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="4")]
-    pub result: ::std::option::Option<ResponseDeliverTx>,
+    pub result: ::core::option::Option<ResponseDeliverTx>,
 }
 //----------------------------------------
 // Blockchain Types
@@ -483,8 +488,8 @@ pub struct TxResult {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Validator {
     /// The first 20 bytes of SHA256(public key)
-    #[prost(bytes, tag="1")]
-    pub address: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub address: ::prost::alloc::vec::Vec<u8>,
     /// PubKey pub_key = 2 [(gogoproto.nullable)=false];
     ///
     /// The voting power
@@ -495,7 +500,7 @@ pub struct Validator {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidatorUpdate {
     #[prost(message, optional, tag="1")]
-    pub pub_key: ::std::option::Option<super::crypto::PublicKey>,
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
     #[prost(int64, tag="2")]
     pub power: i64,
 }
@@ -503,7 +508,7 @@ pub struct ValidatorUpdate {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VoteInfo {
     #[prost(message, optional, tag="1")]
-    pub validator: ::std::option::Option<Validator>,
+    pub validator: ::core::option::Option<Validator>,
     #[prost(bool, tag="2")]
     pub signed_last_block: bool,
 }
@@ -513,13 +518,13 @@ pub struct Evidence {
     pub r#type: i32,
     /// The offending validator
     #[prost(message, optional, tag="2")]
-    pub validator: ::std::option::Option<Validator>,
+    pub validator: ::core::option::Option<Validator>,
     /// The height when the offense occurred
     #[prost(int64, tag="3")]
     pub height: i64,
     /// The corresponding time where the offense occurred
     #[prost(message, optional, tag="4")]
-    pub time: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub time: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     /// Total voting power of the validator set in case the ABCI application does
     /// not store historical validators.
     /// https://github.com/tendermint/tendermint/issues/4581
@@ -541,11 +546,11 @@ pub struct Snapshot {
     #[prost(uint32, tag="3")]
     pub chunks: u32,
     /// Arbitrary snapshot hash, equal only if identical
-    #[prost(bytes, tag="4")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
     /// Arbitrary application metadata
-    #[prost(bytes, tag="5")]
-    pub metadata: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="5")]
+    pub metadata: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/proto/src/prost/tendermint.blockchain.rs
+++ b/proto/src/prost/tendermint.blockchain.rs
@@ -14,7 +14,7 @@ pub struct NoBlockResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockResponse {
     #[prost(message, optional, tag="1")]
-    pub block: ::std::option::Option<super::types::Block>,
+    pub block: ::core::option::Option<super::types::Block>,
 }
 /// StatusRequest requests the status of a peer.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -31,8 +31,9 @@ pub struct StatusResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
     #[prost(oneof="message::Sum", tags="1, 2, 3, 4, 5")]
-    pub sum: ::std::option::Option<message::Sum>,
+    pub sum: ::core::option::Option<message::Sum>,
 }
+/// Nested message and enum types in `Message`.
 pub mod message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {

--- a/proto/src/prost/tendermint.consensus.rs
+++ b/proto/src/prost/tendermint.consensus.rs
@@ -23,9 +23,9 @@ pub struct NewValidBlock {
     #[prost(int32, tag="2")]
     pub round: i32,
     #[prost(message, optional, tag="3")]
-    pub block_part_set_header: ::std::option::Option<super::types::PartSetHeader>,
+    pub block_part_set_header: ::core::option::Option<super::types::PartSetHeader>,
     #[prost(message, optional, tag="4")]
-    pub block_parts: ::std::option::Option<super::libs::bits::BitArray>,
+    pub block_parts: ::core::option::Option<super::libs::bits::BitArray>,
     #[prost(bool, tag="5")]
     pub is_commit: bool,
 }
@@ -33,7 +33,7 @@ pub struct NewValidBlock {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proposal {
     #[prost(message, optional, tag="1")]
-    pub proposal: ::std::option::Option<super::types::Proposal>,
+    pub proposal: ::core::option::Option<super::types::Proposal>,
 }
 /// ProposalPOL is sent when a previous proposal is re-proposed.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -43,7 +43,7 @@ pub struct ProposalPol {
     #[prost(int32, tag="2")]
     pub proposal_pol_round: i32,
     #[prost(message, optional, tag="3")]
-    pub proposal_pol: ::std::option::Option<super::libs::bits::BitArray>,
+    pub proposal_pol: ::core::option::Option<super::libs::bits::BitArray>,
 }
 /// BlockPart is sent when gossipping a piece of the proposed block.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -53,13 +53,13 @@ pub struct BlockPart {
     #[prost(int32, tag="2")]
     pub round: i32,
     #[prost(message, optional, tag="3")]
-    pub part: ::std::option::Option<super::types::Part>,
+    pub part: ::core::option::Option<super::types::Part>,
 }
 /// Vote is sent when voting for a proposal (or lack thereof).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vote {
     #[prost(message, optional, tag="1")]
-    pub vote: ::std::option::Option<super::types::Vote>,
+    pub vote: ::core::option::Option<super::types::Vote>,
 }
 /// HasVote is sent to indicate that a particular vote has been received.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -83,7 +83,7 @@ pub struct VoteSetMaj23 {
     #[prost(enumeration="super::types::SignedMsgType", tag="3")]
     pub r#type: i32,
     #[prost(message, optional, tag="4")]
-    pub block_id: ::std::option::Option<super::types::BlockId>,
+    pub block_id: ::core::option::Option<super::types::BlockId>,
 }
 /// VoteSetBits is sent to communicate the bit-array of votes seen for the BlockID.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -95,15 +95,16 @@ pub struct VoteSetBits {
     #[prost(enumeration="super::types::SignedMsgType", tag="3")]
     pub r#type: i32,
     #[prost(message, optional, tag="4")]
-    pub block_id: ::std::option::Option<super::types::BlockId>,
+    pub block_id: ::core::option::Option<super::types::BlockId>,
     #[prost(message, optional, tag="5")]
-    pub votes: ::std::option::Option<super::libs::bits::BitArray>,
+    pub votes: ::core::option::Option<super::libs::bits::BitArray>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
     #[prost(oneof="message::Sum", tags="1, 2, 3, 4, 5, 6, 7, 8, 9")]
-    pub sum: ::std::option::Option<message::Sum>,
+    pub sum: ::core::option::Option<message::Sum>,
 }
+/// Nested message and enum types in `Message`.
 pub mod message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {
@@ -131,15 +132,15 @@ pub mod message {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgInfo {
     #[prost(message, optional, tag="1")]
-    pub msg: ::std::option::Option<Message>,
+    pub msg: ::core::option::Option<Message>,
     #[prost(string, tag="2")]
-    pub peer_id: std::string::String,
+    pub peer_id: ::prost::alloc::string::String,
 }
 /// TimeoutInfo internally generated messages which may update the state
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutInfo {
     #[prost(message, optional, tag="1")]
-    pub duration: ::std::option::Option<super::super::google::protobuf::Duration>,
+    pub duration: ::core::option::Option<super::super::google::protobuf::Duration>,
     #[prost(int64, tag="2")]
     pub height: i64,
     #[prost(int32, tag="3")]
@@ -157,8 +158,9 @@ pub struct EndHeight {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalMessage {
     #[prost(oneof="wal_message::Sum", tags="1, 2, 3, 4")]
-    pub sum: ::std::option::Option<wal_message::Sum>,
+    pub sum: ::core::option::Option<wal_message::Sum>,
 }
+/// Nested message and enum types in `WALMessage`.
 pub mod wal_message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {
@@ -176,7 +178,7 @@ pub mod wal_message {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimedWalMessage {
     #[prost(message, optional, tag="1")]
-    pub time: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub time: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
-    pub msg: ::std::option::Option<WalMessage>,
+    pub msg: ::core::option::Option<WalMessage>,
 }

--- a/proto/src/prost/tendermint.crypto.rs
+++ b/proto/src/prost/tendermint.crypto.rs
@@ -1,5 +1,26 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
+/// PublicKey defines the keys available for use with Tendermint Validators
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublicKey {
+    #[prost(oneof="public_key::Sum", tags="1, 2")]
+    pub sum: ::core::option::Option<public_key::Sum>,
+}
+/// Nested message and enum types in `PublicKey`.
+pub mod public_key {
+    #[derive(::serde::Deserialize, ::serde::Serialize)]
+    #[serde(tag = "type", content = "value")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(bytes, tag="1")]
+        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
+        Ed25519(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag="2")]
+        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
+        Secp256k1(::prost::alloc::vec::Vec<u8>),
+    }
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
     #[prost(int64, tag="1")]
     #[serde(with = "crate::serializers::from_str")]
@@ -7,30 +28,30 @@ pub struct Proof {
     #[prost(int64, tag="2")]
     #[serde(with = "crate::serializers::from_str")]
     pub index: i64,
-    #[prost(bytes, tag="3")]
+    #[prost(bytes="vec", tag="3")]
     #[serde(with = "crate::serializers::bytes::base64string")]
-    pub leaf_hash: std::vec::Vec<u8>,
-    #[prost(bytes, repeated, tag="4")]
+    pub leaf_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", repeated, tag="4")]
     #[serde(with = "crate::serializers::bytes::vec_base64string")]
-    pub aunts: ::std::vec::Vec<std::vec::Vec<u8>>,
+    pub aunts: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValueOp {
     /// Encoded in ProofOp.Key.
-    #[prost(bytes, tag="1")]
-    pub key: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     /// To encode in ProofOp.Data
     #[prost(message, optional, tag="2")]
-    pub proof: ::std::option::Option<Proof>,
+    pub proof: ::core::option::Option<Proof>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DominoOp {
     #[prost(string, tag="1")]
-    pub key: std::string::String,
+    pub key: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
-    pub input: std::string::String,
+    pub input: ::prost::alloc::string::String,
     #[prost(string, tag="3")]
-    pub output: std::string::String,
+    pub output: ::prost::alloc::string::String,
 }
 /// ProofOp defines an operation used for calculating Merkle root
 /// The data could be arbitrary format, providing nessecary data
@@ -38,35 +59,15 @@ pub struct DominoOp {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProofOp {
     #[prost(string, tag="1")]
-    pub r#type: std::string::String,
-    #[prost(bytes, tag="2")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag="3")]
-    pub data: std::vec::Vec<u8>,
+    pub r#type: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="2")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// ProofOps is Merkle proof defined by the list of ProofOps
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProofOps {
     #[prost(message, repeated, tag="1")]
-    pub ops: ::std::vec::Vec<ProofOp>,
-}
-/// PublicKey defines the keys available for use with Tendermint Validators
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-pub struct PublicKey {
-    #[prost(oneof="public_key::Sum", tags="1, 2")]
-    pub sum: ::std::option::Option<public_key::Sum>,
-}
-pub mod public_key {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    #[derive(::serde::Deserialize, ::serde::Serialize)]
-    #[serde(tag = "type", content = "value")]
-    pub enum Sum {
-        #[prost(bytes, tag="1")]
-        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
-        Ed25519(std::vec::Vec<u8>),
-        #[prost(bytes, tag="2")]
-        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
-        Secp256k1(std::vec::Vec<u8>),
-    }
+    pub ops: ::prost::alloc::vec::Vec<ProofOp>,
 }

--- a/proto/src/prost/tendermint.libs.bits.rs
+++ b/proto/src/prost/tendermint.libs.bits.rs
@@ -1,8 +1,8 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BitArray {
     #[prost(int64, tag="1")]
     pub bits: i64,
     #[prost(uint64, repeated, tag="2")]
-    pub elems: ::std::vec::Vec<u64>,
+    pub elems: ::prost::alloc::vec::Vec<u64>,
 }

--- a/proto/src/prost/tendermint.mempool.rs
+++ b/proto/src/prost/tendermint.mempool.rs
@@ -1,13 +1,14 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Txs {
-    #[prost(bytes, repeated, tag="1")]
-    pub txs: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes="vec", repeated, tag="1")]
+    pub txs: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
     #[prost(oneof="message::Sum", tags="1")]
-    pub sum: ::std::option::Option<message::Sum>,
+    pub sum: ::core::option::Option<message::Sum>,
 }
+/// Nested message and enum types in `Message`.
 pub mod message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {

--- a/proto/src/prost/tendermint.p2p.rs
+++ b/proto/src/prost/tendermint.p2p.rs
@@ -1,9 +1,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetAddress {
     #[prost(string, tag="1")]
-    pub id: std::string::String,
+    pub id: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
-    pub ip: std::string::String,
+    pub ip: ::prost::alloc::string::String,
     #[prost(uint32, tag="3")]
     pub port: u32,
 }
@@ -19,28 +19,51 @@ pub struct ProtocolVersion {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DefaultNodeInfo {
     #[prost(message, optional, tag="1")]
-    pub protocol_version: ::std::option::Option<ProtocolVersion>,
+    pub protocol_version: ::core::option::Option<ProtocolVersion>,
     #[prost(string, tag="2")]
-    pub default_node_id: std::string::String,
+    pub default_node_id: ::prost::alloc::string::String,
     #[prost(string, tag="3")]
-    pub listen_addr: std::string::String,
+    pub listen_addr: ::prost::alloc::string::String,
     #[prost(string, tag="4")]
-    pub network: std::string::String,
+    pub network: ::prost::alloc::string::String,
     #[prost(string, tag="5")]
-    pub version: std::string::String,
-    #[prost(bytes, tag="6")]
-    pub channels: std::vec::Vec<u8>,
+    pub version: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="6")]
+    pub channels: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag="7")]
-    pub moniker: std::string::String,
+    pub moniker: ::prost::alloc::string::String,
     #[prost(message, optional, tag="8")]
-    pub other: ::std::option::Option<DefaultNodeInfoOther>,
+    pub other: ::core::option::Option<DefaultNodeInfoOther>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DefaultNodeInfoOther {
     #[prost(string, tag="1")]
-    pub tx_index: std::string::String,
+    pub tx_index: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
-    pub rpc_address: std::string::String,
+    pub rpc_address: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexRequest {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexAddrs {
+    #[prost(message, repeated, tag="1")]
+    pub addrs: ::prost::alloc::vec::Vec<NetAddress>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Message {
+    #[prost(oneof="message::Sum", tags="1, 2")]
+    pub sum: ::core::option::Option<message::Sum>,
+}
+/// Nested message and enum types in `Message`.
+pub mod message {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(message, tag="1")]
+        PexRequest(super::PexRequest),
+        #[prost(message, tag="2")]
+        PexAddrs(super::PexAddrs),
+    }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PacketPing {
@@ -54,14 +77,15 @@ pub struct PacketMsg {
     pub channel_id: i32,
     #[prost(bool, tag="2")]
     pub eof: bool,
-    #[prost(bytes, tag="3")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Packet {
     #[prost(oneof="packet::Sum", tags="1, 2, 3")]
-    pub sum: ::std::option::Option<packet::Sum>,
+    pub sum: ::core::option::Option<packet::Sum>,
 }
+/// Nested message and enum types in `Packet`.
 pub mod packet {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {
@@ -76,29 +100,7 @@ pub mod packet {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthSigMessage {
     #[prost(message, optional, tag="1")]
-    pub pub_key: ::std::option::Option<super::crypto::PublicKey>,
-    #[prost(bytes, tag="2")]
-    pub sig: std::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexRequest {
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexAddrs {
-    #[prost(message, repeated, tag="1")]
-    pub addrs: ::std::vec::Vec<NetAddress>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Message {
-    #[prost(oneof="message::Sum", tags="1, 2")]
-    pub sum: ::std::option::Option<message::Sum>,
-}
-pub mod message {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(message, tag="1")]
-        PexRequest(super::PexRequest),
-        #[prost(message, tag="2")]
-        PexAddrs(super::PexAddrs),
-    }
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
+    #[prost(bytes="vec", tag="2")]
+    pub sig: ::prost::alloc::vec::Vec<u8>,
 }

--- a/proto/src/prost/tendermint.privval.rs
+++ b/proto/src/prost/tendermint.privval.rs
@@ -3,53 +3,53 @@ pub struct RemoteSignerError {
     #[prost(int32, tag="1")]
     pub code: i32,
     #[prost(string, tag="2")]
-    pub description: std::string::String,
+    pub description: ::prost::alloc::string::String,
 }
 /// PubKeyRequest requests the consensus public key from the remote signer.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PubKeyRequest {
     #[prost(string, tag="1")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
 }
 /// PubKeyResponse is a response message containing the public key.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PubKeyResponse {
     #[prost(message, optional, tag="1")]
-    pub pub_key: ::std::option::Option<super::crypto::PublicKey>,
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
     #[prost(message, optional, tag="2")]
-    pub error: ::std::option::Option<RemoteSignerError>,
+    pub error: ::core::option::Option<RemoteSignerError>,
 }
 /// SignVoteRequest is a request to sign a vote
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignVoteRequest {
     #[prost(message, optional, tag="1")]
-    pub vote: ::std::option::Option<super::types::Vote>,
+    pub vote: ::core::option::Option<super::types::Vote>,
     #[prost(string, tag="2")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
 }
 /// SignedVoteResponse is a response containing a signed vote or an error
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedVoteResponse {
     #[prost(message, optional, tag="1")]
-    pub vote: ::std::option::Option<super::types::Vote>,
+    pub vote: ::core::option::Option<super::types::Vote>,
     #[prost(message, optional, tag="2")]
-    pub error: ::std::option::Option<RemoteSignerError>,
+    pub error: ::core::option::Option<RemoteSignerError>,
 }
 /// SignProposalRequest is a request to sign a proposal
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignProposalRequest {
     #[prost(message, optional, tag="1")]
-    pub proposal: ::std::option::Option<super::types::Proposal>,
+    pub proposal: ::core::option::Option<super::types::Proposal>,
     #[prost(string, tag="2")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
 }
 /// SignedProposalResponse is response containing a signed proposal or an error
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedProposalResponse {
     #[prost(message, optional, tag="1")]
-    pub proposal: ::std::option::Option<super::types::Proposal>,
+    pub proposal: ::core::option::Option<super::types::Proposal>,
     #[prost(message, optional, tag="2")]
-    pub error: ::std::option::Option<RemoteSignerError>,
+    pub error: ::core::option::Option<RemoteSignerError>,
 }
 /// PingRequest is a request to confirm that the connection is alive.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -62,8 +62,9 @@ pub struct PingResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
     #[prost(oneof="message::Sum", tags="1, 2, 3, 4, 5, 6, 7, 8")]
-    pub sum: ::std::option::Option<message::Sum>,
+    pub sum: ::core::option::Option<message::Sum>,
 }
+/// Nested message and enum types in `Message`.
 pub mod message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {

--- a/proto/src/prost/tendermint.rpc.grpc.rs
+++ b/proto/src/prost/tendermint.rpc.grpc.rs
@@ -6,8 +6,8 @@ pub struct RequestPing {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestBroadcastTx {
-    #[prost(bytes, tag="1")]
-    pub tx: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub tx: ::prost::alloc::vec::Vec<u8>,
 }
 //----------------------------------------
 // Response types
@@ -18,7 +18,7 @@ pub struct ResponsePing {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseBroadcastTx {
     #[prost(message, optional, tag="1")]
-    pub check_tx: ::std::option::Option<super::super::abci::ResponseCheckTx>,
+    pub check_tx: ::core::option::Option<super::super::abci::ResponseCheckTx>,
     #[prost(message, optional, tag="2")]
-    pub deliver_tx: ::std::option::Option<super::super::abci::ResponseDeliverTx>,
+    pub deliver_tx: ::core::option::Option<super::super::abci::ResponseDeliverTx>,
 }

--- a/proto/src/prost/tendermint.state.rs
+++ b/proto/src/prost/tendermint.state.rs
@@ -4,17 +4,17 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbciResponses {
     #[prost(message, repeated, tag="1")]
-    pub deliver_txs: ::std::vec::Vec<super::abci::ResponseDeliverTx>,
+    pub deliver_txs: ::prost::alloc::vec::Vec<super::abci::ResponseDeliverTx>,
     #[prost(message, optional, tag="2")]
-    pub end_block: ::std::option::Option<super::abci::ResponseEndBlock>,
+    pub end_block: ::core::option::Option<super::abci::ResponseEndBlock>,
     #[prost(message, optional, tag="3")]
-    pub begin_block: ::std::option::Option<super::abci::ResponseBeginBlock>,
+    pub begin_block: ::core::option::Option<super::abci::ResponseBeginBlock>,
 }
 /// ValidatorsInfo represents the latest validator set, or the last height it changed
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidatorsInfo {
     #[prost(message, optional, tag="1")]
-    pub validator_set: ::std::option::Option<super::types::ValidatorSet>,
+    pub validator_set: ::core::option::Option<super::types::ValidatorSet>,
     #[prost(int64, tag="2")]
     pub last_height_changed: i64,
 }
@@ -22,33 +22,33 @@ pub struct ValidatorsInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusParamsInfo {
     #[prost(message, optional, tag="1")]
-    pub consensus_params: ::std::option::Option<super::types::ConsensusParams>,
+    pub consensus_params: ::core::option::Option<super::types::ConsensusParams>,
     #[prost(int64, tag="2")]
     pub last_height_changed: i64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Version {
     #[prost(message, optional, tag="1")]
-    pub consensus: ::std::option::Option<super::version::Consensus>,
+    pub consensus: ::core::option::Option<super::version::Consensus>,
     #[prost(string, tag="2")]
-    pub software: std::string::String,
+    pub software: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct State {
     #[prost(message, optional, tag="1")]
-    pub version: ::std::option::Option<Version>,
+    pub version: ::core::option::Option<Version>,
     /// immutable
     #[prost(string, tag="2")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
     #[prost(int64, tag="14")]
     pub initial_height: i64,
     /// LastBlockHeight=0 at genesis (ie. block(H=0) does not exist)
     #[prost(int64, tag="3")]
     pub last_block_height: i64,
     #[prost(message, optional, tag="4")]
-    pub last_block_id: ::std::option::Option<super::types::BlockId>,
+    pub last_block_id: ::core::option::Option<super::types::BlockId>,
     #[prost(message, optional, tag="5")]
-    pub last_block_time: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub last_block_time: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     /// LastValidators is used to validate block.LastCommit.
     /// Validators are persisted to the database separately every time they change,
     /// so we can query for historical validator sets.
@@ -56,23 +56,23 @@ pub struct State {
     /// we set s.LastHeightValidatorsChanged = s.LastBlockHeight + 1 + 1
     /// Extra +1 due to nextValSet delay.
     #[prost(message, optional, tag="6")]
-    pub next_validators: ::std::option::Option<super::types::ValidatorSet>,
+    pub next_validators: ::core::option::Option<super::types::ValidatorSet>,
     #[prost(message, optional, tag="7")]
-    pub validators: ::std::option::Option<super::types::ValidatorSet>,
+    pub validators: ::core::option::Option<super::types::ValidatorSet>,
     #[prost(message, optional, tag="8")]
-    pub last_validators: ::std::option::Option<super::types::ValidatorSet>,
+    pub last_validators: ::core::option::Option<super::types::ValidatorSet>,
     #[prost(int64, tag="9")]
     pub last_height_validators_changed: i64,
     /// Consensus parameters used for validating blocks.
     /// Changes returned by EndBlock and updated after Commit.
     #[prost(message, optional, tag="10")]
-    pub consensus_params: ::std::option::Option<super::types::ConsensusParams>,
+    pub consensus_params: ::core::option::Option<super::types::ConsensusParams>,
     #[prost(int64, tag="11")]
     pub last_height_consensus_params_changed: i64,
     /// Merkle root of the results from executing prev block
-    #[prost(bytes, tag="12")]
-    pub last_results_hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="12")]
+    pub last_results_hash: ::prost::alloc::vec::Vec<u8>,
     /// the latest AppHash we've received from calling abci.Commit()
-    #[prost(bytes, tag="13")]
-    pub app_hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="13")]
+    pub app_hash: ::prost::alloc::vec::Vec<u8>,
 }

--- a/proto/src/prost/tendermint.statesync.rs
+++ b/proto/src/prost/tendermint.statesync.rs
@@ -1,8 +1,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
     #[prost(oneof="message::Sum", tags="1, 2, 3, 4")]
-    pub sum: ::std::option::Option<message::Sum>,
+    pub sum: ::core::option::Option<message::Sum>,
 }
+/// Nested message and enum types in `Message`.
 pub mod message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {
@@ -27,10 +28,10 @@ pub struct SnapshotsResponse {
     pub format: u32,
     #[prost(uint32, tag="3")]
     pub chunks: u32,
-    #[prost(bytes, tag="4")]
-    pub hash: std::vec::Vec<u8>,
-    #[prost(bytes, tag="5")]
-    pub metadata: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="5")]
+    pub metadata: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChunkRequest {
@@ -49,8 +50,8 @@ pub struct ChunkResponse {
     pub format: u32,
     #[prost(uint32, tag="3")]
     pub index: u32,
-    #[prost(bytes, tag="4")]
-    pub chunk: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub chunk: ::prost::alloc::vec::Vec<u8>,
     #[prost(bool, tag="5")]
     pub missing: bool,
 }

--- a/proto/src/prost/tendermint.types.rs
+++ b/proto/src/prost/tendermint.types.rs
@@ -1,21 +1,21 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidatorSet {
     #[prost(message, repeated, tag="1")]
-    pub validators: ::std::vec::Vec<Validator>,
+    pub validators: ::prost::alloc::vec::Vec<Validator>,
     #[prost(message, optional, tag="2")]
-    pub proposer: ::std::option::Option<Validator>,
+    pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag="3")]
     pub total_voting_power: i64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Validator {
-    #[prost(bytes, tag="1")]
+    #[prost(bytes="vec", tag="1")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub address: std::vec::Vec<u8>,
+    pub address: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="2")]
-    pub pub_key: ::std::option::Option<super::crypto::PublicKey>,
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
     #[prost(int64, tag="3")]
     #[serde(alias = "power", with = "crate::serializers::from_str")]
     pub voting_power: i64,
@@ -26,119 +26,119 @@ pub struct Validator {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimpleValidator {
     #[prost(message, optional, tag="1")]
-    pub pub_key: ::std::option::Option<super::crypto::PublicKey>,
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
     #[prost(int64, tag="2")]
     pub voting_power: i64,
 }
 /// PartsetHeader
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartSetHeader {
     #[prost(uint32, tag="1")]
     #[serde(with = "crate::serializers::part_set_header_total")]
     pub total: u32,
-    #[prost(bytes, tag="2")]
+    #[prost(bytes="vec", tag="2")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub hash: std::vec::Vec<u8>,
+    pub hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Part {
     #[prost(uint32, tag="1")]
     pub index: u32,
-    #[prost(bytes, tag="2")]
-    pub bytes: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub bytes: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="3")]
-    pub proof: ::std::option::Option<super::crypto::Proof>,
+    pub proof: ::core::option::Option<super::crypto::Proof>,
 }
 /// BlockID
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockId {
-    #[prost(bytes, tag="1")]
+    #[prost(bytes="vec", tag="1")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub hash: std::vec::Vec<u8>,
+    pub hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="2")]
     #[serde(alias = "parts")]
-    pub part_set_header: ::std::option::Option<PartSetHeader>,
+    pub part_set_header: ::core::option::Option<PartSetHeader>,
 }
 // --------------------------------
 
 /// Header defines the structure of a Tendermint block header.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Header {
     /// basic block info
     #[prost(message, optional, tag="1")]
-    pub version: ::std::option::Option<super::version::Consensus>,
+    pub version: ::core::option::Option<super::version::Consensus>,
     #[prost(string, tag="2")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
     #[prost(int64, tag="3")]
     #[serde(with = "crate::serializers::from_str")]
     pub height: i64,
     #[prost(message, optional, tag="4")]
     #[serde(with = "crate::serializers::optional")]
-    pub time: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub time: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     /// prev block info
     #[prost(message, optional, tag="5")]
-    pub last_block_id: ::std::option::Option<BlockId>,
+    pub last_block_id: ::core::option::Option<BlockId>,
     /// hashes of block data
     ///
     /// commit from validators from the last block
-    #[prost(bytes, tag="6")]
+    #[prost(bytes="vec", tag="6")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub last_commit_hash: std::vec::Vec<u8>,
+    pub last_commit_hash: ::prost::alloc::vec::Vec<u8>,
     /// transactions
-    #[prost(bytes, tag="7")]
+    #[prost(bytes="vec", tag="7")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub data_hash: std::vec::Vec<u8>,
+    pub data_hash: ::prost::alloc::vec::Vec<u8>,
     /// hashes from the app output from the prev block
     ///
     /// validators for the current block
-    #[prost(bytes, tag="8")]
+    #[prost(bytes="vec", tag="8")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub validators_hash: std::vec::Vec<u8>,
+    pub validators_hash: ::prost::alloc::vec::Vec<u8>,
     /// validators for the next block
-    #[prost(bytes, tag="9")]
+    #[prost(bytes="vec", tag="9")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub next_validators_hash: std::vec::Vec<u8>,
+    pub next_validators_hash: ::prost::alloc::vec::Vec<u8>,
     /// consensus params for current block
-    #[prost(bytes, tag="10")]
+    #[prost(bytes="vec", tag="10")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub consensus_hash: std::vec::Vec<u8>,
+    pub consensus_hash: ::prost::alloc::vec::Vec<u8>,
     /// state after txs from the previous block
-    #[prost(bytes, tag="11")]
+    #[prost(bytes="vec", tag="11")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub app_hash: std::vec::Vec<u8>,
+    pub app_hash: ::prost::alloc::vec::Vec<u8>,
     /// root hash of all results from the txs from the previous block
-    #[prost(bytes, tag="12")]
+    #[prost(bytes="vec", tag="12")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub last_results_hash: std::vec::Vec<u8>,
+    pub last_results_hash: ::prost::alloc::vec::Vec<u8>,
     /// consensus info
     ///
     /// evidence included in the block
-    #[prost(bytes, tag="13")]
+    #[prost(bytes="vec", tag="13")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub evidence_hash: std::vec::Vec<u8>,
+    pub evidence_hash: ::prost::alloc::vec::Vec<u8>,
     /// original proposer of the block
-    #[prost(bytes, tag="14")]
+    #[prost(bytes="vec", tag="14")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub proposer_address: std::vec::Vec<u8>,
+    pub proposer_address: ::prost::alloc::vec::Vec<u8>,
 }
 /// Data contains the set of transactions included in the block
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Data {
     /// Txs that will be applied by state @ block.Height+1.
     /// NOTE: not all txs here are valid.  We're just agreeing on the order first.
     /// This means that block.AppHash does not include these txs.
-    #[prost(bytes, repeated, tag="1")]
+    #[prost(bytes="vec", repeated, tag="1")]
     #[serde(with = "crate::serializers::txs")]
-    pub txs: ::std::vec::Vec<std::vec::Vec<u8>>,
+    pub txs: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// Vote represents a prevote, precommit, or commit vote from validators for
 /// consensus.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vote {
     #[prost(enumeration="SignedMsgType", tag="1")]
     pub r#type: i32,
@@ -150,23 +150,23 @@ pub struct Vote {
     pub round: i32,
     /// zero if vote is nil.
     #[prost(message, optional, tag="4")]
-    pub block_id: ::std::option::Option<BlockId>,
+    pub block_id: ::core::option::Option<BlockId>,
     #[prost(message, optional, tag="5")]
     #[serde(with = "crate::serializers::optional")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(bytes, tag="6")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(bytes="vec", tag="6")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub validator_address: std::vec::Vec<u8>,
+    pub validator_address: ::prost::alloc::vec::Vec<u8>,
     #[prost(int32, tag="7")]
     #[serde(with = "crate::serializers::from_str")]
     pub validator_index: i32,
-    #[prost(bytes, tag="8")]
+    #[prost(bytes="vec", tag="8")]
     #[serde(with = "crate::serializers::bytes::base64string")]
-    pub signature: std::vec::Vec<u8>,
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commit contains the evidence that a block was committed by a set of validators.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commit {
     #[prost(int64, tag="1")]
     #[serde(with = "crate::serializers::from_str")]
@@ -174,26 +174,26 @@ pub struct Commit {
     #[prost(int32, tag="2")]
     pub round: i32,
     #[prost(message, optional, tag="3")]
-    pub block_id: ::std::option::Option<BlockId>,
+    pub block_id: ::core::option::Option<BlockId>,
     #[prost(message, repeated, tag="4")]
     #[serde(with = "crate::serializers::nullable")]
-    pub signatures: ::std::vec::Vec<CommitSig>,
+    pub signatures: ::prost::alloc::vec::Vec<CommitSig>,
 }
 /// CommitSig is a part of the Vote included in a Commit.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommitSig {
     #[prost(enumeration="BlockIdFlag", tag="1")]
     pub block_id_flag: i32,
-    #[prost(bytes, tag="2")]
+    #[prost(bytes="vec", tag="2")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub validator_address: std::vec::Vec<u8>,
+    pub validator_address: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="3")]
     #[serde(with = "crate::serializers::optional")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(bytes, tag="4")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(bytes="vec", tag="4")]
     #[serde(with = "crate::serializers::bytes::base64string")]
-    pub signature: std::vec::Vec<u8>,
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proposal {
@@ -206,59 +206,59 @@ pub struct Proposal {
     #[prost(int32, tag="4")]
     pub pol_round: i32,
     #[prost(message, optional, tag="5")]
-    pub block_id: ::std::option::Option<BlockId>,
+    pub block_id: ::core::option::Option<BlockId>,
     #[prost(message, optional, tag="6")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(bytes, tag="7")]
-    pub signature: std::vec::Vec<u8>,
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(bytes="vec", tag="7")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedHeader {
     #[prost(message, optional, tag="1")]
-    pub header: ::std::option::Option<Header>,
+    pub header: ::core::option::Option<Header>,
     #[prost(message, optional, tag="2")]
-    pub commit: ::std::option::Option<Commit>,
+    pub commit: ::core::option::Option<Commit>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LightBlock {
     #[prost(message, optional, tag="1")]
-    pub signed_header: ::std::option::Option<SignedHeader>,
+    pub signed_header: ::core::option::Option<SignedHeader>,
     #[prost(message, optional, tag="2")]
-    pub validator_set: ::std::option::Option<ValidatorSet>,
+    pub validator_set: ::core::option::Option<ValidatorSet>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockMeta {
     #[prost(message, optional, tag="1")]
-    pub block_id: ::std::option::Option<BlockId>,
+    pub block_id: ::core::option::Option<BlockId>,
     #[prost(int64, tag="2")]
     #[serde(with = "crate::serializers::from_str")]
     pub block_size: i64,
     #[prost(message, optional, tag="3")]
-    pub header: ::std::option::Option<Header>,
+    pub header: ::core::option::Option<Header>,
     #[prost(int64, tag="4")]
     #[serde(with = "crate::serializers::from_str")]
     pub num_txs: i64,
 }
 /// TxProof represents a Merkle proof of the presence of a transaction in the Merkle tree.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxProof {
-    #[prost(bytes, tag="1")]
+    #[prost(bytes="vec", tag="1")]
     #[serde(with = "crate::serializers::bytes::hexstring")]
-    pub root_hash: std::vec::Vec<u8>,
-    #[prost(bytes, tag="2")]
+    pub root_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
     #[serde(with = "crate::serializers::bytes::base64string")]
-    pub data: std::vec::Vec<u8>,
+    pub data: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="3")]
-    pub proof: ::std::option::Option<super::crypto::Proof>,
+    pub proof: ::core::option::Option<super::crypto::Proof>,
 }
 /// BlockIdFlag indicates which BlcokID the signature is for
+#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]
 pub enum BlockIdFlag {
     Unknown = 0,
     Absent = 1,
@@ -276,6 +276,62 @@ pub enum SignedMsgType {
     /// Proposals
     Proposal = 32,
 }
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalBlockId {
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    #[serde(alias = "parts")]
+    pub part_set_header: ::core::option::Option<CanonicalPartSetHeader>,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalPartSetHeader {
+    #[prost(uint32, tag="1")]
+    pub total: u32,
+    #[prost(bytes="vec", tag="2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalProposal {
+    /// type alias for byte
+    #[prost(enumeration="SignedMsgType", tag="1")]
+    pub r#type: i32,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="2")]
+    pub height: i64,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="3")]
+    pub round: i64,
+    #[prost(int64, tag="4")]
+    pub pol_round: i64,
+    #[prost(message, optional, tag="5")]
+    pub block_id: ::core::option::Option<CanonicalBlockId>,
+    #[prost(message, optional, tag="6")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="7")]
+    pub chain_id: ::prost::alloc::string::String,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalVote {
+    /// type alias for byte
+    #[prost(enumeration="SignedMsgType", tag="1")]
+    pub r#type: i32,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="2")]
+    pub height: i64,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="3")]
+    pub round: i64,
+    #[prost(message, optional, tag="4")]
+    pub block_id: ::core::option::Option<CanonicalBlockId>,
+    #[prost(message, optional, tag="5")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="6")]
+    pub chain_id: ::prost::alloc::string::String,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventDataRoundState {
     #[prost(int64, tag="1")]
@@ -283,20 +339,20 @@ pub struct EventDataRoundState {
     #[prost(int32, tag="2")]
     pub round: i32,
     #[prost(string, tag="3")]
-    pub step: std::string::String,
+    pub step: ::prost::alloc::string::String,
 }
 /// ConsensusParams contains consensus critical parameters that determine the
 /// validity of blocks.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusParams {
     #[prost(message, optional, tag="1")]
-    pub block: ::std::option::Option<BlockParams>,
+    pub block: ::core::option::Option<BlockParams>,
     #[prost(message, optional, tag="2")]
-    pub evidence: ::std::option::Option<EvidenceParams>,
+    pub evidence: ::core::option::Option<EvidenceParams>,
     #[prost(message, optional, tag="3")]
-    pub validator: ::std::option::Option<ValidatorParams>,
+    pub validator: ::core::option::Option<ValidatorParams>,
     #[prost(message, optional, tag="4")]
-    pub version: ::std::option::Option<VersionParams>,
+    pub version: ::core::option::Option<VersionParams>,
 }
 /// BlockParams contains limits on the block size.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -317,8 +373,8 @@ pub struct BlockParams {
     pub time_iota_ms: i64,
 }
 /// EvidenceParams determine how we handle evidence of malfeasance.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvidenceParams {
     /// Max age of evidence, in blocks.
     ///
@@ -332,7 +388,7 @@ pub struct EvidenceParams {
     /// mechanism for handling [Nothing-At-Stake
     /// attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
     #[prost(message, optional, tag="2")]
-    pub max_age_duration: ::std::option::Option<super::super::google::protobuf::Duration>,
+    pub max_age_duration: ::core::option::Option<super::super::google::protobuf::Duration>,
     /// This sets the maximum size of total evidence in bytes that can be committed in a single block.
     /// and should fall comfortably under the max block bytes.
     /// Default is 1048576 or 1MB
@@ -345,7 +401,7 @@ pub struct EvidenceParams {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidatorParams {
     #[prost(string, repeated, tag="1")]
-    pub pub_key_types: ::std::vec::Vec<std::string::String>,
+    pub pub_key_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// VersionParams contains the ABCI application version.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -363,18 +419,19 @@ pub struct HashedParams {
     #[prost(int64, tag="2")]
     pub block_max_gas: i64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Evidence {
     #[prost(oneof="evidence::Sum", tags="1, 2")]
-    pub sum: ::std::option::Option<evidence::Sum>,
+    pub sum: ::core::option::Option<evidence::Sum>,
 }
+/// Nested message and enum types in `Evidence`.
 pub mod evidence {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
     #[derive(::serde::Deserialize, ::serde::Serialize)]
     #[serde(tag = "type", content = "value")]
     #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {
         #[prost(message, tag="1")]
         #[serde(rename = "tendermint/DuplicateVoteEvidence")]
@@ -385,107 +442,51 @@ pub mod evidence {
     }
 }
 /// DuplicateVoteEvidence contains evidence of a validator signed two conflicting votes.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DuplicateVoteEvidence {
     #[prost(message, optional, tag="1")]
-    pub vote_a: ::std::option::Option<Vote>,
+    pub vote_a: ::core::option::Option<Vote>,
     #[prost(message, optional, tag="2")]
-    pub vote_b: ::std::option::Option<Vote>,
+    pub vote_b: ::core::option::Option<Vote>,
     #[prost(int64, tag="3")]
     pub total_voting_power: i64,
     #[prost(int64, tag="4")]
     pub validator_power: i64,
     #[prost(message, optional, tag="5")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
 }
 /// LightClientAttackEvidence contains evidence of a set of validators attempting to mislead a light client.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LightClientAttackEvidence {
     #[prost(message, optional, tag="1")]
-    pub conflicting_block: ::std::option::Option<LightBlock>,
+    pub conflicting_block: ::core::option::Option<LightBlock>,
     #[prost(int64, tag="2")]
     pub common_height: i64,
     #[prost(message, repeated, tag="3")]
-    pub byzantine_validators: ::std::vec::Vec<Validator>,
+    pub byzantine_validators: ::prost::alloc::vec::Vec<Validator>,
     #[prost(int64, tag="4")]
     pub total_voting_power: i64,
     #[prost(message, optional, tag="5")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvidenceList {
     #[prost(message, repeated, tag="1")]
     #[serde(with = "crate::serializers::nullable")]
-    pub evidence: ::std::vec::Vec<Evidence>,
+    pub evidence: ::prost::alloc::vec::Vec<Evidence>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
-pub struct CanonicalBlockId {
-    #[prost(bytes, tag="1")]
-    pub hash: std::vec::Vec<u8>,
-    #[prost(message, optional, tag="2")]
-    #[serde(alias = "parts")]
-    pub part_set_header: ::std::option::Option<CanonicalPartSetHeader>,
-}
 #[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-pub struct CanonicalPartSetHeader {
-    #[prost(uint32, tag="1")]
-    pub total: u32,
-    #[prost(bytes, tag="2")]
-    pub hash: std::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalProposal {
-    /// type alias for byte
-    #[prost(enumeration="SignedMsgType", tag="1")]
-    pub r#type: i32,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="2")]
-    pub height: i64,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="3")]
-    pub round: i64,
-    #[prost(int64, tag="4")]
-    pub pol_round: i64,
-    #[prost(message, optional, tag="5")]
-    pub block_id: ::std::option::Option<CanonicalBlockId>,
-    #[prost(message, optional, tag="6")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="7")]
-    pub chain_id: std::string::String,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-pub struct CanonicalVote {
-    /// type alias for byte
-    #[prost(enumeration="SignedMsgType", tag="1")]
-    pub r#type: i32,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="2")]
-    pub height: i64,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="3")]
-    pub round: i64,
-    #[prost(message, optional, tag="4")]
-    pub block_id: ::std::option::Option<CanonicalBlockId>,
-    #[prost(message, optional, tag="5")]
-    pub timestamp: ::std::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="6")]
-    pub chain_id: std::string::String,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(::serde::Deserialize, ::serde::Serialize)]
 pub struct Block {
     #[prost(message, optional, tag="1")]
-    pub header: ::std::option::Option<Header>,
+    pub header: ::core::option::Option<Header>,
     #[prost(message, optional, tag="2")]
-    pub data: ::std::option::Option<Data>,
+    pub data: ::core::option::Option<Data>,
     #[prost(message, optional, tag="3")]
-    pub evidence: ::std::option::Option<EvidenceList>,
+    pub evidence: ::core::option::Option<EvidenceList>,
     #[prost(message, optional, tag="4")]
-    pub last_commit: ::std::option::Option<Commit>,
+    pub last_commit: ::core::option::Option<Commit>,
 }

--- a/proto/src/prost/tendermint.version.rs
+++ b/proto/src/prost/tendermint.version.rs
@@ -6,13 +6,13 @@ pub struct App {
     #[prost(uint64, tag="1")]
     pub protocol: u64,
     #[prost(string, tag="2")]
-    pub software: std::string::String,
+    pub software: ::prost::alloc::string::String,
 }
 /// Consensus captures the consensus rules for processing a block in the blockchain,
 /// including all blockchain data structures and the rules of the application's
 /// state transition machine.
-#[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Consensus {
     #[prost(uint64, tag="1")]
     #[serde(with = "crate::serializers::from_str")]

--- a/proto/src/tendermint.rs
+++ b/proto/src/tendermint.rs
@@ -1,57 +1,15 @@
 //! Tendermint-proto auto-generated sub-modules for Tendermint
 
-pub mod statesync {
-    include!("prost/tendermint.statesync.rs");
-}
-
-pub mod abci {
-    include!("prost/tendermint.abci.rs");
-}
-
-pub mod store {
-    include!("prost/tendermint.store.rs");
-}
-
-pub mod version {
-    include!("prost/tendermint.version.rs");
+pub mod consensus {
+    include!("prost/tendermint.consensus.rs");
 }
 
 pub mod types {
     include!("prost/tendermint.types.rs");
 }
 
-pub mod consensus {
-    include!("prost/tendermint.consensus.rs");
-}
-
-pub mod p2p {
-    include!("prost/tendermint.p2p.rs");
-}
-
-pub mod privval {
-    include!("prost/tendermint.privval.rs");
-}
-
-pub mod blockchain {
-    include!("prost/tendermint.blockchain.rs");
-}
-
-pub mod crypto {
-    include!("prost/tendermint.crypto.rs");
-}
-
 pub mod mempool {
     include!("prost/tendermint.mempool.rs");
-}
-
-pub mod state {
-    include!("prost/tendermint.state.rs");
-}
-
-pub mod libs {
-    pub mod bits {
-        include!("prost/tendermint.libs.bits.rs");
-    }
 }
 
 pub mod rpc {
@@ -60,7 +18,49 @@ pub mod rpc {
     }
 }
 
+pub mod blockchain {
+    include!("prost/tendermint.blockchain.rs");
+}
+
+pub mod libs {
+    pub mod bits {
+        include!("prost/tendermint.libs.bits.rs");
+    }
+}
+
+pub mod state {
+    include!("prost/tendermint.state.rs");
+}
+
+pub mod version {
+    include!("prost/tendermint.version.rs");
+}
+
+pub mod store {
+    include!("prost/tendermint.store.rs");
+}
+
+pub mod privval {
+    include!("prost/tendermint.privval.rs");
+}
+
+pub mod statesync {
+    include!("prost/tendermint.statesync.rs");
+}
+
+pub mod p2p {
+    include!("prost/tendermint.p2p.rs");
+}
+
+pub mod abci {
+    include!("prost/tendermint.abci.rs");
+}
+
+pub mod crypto {
+    include!("prost/tendermint.crypto.rs");
+}
+
 pub mod meta {
     pub const REPOSITORY: &str = "https://github.com/tendermint/tendermint";
-    pub const COMMITISH: &str = "v0.34.0";
+    pub const COMMITISH: &str = "v0.34.9";
 }

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -6,7 +6,7 @@ pub const TENDERMINT_REPO: &str = "https://github.com/tendermint/tendermint";
 // Tag: v0.34.0-rc4
 // Branch: master
 // Commit ID (full length): d7d0ffea13c60c98b812d243ba5a2c375f341c15
-pub const TENDERMINT_COMMITISH: &str = "v0.34.0";
+pub const TENDERMINT_COMMITISH: &str = "v0.34.9";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;
@@ -140,7 +140,10 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.types.BlockMeta.block_size", QUOTED),
     (".tendermint.types.BlockMeta.num_txs", QUOTED),
     (".tendermint.crypto.PublicKey.sum.ed25519", RENAME_EDPUBKEY),
-    (".tendermint.crypto.PublicKey.sum.secp256k1", RENAME_SECPPUBKEY),
+    (
+        ".tendermint.crypto.PublicKey.sum.secp256k1",
+        RENAME_SECPPUBKEY,
+    ),
     (
         ".tendermint.types.Evidence.sum.duplicate_vote_evidence",
         RENAME_DUPLICATEVOTE,


### PR DESCRIPTION
Closes #871 

Additionally just updates `tendermint-rs` to ensure compatibility with the latest released version of Gaia. I've given the (automatically produced) changes a once-over and it doesn't look like there are any meaningful changes.

If so, then this PR effectively just reduces the noise for any future rebuilds of the serialization types to make those changes easier to see.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
