### PR TITLE
Update prost version for proto-compiler

### DIFF
--- a/proto/src/prost/tendermint.crypto.rs
+++ b/proto/src/prost/tendermint.crypto.rs
@@ -1,3 +1,23 @@
+/// PublicKey defines the keys available for use with Tendermint Validators
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublicKey {
+    #[prost(oneof="public_key::Sum", tags="1, 2")]
+    pub sum: ::core::option::Option<public_key::Sum>,
+}
+/// Nested message and enum types in `PublicKey`.
+pub mod public_key {
+    #[serde(tag = "type", content = "value")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(bytes, tag="1")]
+        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
+        Ed25519(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag="2")]
+        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
+        Secp256k1(::prost::alloc::vec::Vec<u8>),
+    }
+}
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
@@ -49,25 +69,4 @@ pub struct ProofOp {
 pub struct ProofOps {
     #[prost(message, repeated, tag="1")]
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
-}
-/// PublicKey defines the keys available for use with Tendermint Validators
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PublicKey {
-    #[prost(oneof="public_key::Sum", tags="1, 2")]
-    pub sum: ::core::option::Option<public_key::Sum>,
-}
-/// Nested message and enum types in `PublicKey`.
-pub mod public_key {
-    #[derive(::serde::Deserialize, ::serde::Serialize)]
-    #[serde(tag = "type", content = "value")]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(bytes, tag="1")]
-        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
-        Ed25519(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag="2")]
-        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
-        Secp256k1(::prost::alloc::vec::Vec<u8>),
-    }
 }

--- a/proto/src/prost/tendermint.p2p.rs
+++ b/proto/src/prost/tendermint.p2p.rs
@@ -43,6 +43,29 @@ pub struct DefaultNodeInfoOther {
     pub rpc_address: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexRequest {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexAddrs {
+    #[prost(message, repeated, tag="1")]
+    pub addrs: ::prost::alloc::vec::Vec<NetAddress>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Message {
+    #[prost(oneof="message::Sum", tags="1, 2")]
+    pub sum: ::core::option::Option<message::Sum>,
+}
+/// Nested message and enum types in `Message`.
+pub mod message {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(message, tag="1")]
+        PexRequest(super::PexRequest),
+        #[prost(message, tag="2")]
+        PexAddrs(super::PexAddrs),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PacketPing {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -80,27 +103,4 @@ pub struct AuthSigMessage {
     pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
     #[prost(bytes="vec", tag="2")]
     pub sig: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexRequest {
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexAddrs {
-    #[prost(message, repeated, tag="1")]
-    pub addrs: ::prost::alloc::vec::Vec<NetAddress>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Message {
-    #[prost(oneof="message::Sum", tags="1, 2")]
-    pub sum: ::core::option::Option<message::Sum>,
-}
-/// Nested message and enum types in `Message`.
-pub mod message {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(message, tag="1")]
-        PexRequest(super::PexRequest),
-        #[prost(message, tag="2")]
-        PexAddrs(super::PexAddrs),
-    }
 }

--- a/proto/src/prost/tendermint.types.rs
+++ b/proto/src/prost/tendermint.types.rs
@@ -276,6 +276,62 @@ pub enum SignedMsgType {
     /// Proposals
     Proposal = 32,
 }
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalBlockId {
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    #[serde(alias = "parts")]
+    pub part_set_header: ::core::option::Option<CanonicalPartSetHeader>,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalPartSetHeader {
+    #[prost(uint32, tag="1")]
+    pub total: u32,
+    #[prost(bytes="vec", tag="2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalProposal {
+    /// type alias for byte
+    #[prost(enumeration="SignedMsgType", tag="1")]
+    pub r#type: i32,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="2")]
+    pub height: i64,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="3")]
+    pub round: i64,
+    #[prost(int64, tag="4")]
+    pub pol_round: i64,
+    #[prost(message, optional, tag="5")]
+    pub block_id: ::core::option::Option<CanonicalBlockId>,
+    #[prost(message, optional, tag="6")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="7")]
+    pub chain_id: ::prost::alloc::string::String,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalVote {
+    /// type alias for byte
+    #[prost(enumeration="SignedMsgType", tag="1")]
+    pub r#type: i32,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="2")]
+    pub height: i64,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="3")]
+    pub round: i64,
+    #[prost(message, optional, tag="4")]
+    pub block_id: ::core::option::Option<CanonicalBlockId>,
+    #[prost(message, optional, tag="5")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="6")]
+    pub chain_id: ::prost::alloc::string::String,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventDataRoundState {
     #[prost(int64, tag="1")]
@@ -363,7 +419,6 @@ pub struct HashedParams {
     #[prost(int64, tag="2")]
     pub block_max_gas: i64,
 }
-#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Evidence {
@@ -372,9 +427,7 @@ pub struct Evidence {
 }
 /// Nested message and enum types in `Evidence`.
 pub mod evidence {
-    #[derive(::serde::Deserialize, ::serde::Serialize)]
     #[serde(tag = "type", content = "value")]
-    #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Sum {
         #[prost(message, tag="1")]
@@ -421,62 +474,6 @@ pub struct EvidenceList {
     #[prost(message, repeated, tag="1")]
     #[serde(with = "crate::serializers::nullable")]
     pub evidence: ::prost::alloc::vec::Vec<Evidence>,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalBlockId {
-    #[prost(bytes="vec", tag="1")]
-    pub hash: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="2")]
-    #[serde(alias = "parts")]
-    pub part_set_header: ::core::option::Option<CanonicalPartSetHeader>,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalPartSetHeader {
-    #[prost(uint32, tag="1")]
-    pub total: u32,
-    #[prost(bytes="vec", tag="2")]
-    pub hash: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalProposal {
-    /// type alias for byte
-    #[prost(enumeration="SignedMsgType", tag="1")]
-    pub r#type: i32,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="2")]
-    pub height: i64,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="3")]
-    pub round: i64,
-    #[prost(int64, tag="4")]
-    pub pol_round: i64,
-    #[prost(message, optional, tag="5")]
-    pub block_id: ::core::option::Option<CanonicalBlockId>,
-    #[prost(message, optional, tag="6")]
-    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="7")]
-    pub chain_id: ::prost::alloc::string::String,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalVote {
-    /// type alias for byte
-    #[prost(enumeration="SignedMsgType", tag="1")]
-    pub r#type: i32,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="2")]
-    pub height: i64,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="3")]
-    pub round: i64,
-    #[prost(message, optional, tag="4")]
-    pub block_id: ::core::option::Option<CanonicalBlockId>,
-    #[prost(message, optional, tag="5")]
-    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="6")]
-    pub chain_id: ::prost::alloc::string::String,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/tendermint.rs
+++ b/proto/src/tendermint.rs
@@ -1,51 +1,25 @@
 //! Tendermint-proto auto-generated sub-modules for Tendermint
 
-pub mod statesync {
-    include!("prost/tendermint.statesync.rs");
-}
-
-pub mod abci {
-    include!("prost/tendermint.abci.rs");
-}
-
-pub mod store {
-    include!("prost/tendermint.store.rs");
-}
-
-pub mod version {
-    include!("prost/tendermint.version.rs");
+pub mod consensus {
+    include!("prost/tendermint.consensus.rs");
 }
 
 pub mod types {
     include!("prost/tendermint.types.rs");
 }
 
-pub mod consensus {
-    include!("prost/tendermint.consensus.rs");
-}
-
-pub mod p2p {
-    include!("prost/tendermint.p2p.rs");
-}
-
-pub mod privval {
-    include!("prost/tendermint.privval.rs");
-}
-
-pub mod blockchain {
-    include!("prost/tendermint.blockchain.rs");
-}
-
-pub mod crypto {
-    include!("prost/tendermint.crypto.rs");
-}
-
 pub mod mempool {
     include!("prost/tendermint.mempool.rs");
 }
 
-pub mod state {
-    include!("prost/tendermint.state.rs");
+pub mod rpc {
+    pub mod grpc {
+        include!("prost/tendermint.rpc.grpc.rs");
+    }
+}
+
+pub mod blockchain {
+    include!("prost/tendermint.blockchain.rs");
 }
 
 pub mod libs {
@@ -54,10 +28,36 @@ pub mod libs {
     }
 }
 
-pub mod rpc {
-    pub mod grpc {
-        include!("prost/tendermint.rpc.grpc.rs");
-    }
+pub mod state {
+    include!("prost/tendermint.state.rs");
+}
+
+pub mod version {
+    include!("prost/tendermint.version.rs");
+}
+
+pub mod store {
+    include!("prost/tendermint.store.rs");
+}
+
+pub mod privval {
+    include!("prost/tendermint.privval.rs");
+}
+
+pub mod statesync {
+    include!("prost/tendermint.statesync.rs");
+}
+
+pub mod p2p {
+    include!("prost/tendermint.p2p.rs");
+}
+
+pub mod abci {
+    include!("prost/tendermint.abci.rs");
+}
+
+pub mod crypto {
+    include!("prost/tendermint.crypto.rs");
 }
 
 pub mod meta {

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 walkdir         = { version = "2.3" }
-prost-build     = { version = "0.7" }
+prost-build     = { version = "0.8" }
 git2            = { version = "0.13" }
 tempfile        = { version = "3.2.0" }
 subtle-encoding = { version = "0.5" }


### PR DESCRIPTION
Follow-up to #925 and #926.

In this PR I've bumped the proto-compiler tool's prost version to v0.8 and have rebuilt the Protobuf data structures.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
