### PR TITLE
Fix Warning in Cargo Build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ members = [
 exclude = [
     "proto-compiler"
 ]
+
+[profile.release.package.tendermint-light-client-js]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -43,7 +43,3 @@ wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"


### PR DESCRIPTION
I believe that the "blessed" way to add profile settings in Cargo workspaces is with package overrides now
- [Cargo Documentation](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides)
- [Stack Overflow Thread](https://stackoverflow.com/questions/45794917/specific-profiles-for-workspace-members)

I was getting warnings when building which suggested that the profile setting in `light-client-js` wasn't doing anything because profiles need to be set on the project manifest.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
