### PR TITLE
Implement full-duplex secret connection

### DIFF
--- a/.changelog/unreleased/improvements/814-clonable-secret-conn.md
+++ b/.changelog/unreleased/improvements/814-clonable-secret-conn.md
@@ -1,4 +1,4 @@
-- `[tendermint-p2p]` The `SecretConnection` can now be cloned such that it can
-  be accessed from multiple threads simultaneously. The main use case for this
-  is to separate reading into one thread, and writing into another.
+- `[tendermint-p2p]` The `SecretConnection` can now be split into two halves to
+  facilitate full-duplex communication (must be facilitated by using each half
+  in a separate thread).
   ([#938](https://github.com/informalsystems/tendermint-rs/pull/938))

--- a/.changelog/unreleased/improvements/814-clonable-secret-conn.md
+++ b/.changelog/unreleased/improvements/814-clonable-secret-conn.md
@@ -1,0 +1,4 @@
+- `[tendermint-p2p]` The `SecretConnection` can now be cloned such that it can
+  be accessed from multiple threads simultaneously. The main use case for this
+  is to separate reading into one thread, and writing into another.
+  ([#938](https://github.com/informalsystems/tendermint-rs/pull/938))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "pbt-gen",
     "proto",
     "rpc",
+    "std-ext",
     "tendermint",
     "test",
     "testgen"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -43,6 +43,7 @@ zeroize = "1"
 # path dependencies
 tendermint = { path = "../tendermint", version = "0.21.0" }
 tendermint-proto = { path = "../proto", version = "0.21.0" }
+tendermint-std-ext = { path = "../std-ext", version = "0.21.0" }
 
 # optional dependencies
 prost-amino = { version = "0.6", optional = true }

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -227,7 +227,7 @@ impl Handshake<AwaitingAuthSig> {
 /// not both simultaneously).
 ///
 /// If, however, the underlying I/O handler class implements
-/// [`crate::transport::TryClone`], then you can use
+/// [`tendermint_std_ext::TryClone`], then you can use
 /// [`SecretConnection::try_split`] to split the `SecretConnection` into its
 /// sending and receiving halves. Each of these halves can then be used in a
 /// separate thread to facilitate full-duplex communication.

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -221,6 +221,12 @@ impl Handshake<AwaitingAuthSig> {
 
 /// Encrypted connection between peers in a Tendermint network.
 ///
+/// ## Connection integrity and failures
+///
+/// Due to the underlying encryption mechanism (currently [RFC 8439]), when a
+/// read or write failure occurs, it is necessary to disconnect from the remote
+/// peer and attempt to reconnect.
+///
 /// ## Half- and full-duplex connections
 /// By default, a `SecretConnection` facilitates half-duplex operations (i.e.
 /// one can either read from the connection or write to it at a given time, but
@@ -232,9 +238,11 @@ impl Handshake<AwaitingAuthSig> {
 /// sending and receiving halves. Each of these halves can then be used in a
 /// separate thread to facilitate full-duplex communication.
 ///
-/// ## Contract
+/// ## Contracts
 ///
 /// When reading data, data smaller than [`DATA_MAX_SIZE`] is read atomically.
+///
+/// [RFC 8439]: https://www.rfc-editor.org/rfc/rfc8439.html
 pub struct SecretConnection<IoHandler> {
     io_handler: IoHandler,
     protocol_version: Version,

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -469,8 +469,8 @@ fn encrypt(
     send_nonce: &Nonce,
     sealed_frame: &mut [u8; TAG_SIZE + TOTAL_FRAME_SIZE],
 ) -> Result<()> {
-    debug_assert!(!chunk.is_empty(), "chunk is empty");
-    debug_assert!(
+    assert!(!chunk.is_empty(), "chunk is empty");
+    assert!(
         chunk.len() <= TOTAL_FRAME_SIZE - DATA_LEN_SIZE,
         "chunk is too big: {}! max: {}",
         chunk.len(),

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -351,7 +351,7 @@ where
     /// ## Errors
     /// Fails when the `try_clone` operation for the underlying I/O handler
     /// fails.
-    pub fn try_split(self) -> Result<(Sender<IoHandler>, Receiver<IoHandler>)> {
+    pub fn split(self) -> Result<(Sender<IoHandler>, Receiver<IoHandler>)> {
         let remote_pubkey = self.remote_pubkey.expect("remote_pubkey to be initialized");
         Ok((
             Sender {

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -221,6 +221,7 @@ impl Handshake<AwaitingAuthSig> {
 
 /// Encrypted connection between peers in a Tendermint network.
 ///
+/// ## Half- and full-duplex connections
 /// By default, a `SecretConnection` facilitates half-duplex operations (i.e.
 /// one can either read from the connection or write to it at a given time, but
 /// not both simultaneously).
@@ -230,6 +231,10 @@ impl Handshake<AwaitingAuthSig> {
 /// [`SecretConnection::try_split`] to split the `SecretConnection` into its
 /// sending and receiving halves. Each of these halves can then be used in a
 /// separate thread to facilitate full-duplex communication.
+///
+/// ## Contract
+///
+/// When reading data, data smaller than [`DATA_MAX_SIZE`] is read atomically.
 pub struct SecretConnection<IoHandler> {
     io_handler: IoHandler,
     protocol_version: Version,
@@ -494,7 +499,6 @@ fn encrypt(
 }
 
 // Writes encrypted frames of `TAG_SIZE` + `TOTAL_FRAME_SIZE`
-// CONTRACT: data smaller than DATA_MAX_SIZE is read atomically.
 fn encrypt_and_write<IoHandler: Write>(
     io_handler: &mut IoHandler,
     send_state: &mut SendState,
@@ -569,7 +573,6 @@ fn decrypt(
     Ok(in_out.len())
 }
 
-// CONTRACT: data smaller than DATA_MAX_SIZE is read atomically.
 fn read_and_decrypt<IoHandler: Read>(
     io_handler: &mut IoHandler,
     recv_state: &mut ReceiveState,

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -256,7 +256,7 @@ macro_rules! checked_io {
 ///
 /// If, however, the underlying I/O handler class implements
 /// [`tendermint_std_ext::TryClone`], then you can use
-/// [`SecretConnection::try_split`] to split the `SecretConnection` into its
+/// [`SecretConnection::split`] to split the `SecretConnection` into its
 /// sending and receiving halves. Each of these halves can then be used in a
 /// separate thread to facilitate full-duplex communication.
 ///

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -315,15 +315,16 @@ where
     /// Fails when the `try_clone` operation for the underlying I/O handler
     /// fails.
     pub fn try_split(self) -> Result<(Sender<IoHandler>, Receiver<IoHandler>)> {
+        let remote_pubkey = self.remote_pubkey.expect("remote_pubkey to be initialized");
         Ok((
             Sender {
                 io_handler: self.io_handler.try_clone()?,
-                remote_pubkey: self.remote_pubkey,
+                remote_pubkey,
                 send_state: self.send_state,
             },
             Receiver {
                 io_handler: self.io_handler,
-                remote_pubkey: self.remote_pubkey,
+                remote_pubkey,
                 recv_state: self.recv_state,
             },
         ))
@@ -362,14 +363,14 @@ struct ReceiveState {
 /// The sending end of a [`SecretConnection`].
 pub struct Sender<IoHandler> {
     io_handler: IoHandler,
-    remote_pubkey: Option<PublicKey>,
+    remote_pubkey: PublicKey,
     send_state: SendState,
 }
 
 impl<IoHandler> Sender<IoHandler> {
     /// Returns the remote pubkey. Panics if there's no key.
-    pub fn remote_pubkey(&self) -> PublicKey {
-        self.remote_pubkey.expect("remote_pubkey uninitialized")
+    pub const fn remote_pubkey(&self) -> PublicKey {
+        self.remote_pubkey
     }
 }
 
@@ -386,14 +387,14 @@ impl<IoHandler: Write> Write for Sender<IoHandler> {
 /// The receiving end of a [`SecretConnection`].
 pub struct Receiver<IoHandler> {
     io_handler: IoHandler,
-    remote_pubkey: Option<PublicKey>,
+    remote_pubkey: PublicKey,
     recv_state: ReceiveState,
 }
 
 impl<IoHandler> Receiver<IoHandler> {
     /// Returns the remote pubkey. Panics if there's no key.
-    pub fn remote_pubkey(&self) -> PublicKey {
-        self.remote_pubkey.expect("remote_pubkey uninitialized")
+    pub const fn remote_pubkey(&self) -> PublicKey {
+        self.remote_pubkey
     }
 }
 

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -310,7 +310,7 @@ where
     <IoHandler as TryClone>::Error: 'static + std::error::Error + Send + Sync,
 {
     /// For secret connections whose underlying I/O layer implements
-    /// [`crate::transport::TryClone`], this attempts to split such a
+    /// [`tendermint_std_ext::TryClone`], this attempts to split such a
     /// connection into its sending and receiving halves.
     ///
     /// This facilitates full-duplex communications when each half is used in

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -511,15 +511,13 @@ fn encrypt_and_write<IoHandler: Write>(
             data_copy = &[0_u8; 0];
         }
         let sealed_frame = &mut [0_u8; TAG_SIZE + TOTAL_FRAME_SIZE];
-        let res = encrypt(
+        encrypt(
             chunk,
             &send_state.send_cipher,
             &send_state.send_nonce,
             sealed_frame,
-        );
-        if let Err(err) = res {
-            return Err(io::Error::new(io::ErrorKind::Other, err.to_string()));
-        }
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
         send_state.send_nonce.increment();
         // end encryption
 

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -293,10 +293,7 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
     }
 }
 
-impl<IoHandler> Read for SecretConnection<IoHandler>
-where
-    IoHandler: Read + Write + Send + Sync,
-{
+impl<IoHandler: Read> Read for SecretConnection<IoHandler> {
     // CONTRACT: data smaller than DATA_MAX_SIZE is read atomically.
     fn read(&mut self, data: &mut [u8]) -> io::Result<usize> {
         if !self.recv_buffer.is_empty() {
@@ -359,10 +356,7 @@ where
     }
 }
 
-impl<IoHandler> Write for SecretConnection<IoHandler>
-where
-    IoHandler: Read + Write + Send + Sync,
-{
+impl<IoHandler: Write> Write for SecretConnection<IoHandler> {
     // Writes encrypted frames of `TAG_SIZE` + `TOTAL_FRAME_SIZE`
     // CONTRACT: data smaller than DATA_MAX_SIZE is read atomically.
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -221,11 +221,15 @@ impl Handshake<AwaitingAuthSig> {
 
 /// Encrypted connection between peers in a Tendermint network.
 ///
-/// Can be safely shared between multiple threads, however only one thread can
-/// read from and one other thread can write to the secret connection
-/// simultaneously. This is intended to allow for use from two threads
-/// simultaneously: one thread for reading from the connection, and one thread
-/// for simultaneously writing to it.
+/// By default, a `SecretConnection` facilitates half-duplex operations (i.e.
+/// one can either read from the connection or write to it at a given time, but
+/// not both simultaneously).
+///
+/// If, however, the underlying I/O handler class implements
+/// [`crate::transport::TryClone`], then you can use
+/// [`SecretConnection::try_split`] to split the `SecretConnection` into its
+/// sending and receiving halves. Each of these halves can then be used in a
+/// separate thread to facilitate full-duplex communication.
 pub struct SecretConnection<IoHandler> {
     io_handler: IoHandler,
     protocol_version: Version,

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -248,7 +248,11 @@ impl Default for SecretConnectionRecvState {
 
 /// Encrypted connection between peers in a Tendermint network.
 ///
-/// Can be safely shared between multiple threads.
+/// Can be safely shared between multiple threads, however only one thread can
+/// read from and one other thread can write to the secret connection
+/// simultaneously. This is intended to allow for use from two threads
+/// simultaneously: one thread for reading from the connection, and one thread
+/// for simultaneously writing to it.
 pub struct SecretConnection<IoHandler> {
     io_handler: IoHandler,
     protocol_version: Version,

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 use x25519_dalek::{EphemeralSecret, PublicKey as EphemeralPublic};
 
 use tendermint_proto as proto;
+use tendermint_std_ext::TryClone;
 
 pub use self::{
     kdf::Kdf,
@@ -28,7 +29,6 @@ pub use self::{
     protocol::Version,
     public_key::PublicKey,
 };
-use crate::transport::TryClone;
 
 #[cfg(feature = "amino")]
 mod amino_types;

--- a/p2p/src/transport.rs
+++ b/p2p/src/transport.rs
@@ -1,7 +1,7 @@
 //! Abstractions that describe types which support the physical transport - i.e. connection
 //! management - used in the p2p stack.
 
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, ToSocketAddrs};
 
 use eyre::Result;
 
@@ -142,30 +142,4 @@ where
     ///
     /// * If resource allocation fails for lack of privileges or being not available.
     fn bind(self, bind_info: BindInfo<A>) -> Result<(Self::Endpoint, Self::Incoming)>;
-}
-
-/// Types that can be cloned where success is not guaranteed can implement this
-/// trait.
-pub trait TryClone: Sized {
-    /// The type of error that can be returned when an attempted clone
-    /// operation fails.
-    type Error;
-
-    /// Attempt to clone this instance.
-    ///
-    /// # Errors
-    /// Can fail if the underlying instance cannot be cloned (e.g. the OS could
-    /// be out of file descriptors, or some low-level OS-specific error could
-    /// be produced).
-    fn try_clone(&self) -> Result<Self, Self::Error>;
-}
-
-impl TryClone for TcpStream {
-    type Error = std::io::Error;
-
-    fn try_clone(&self) -> Result<Self, Self::Error> {
-        // Uses the TcpStream struct's method. See
-        // https://doc.rust-lang.org/stable/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name
-        self.try_clone()
-    }
 }

--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ set -e
 # A space-separated list of all the crates we want to publish, in the order in
 # which they must be published. It's important to respect this order, since
 # each subsequent crate depends on one or more of the preceding ones.
-DEFAULT_CRATES="tendermint-proto tendermint tendermint-abci tendermint-rpc tendermint-p2p tendermint-light-client tendermint-light-client-js tendermint-testgen"
+DEFAULT_CRATES="tendermint-proto tendermint-std-ext tendermint tendermint-abci tendermint-rpc tendermint-p2p tendermint-light-client tendermint-light-client-js tendermint-testgen"
 
 # Allows us to override the crates we want to publish.
 CRATES=${*:-${DEFAULT_CRATES}}

--- a/std-ext/Cargo.toml
+++ b/std-ext/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name       = "tendermint-std-ext"
+version    = "0.21.0"
+edition    = "2018"
+license    = "Apache-2.0"
+homepage   = "https://www.tendermint.com/"
+repository = "https://github.com/informalsystems/tendermint-rs"
+readme     = "README.md"
+keywords   = ["blockchain", "cosmos", "tendermint"]
+categories = ["development-tools"]
+authors    = ["Informal Systems <hello@informal.systems>"]
+
+description = """
+    tendermint-std-ext contains extensions to the Rust standard library for use
+    from tendermint-rs.
+    """
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/std-ext/README.md
+++ b/std-ext/README.md
@@ -1,0 +1,24 @@
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+
+See the [repo root] for build status, license, rust version, etc.
+
+# tendermint-std-ext
+
+Extensions to the [Rust standard library][std] for use by Tendermint in Rust.
+
+## Documentation
+
+See documentation on [crates.io][docs-link].
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/tendermint-std-ext.svg
+[crate-link]: https://crates.io/crates/tendermint-std-ext
+[docs-image]: https://docs.rs/tendermint-std-ext/badge.svg
+[docs-link]: https://docs.rs/tendermint-std-ext/
+
+[//]: # (general links)
+
+[repo root]: https://github.com/informalsystems/tendermint-rs
+[std]: https://doc.rust-lang.org/std/

--- a/std-ext/src/lib.rs
+++ b/std-ext/src/lib.rs
@@ -1,0 +1,8 @@
+//! Extensions to the [Rust standard library][std] for use by [tendermint-rs].
+//!
+//! [std]: https://doc.rust-lang.org/std/
+//! [tendermint-rs]: https://github.com/informalsystems/tendermint-rs/
+
+mod try_clone;
+
+pub use try_clone::TryClone;

--- a/std-ext/src/try_clone.rs
+++ b/std-ext/src/try_clone.rs
@@ -1,0 +1,27 @@
+//! Rust standard library types that can be fallibly cloned.
+
+use std::net::TcpStream;
+
+/// Types that can be cloned where success is not guaranteed can implement this
+/// trait.
+pub trait TryClone: Sized {
+    /// The type of error that can be returned when an attempted clone
+    /// operation fails.
+    type Error;
+
+    /// Attempt to clone this instance.
+    ///
+    /// # Errors
+    /// Can fail if the underlying instance cannot be cloned (e.g. the OS could
+    /// be out of file descriptors, or some low-level OS-specific error could
+    /// be produced).
+    fn try_clone(&self) -> Result<Self, Self::Error>;
+}
+
+impl TryClone for TcpStream {
+    type Error = std::io::Error;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        TcpStream::try_clone(self)
+    }
+}

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -143,7 +143,7 @@ fn test_split_secret_connection() {
     println!("peer2 handshake concluded");
 
     let (mut write_conn, mut read_conn) = conn_to_peer1
-        .try_split()
+        .split()
         .expect("to be able to clone the underlying TcpStream");
     let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
 

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -1,11 +1,11 @@
 use std::io::Read as _;
 use std::io::Write as _;
+use std::net::{TcpListener, TcpStream};
 use std::thread;
 
 use ed25519_dalek::{self as ed25519};
 use eyre::Result;
 use rand_core::OsRng;
-use std::net::{TcpListener, TcpStream};
 use x25519_dalek::PublicKey as EphemeralPublic;
 
 use tendermint_p2p::secret_connection::{sort32, Handshake, SecretConnection, Version};

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -5,14 +5,12 @@ use std::thread;
 use ed25519_dalek::{self as ed25519};
 use eyre::Result;
 use rand_core::OsRng;
-use std::net::{TcpListener, TcpStream};
 use x25519_dalek::PublicKey as EphemeralPublic;
 
 use tendermint_p2p::secret_connection::{sort32, Handshake, SecretConnection, Version};
 use tendermint_proto as proto;
 
 use crate::pipe;
-use tendermint_p2p::transport::TryClone;
 
 mod nonce;
 mod public_key;
@@ -105,81 +103,81 @@ fn test_sort() {
     assert_eq!(t2, *t4);
 }
 
-#[test]
-fn test_cloned_secret_connection() {
-    const MESSAGES_1_TO_2: &[&str] = &["one", "three", "five", "seven"];
-    const MESSAGES_2_TO_1: &[&str] = &["two", "four", "six", "eight"];
-    let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
-    let peer1_addr = peer1_listener.local_addr().unwrap();
-    println!("peer1 bound to {:?}", peer1_addr);
-
-    let peer1 = thread::spawn(move || {
-        let stream = peer1_listener
-            .incoming()
-            .next()
-            .unwrap()
-            .expect("an incoming TCP stream from peer 2");
-        let mut conn_to_peer2 = new_peer_conn(stream).expect("handshake to succeed");
-        println!("peer1 handshake concluded");
-        for msg_counter in 0..MESSAGES_1_TO_2.len() {
-            // Peer 1 sends first
-            conn_to_peer2
-                .write_all(MESSAGES_1_TO_2[msg_counter].as_bytes())
-                .expect("to write message successfully to peer 2");
-            // Peer 1 expects a response
-            let mut buf = [0u8; 10];
-            let br = conn_to_peer2
-                .read(&mut buf)
-                .expect("to read a message from peer 2");
-            let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
-            println!("Got message from peer2: {}", msg);
-            assert_eq!(msg, MESSAGES_2_TO_1[msg_counter]);
-        }
-    });
-
-    // Peer 2 attempts to initiate the secret connection to peer 1
-    let peer2_to_peer1 = TcpStream::connect(peer1_addr).expect("to be able to connect to peer 1");
-    println!("peer2 connected to peer1");
-    let mut conn_to_peer1 = new_peer_conn(peer2_to_peer1).expect("handshake to succeed");
-    println!("peer2 handshake concluded");
-
-    let mut write_conn = conn_to_peer1
-        .try_clone()
-        .expect("to be able to clone the secret connection");
-    let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
-
-    // We spawn a standalone thread that makes use of peer2's secret connection
-    // purely to write outgoing messages.
-    let peer2_writer = thread::spawn(move || {
-        for _ in 0..MESSAGES_2_TO_1.len() {
-            let msg = write_rx
-                .recv()
-                .expect("to successfully receive a message to be sent to peer1");
-            write_conn
-                .write_all(msg.as_bytes())
-                .expect("to be able to write to peer 1");
-        }
-    });
-
-    for msg_counter in 0..MESSAGES_2_TO_1.len() {
-        // Wait for peer 1 to send first
-        let mut buf = [0u8; 10];
-        let br = conn_to_peer1
-            .read(&mut buf)
-            .expect("to receive a message from peer 1");
-        let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
-        println!("Got message from peer1: {}", msg);
-        assert_eq!(msg, MESSAGES_1_TO_2[msg_counter]);
-        write_tx
-            .send(MESSAGES_2_TO_1[msg_counter].to_string())
-            .expect("to be able to communicate with peer2's writer thread");
-    }
-
-    peer2_writer
-        .join()
-        .expect("peer 2's writer thread to run to completion");
-    peer1.join().expect("peer 1's thread to run to completion")
-}
+// #[test]
+// fn test_cloned_secret_connection() {
+//     const MESSAGES_1_TO_2: &[&str] = &["one", "three", "five", "seven"];
+//     const MESSAGES_2_TO_1: &[&str] = &["two", "four", "six", "eight"];
+//     let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
+//     let peer1_addr = peer1_listener.local_addr().unwrap();
+//     println!("peer1 bound to {:?}", peer1_addr);
+//
+//     let peer1 = thread::spawn(move || {
+//         let stream = peer1_listener
+//             .incoming()
+//             .next()
+//             .unwrap()
+//             .expect("an incoming TCP stream from peer 2");
+//         let mut conn_to_peer2 = new_peer_conn(stream).expect("handshake to succeed");
+//         println!("peer1 handshake concluded");
+//         for msg_counter in 0..MESSAGES_1_TO_2.len() {
+//             // Peer 1 sends first
+//             conn_to_peer2
+//                 .write_all(MESSAGES_1_TO_2[msg_counter].as_bytes())
+//                 .expect("to write message successfully to peer 2");
+//             // Peer 1 expects a response
+//             let mut buf = [0u8; 10];
+//             let br = conn_to_peer2
+//                 .read(&mut buf)
+//                 .expect("to read a message from peer 2");
+//             let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
+//             println!("Got message from peer2: {}", msg);
+//             assert_eq!(msg, MESSAGES_2_TO_1[msg_counter]);
+//         }
+//     });
+//
+//     // Peer 2 attempts to initiate the secret connection to peer 1
+//     let peer2_to_peer1 = TcpStream::connect(peer1_addr).expect("to be able to connect to peer 1");
+//     println!("peer2 connected to peer1");
+//     let mut conn_to_peer1 = new_peer_conn(peer2_to_peer1).expect("handshake to succeed");
+//     println!("peer2 handshake concluded");
+//
+//     let mut write_conn = conn_to_peer1
+//         .try_clone()
+//         .expect("to be able to clone the secret connection");
+//     let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
+//
+//     // We spawn a standalone thread that makes use of peer2's secret connection
+//     // purely to write outgoing messages.
+//     let peer2_writer = thread::spawn(move || {
+//         for _ in 0..MESSAGES_2_TO_1.len() {
+//             let msg = write_rx
+//                 .recv()
+//                 .expect("to successfully receive a message to be sent to peer1");
+//             write_conn
+//                 .write_all(msg.as_bytes())
+//                 .expect("to be able to write to peer 1");
+//         }
+//     });
+//
+//     for msg_counter in 0..MESSAGES_2_TO_1.len() {
+//         // Wait for peer 1 to send first
+//         let mut buf = [0u8; 10];
+//         let br = conn_to_peer1
+//             .read(&mut buf)
+//             .expect("to receive a message from peer 1");
+//         let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
+//         println!("Got message from peer1: {}", msg);
+//         assert_eq!(msg, MESSAGES_1_TO_2[msg_counter]);
+//         write_tx
+//             .send(MESSAGES_2_TO_1[msg_counter].to_string())
+//             .expect("to be able to communicate with peer2's writer thread");
+//     }
+//
+//     peer2_writer
+//         .join()
+//         .expect("peer 2's writer thread to run to completion");
+//     peer1.join().expect("peer 1's thread to run to completion")
+// }
 
 fn new_peer_conn<IoHandler>(io_handler: IoHandler) -> Result<SecretConnection<IoHandler>>
 where

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -5,6 +5,7 @@ use std::thread;
 use ed25519_dalek::{self as ed25519};
 use eyre::Result;
 use rand_core::OsRng;
+use std::net::{TcpListener, TcpStream};
 use x25519_dalek::PublicKey as EphemeralPublic;
 
 use tendermint_p2p::secret_connection::{sort32, Handshake, SecretConnection, Version};
@@ -103,81 +104,81 @@ fn test_sort() {
     assert_eq!(t2, *t4);
 }
 
-// #[test]
-// fn test_cloned_secret_connection() {
-//     const MESSAGES_1_TO_2: &[&str] = &["one", "three", "five", "seven"];
-//     const MESSAGES_2_TO_1: &[&str] = &["two", "four", "six", "eight"];
-//     let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
-//     let peer1_addr = peer1_listener.local_addr().unwrap();
-//     println!("peer1 bound to {:?}", peer1_addr);
-//
-//     let peer1 = thread::spawn(move || {
-//         let stream = peer1_listener
-//             .incoming()
-//             .next()
-//             .unwrap()
-//             .expect("an incoming TCP stream from peer 2");
-//         let mut conn_to_peer2 = new_peer_conn(stream).expect("handshake to succeed");
-//         println!("peer1 handshake concluded");
-//         for msg_counter in 0..MESSAGES_1_TO_2.len() {
-//             // Peer 1 sends first
-//             conn_to_peer2
-//                 .write_all(MESSAGES_1_TO_2[msg_counter].as_bytes())
-//                 .expect("to write message successfully to peer 2");
-//             // Peer 1 expects a response
-//             let mut buf = [0u8; 10];
-//             let br = conn_to_peer2
-//                 .read(&mut buf)
-//                 .expect("to read a message from peer 2");
-//             let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
-//             println!("Got message from peer2: {}", msg);
-//             assert_eq!(msg, MESSAGES_2_TO_1[msg_counter]);
-//         }
-//     });
-//
-//     // Peer 2 attempts to initiate the secret connection to peer 1
-//     let peer2_to_peer1 = TcpStream::connect(peer1_addr).expect("to be able to connect to peer 1");
-//     println!("peer2 connected to peer1");
-//     let mut conn_to_peer1 = new_peer_conn(peer2_to_peer1).expect("handshake to succeed");
-//     println!("peer2 handshake concluded");
-//
-//     let mut write_conn = conn_to_peer1
-//         .try_clone()
-//         .expect("to be able to clone the secret connection");
-//     let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
-//
-//     // We spawn a standalone thread that makes use of peer2's secret connection
-//     // purely to write outgoing messages.
-//     let peer2_writer = thread::spawn(move || {
-//         for _ in 0..MESSAGES_2_TO_1.len() {
-//             let msg = write_rx
-//                 .recv()
-//                 .expect("to successfully receive a message to be sent to peer1");
-//             write_conn
-//                 .write_all(msg.as_bytes())
-//                 .expect("to be able to write to peer 1");
-//         }
-//     });
-//
-//     for msg_counter in 0..MESSAGES_2_TO_1.len() {
-//         // Wait for peer 1 to send first
-//         let mut buf = [0u8; 10];
-//         let br = conn_to_peer1
-//             .read(&mut buf)
-//             .expect("to receive a message from peer 1");
-//         let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
-//         println!("Got message from peer1: {}", msg);
-//         assert_eq!(msg, MESSAGES_1_TO_2[msg_counter]);
-//         write_tx
-//             .send(MESSAGES_2_TO_1[msg_counter].to_string())
-//             .expect("to be able to communicate with peer2's writer thread");
-//     }
-//
-//     peer2_writer
-//         .join()
-//         .expect("peer 2's writer thread to run to completion");
-//     peer1.join().expect("peer 1's thread to run to completion")
-// }
+#[test]
+fn test_split_secret_connection() {
+    const MESSAGES_1_TO_2: &[&str] = &["one", "three", "five", "seven"];
+    const MESSAGES_2_TO_1: &[&str] = &["two", "four", "six", "eight"];
+    let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
+    let peer1_addr = peer1_listener.local_addr().unwrap();
+    println!("peer1 bound to {:?}", peer1_addr);
+
+    let peer1 = thread::spawn(move || {
+        let stream = peer1_listener
+            .incoming()
+            .next()
+            .unwrap()
+            .expect("an incoming TCP stream from peer 2");
+        let mut conn_to_peer2 = new_peer_conn(stream).expect("handshake to succeed");
+        println!("peer1 handshake concluded");
+        for msg_counter in 0..MESSAGES_1_TO_2.len() {
+            // Peer 1 sends first
+            conn_to_peer2
+                .write_all(MESSAGES_1_TO_2[msg_counter].as_bytes())
+                .expect("to write message successfully to peer 2");
+            // Peer 1 expects a response
+            let mut buf = [0u8; 10];
+            let br = conn_to_peer2
+                .read(&mut buf)
+                .expect("to read a message from peer 2");
+            let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
+            println!("Got message from peer2: {}", msg);
+            assert_eq!(msg, MESSAGES_2_TO_1[msg_counter]);
+        }
+    });
+
+    // Peer 2 attempts to initiate the secret connection to peer 1
+    let peer2_to_peer1 = TcpStream::connect(peer1_addr).expect("to be able to connect to peer 1");
+    println!("peer2 connected to peer1");
+    let conn_to_peer1 = new_peer_conn(peer2_to_peer1).expect("handshake to succeed");
+    println!("peer2 handshake concluded");
+
+    let (mut write_conn, mut read_conn) = conn_to_peer1
+        .try_split()
+        .expect("to be able to clone the underlying TcpStream");
+    let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
+
+    // We spawn a standalone thread that makes use of peer2's secret connection
+    // purely to write outgoing messages.
+    let peer2_writer = thread::spawn(move || {
+        for _ in 0..MESSAGES_2_TO_1.len() {
+            let msg = write_rx
+                .recv()
+                .expect("to successfully receive a message to be sent to peer1");
+            write_conn
+                .write_all(msg.as_bytes())
+                .expect("to be able to write to peer 1");
+        }
+    });
+
+    for msg_counter in 0..MESSAGES_2_TO_1.len() {
+        // Wait for peer 1 to send first
+        let mut buf = [0u8; 10];
+        let br = read_conn
+            .read(&mut buf)
+            .expect("to receive a message from peer 1");
+        let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
+        println!("Got message from peer1: {}", msg);
+        assert_eq!(msg, MESSAGES_1_TO_2[msg_counter]);
+        write_tx
+            .send(MESSAGES_2_TO_1[msg_counter].to_string())
+            .expect("to be able to communicate with peer2's writer thread");
+    }
+
+    peer2_writer
+        .join()
+        .expect("peer 2's writer thread to run to completion");
+    peer1.join().expect("peer 1's thread to run to completion")
+}
 
 fn new_peer_conn<IoHandler>(io_handler: IoHandler) -> Result<SecretConnection<IoHandler>>
 where

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -107,8 +107,8 @@ fn test_sort() {
 
 #[test]
 fn test_cloned_secret_connection() {
-    const MESSAGES_1_TO_2: &[&str] = &["one", "three"];
-    const MESSAGES_2_TO_1: &[&str] = &["two", "four"];
+    const MESSAGES_1_TO_2: &[&str] = &["one", "three", "five", "seven"];
+    const MESSAGES_2_TO_1: &[&str] = &["two", "four", "six", "eight"];
     let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
     let peer1_addr = peer1_listener.local_addr().unwrap();
     println!("peer1 bound to {:?}", peer1_addr);

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -149,6 +149,7 @@ fn test_cloned_secret_connection() {
     let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
 
     // We spawn a standalone thread that makes use of peer2's secret connection
+    // purely to write outgoing messages.
     let peer2_writer = thread::spawn(move || {
         for _ in 0..MESSAGES_2_TO_1.len() {
             let msg = write_rx

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -5,12 +5,14 @@ use std::thread;
 use ed25519_dalek::{self as ed25519};
 use eyre::Result;
 use rand_core::OsRng;
+use std::net::{TcpListener, TcpStream};
 use x25519_dalek::PublicKey as EphemeralPublic;
 
 use tendermint_p2p::secret_connection::{sort32, Handshake, SecretConnection, Version};
 use tendermint_proto as proto;
 
 use crate::pipe;
+use tendermint_p2p::transport::TryClone;
 
 mod nonce;
 mod public_key;
@@ -101,6 +103,81 @@ fn test_sort() {
     let (ref t3, ref t4) = sort32(t1, t2);
     assert_eq!(t1, *t3);
     assert_eq!(t2, *t4);
+}
+
+#[test]
+fn test_cloned_secret_connection() {
+    const MESSAGES_1_TO_2: &[&str] = &["one", "three"];
+    const MESSAGES_2_TO_1: &[&str] = &["two", "four"];
+    let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
+    let peer1_addr = peer1_listener.local_addr().unwrap();
+    println!("peer1 bound to {:?}", peer1_addr);
+
+    let peer1 = thread::spawn(move || {
+        let stream = peer1_listener
+            .incoming()
+            .next()
+            .unwrap()
+            .expect("an incoming TCP stream from peer 2");
+        let mut conn_to_peer2 = new_peer_conn(stream).expect("handshake to succeed");
+        println!("peer1 handshake concluded");
+        for msg_counter in 0..MESSAGES_1_TO_2.len() {
+            // Peer 1 sends first
+            conn_to_peer2
+                .write_all(MESSAGES_1_TO_2[msg_counter].as_bytes())
+                .expect("to write message successfully to peer 2");
+            // Peer 1 expects a response
+            let mut buf = [0u8; 10];
+            let br = conn_to_peer2
+                .read(&mut buf)
+                .expect("to read a message from peer 2");
+            let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
+            println!("Got message from peer2: {}", msg);
+            assert_eq!(msg, MESSAGES_2_TO_1[msg_counter]);
+        }
+    });
+
+    // Peer 2 attempts to initiate the secret connection to peer 1
+    let peer2_to_peer1 = TcpStream::connect(peer1_addr).expect("to be able to connect to peer 1");
+    println!("peer2 connected to peer1");
+    let mut conn_to_peer1 = new_peer_conn(peer2_to_peer1).expect("handshake to succeed");
+    println!("peer2 handshake concluded");
+
+    let mut write_conn = conn_to_peer1
+        .try_clone()
+        .expect("to be able to clone the secret connection");
+    let (write_tx, write_rx) = std::sync::mpsc::channel::<String>();
+
+    // We spawn a standalone thread that makes use of peer2's secret connection
+    let peer2_writer = thread::spawn(move || {
+        for _ in 0..MESSAGES_2_TO_1.len() {
+            let msg = write_rx
+                .recv()
+                .expect("to successfully receive a message to be sent to peer1");
+            write_conn
+                .write_all(msg.as_bytes())
+                .expect("to be able to write to peer 1");
+        }
+    });
+
+    for msg_counter in 0..MESSAGES_2_TO_1.len() {
+        // Wait for peer 1 to send first
+        let mut buf = [0u8; 10];
+        let br = conn_to_peer1
+            .read(&mut buf)
+            .expect("to receive a message from peer 1");
+        let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
+        println!("Got message from peer1: {}", msg);
+        assert_eq!(msg, MESSAGES_1_TO_2[msg_counter]);
+        write_tx
+            .send(MESSAGES_2_TO_1[msg_counter].to_string())
+            .expect("to be able to communicate with peer2's writer thread");
+    }
+
+    peer2_writer
+        .join()
+        .expect("peer 2's writer thread to run to completion");
+    peer1.join().expect("peer 1's thread to run to completion")
 }
 
 fn new_peer_conn<IoHandler>(io_handler: IoHandler) -> Result<SecretConnection<IoHandler>>


### PR DESCRIPTION
Work towards #814 

Something like this is necessary for the MConnection to be able to safely read from and write to the underlying stream from multiple threads (e.g. one thread for reading, one thread for writing).

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
