### PR TITLE
Add equality/ordering/hash trait bounds to RPC URL types

### DIFF
--- a/.changelog/unreleased/improvements/919-rpc-url-bounds.md
+++ b/.changelog/unreleased/improvements/919-rpc-url-bounds.md
@@ -1,0 +1,3 @@
+* `[tendermint-rpc]` Add `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` trait
+  bounds to the RPC URL types
+  ([#919](https://github.com/informalsystems/tendermint-rs/issues/919))

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -92,7 +92,7 @@ impl Client for HttpClient {
 /// A URL limited to use with HTTP clients.
 ///
 /// Facilitates useful type conversions and inferences.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HttpClientUrl(Url);
 
 impl TryFrom<Url> for HttpClientUrl {

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -143,6 +143,12 @@ impl TryFrom<net::Address> for HttpClientUrl {
     }
 }
 
+impl From<HttpClientUrl> for Url {
+    fn from(url: HttpClientUrl) -> Self {
+        url.0
+    }
+}
+
 impl TryFrom<HttpClientUrl> for hyper::Uri {
     type Error = Error;
 

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -172,7 +172,7 @@ impl SubscriptionClient for WebSocketClient {
 /// A URL limited to use with WebSocket clients.
 ///
 /// Facilitates useful type conversions and inferences.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WebSocketClientUrl(Url);
 
 impl TryFrom<Url> for WebSocketClientUrl {

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -223,6 +223,12 @@ impl TryFrom<net::Address> for WebSocketClientUrl {
     }
 }
 
+impl From<WebSocketClientUrl> for Url {
+    fn from(url: WebSocketClientUrl) -> Self {
+        url.0
+    }
+}
+
 mod sealed {
     use super::{
         DriverCommand, SimpleRequestCommand, SubscribeCommand, UnsubscribeCommand,

--- a/rpc/src/rpc_url.rs
+++ b/rpc/src/rpc_url.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// The various schemes supported by Tendermint RPC clients.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Scheme {
     Http,
     Https,
@@ -50,7 +50,7 @@ impl FromStr for Scheme {
 ///
 /// Re-implements relevant parts of [`url::Url`]'s interface with convenience
 /// mechanisms for transformation to/from other types.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Url {
     inner: url::Url,
     scheme: Scheme,


### PR DESCRIPTION
Closes #919 

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
