### PR TITLE
Fix recent clippy errors on `master`

### DIFF
--- a/light-client/src/components/verifier.rs
+++ b/light-client/src/components/verifier.rs
@@ -113,8 +113,8 @@ impl Verifier for ProdVerifier {
             &*self.voting_power_calculator,
             &*self.commit_validator,
             &*self.hasher,
-            &trusted,
-            &untrusted,
+            trusted,
+            untrusted,
             options,
             now,
         )

--- a/light-client/src/evidence.rs
+++ b/light-client/src/evidence.rs
@@ -70,7 +70,7 @@ mod prod {
         #[pre(self.peer_map.contains_key(&peer))]
         fn rpc_client_for(&self, peer: PeerId) -> Result<rpc::HttpClient, IoError> {
             let peer_addr = self.peer_map.get(&peer).unwrap().to_owned();
-            Ok(rpc::HttpClient::new(peer_addr).map_err(IoError::from)?)
+            rpc::HttpClient::new(peer_addr).map_err(IoError::from)
         }
     }
 }

--- a/light-client/src/macros.rs
+++ b/light-client/src/macros.rs
@@ -4,7 +4,7 @@
 #[macro_export]
 macro_rules! bail {
     ($kind:expr) => {
-        return Err($kind.into());
+        return Err($kind.into())
     };
 }
 

--- a/light-client/src/peer_list.rs
+++ b/light-client/src/peer_list.rs
@@ -115,7 +115,7 @@ impl<T> PeerList<T> {
     /// - The given peer id must not be the primary peer id.
     /// - The given peer must be in the witness list
     #[pre(faulty_witness != self.primary && self.witnesses.contains(&faulty_witness))]
-    #[post(Self::invariant(&self))]
+    #[post(Self::invariant(self))]
     pub fn replace_faulty_witness(&mut self, faulty_witness: PeerId) -> Option<PeerId> {
         let mut result = None;
 
@@ -137,7 +137,7 @@ impl<T> PeerList<T> {
     ///
     /// ## Errors
     /// - If there are no witness left, returns `ErrorKind::NoWitnessLeft`.
-    #[post(ret.is_ok() ==> Self::invariant(&self))]
+    #[post(ret.is_ok() ==> Self::invariant(self))]
     pub fn replace_faulty_primary(
         &mut self,
         primary_error: Option<Error>,

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -240,10 +240,10 @@ pub fn verify(
     vp.is_header_from_past(&untrusted.signed_header.header, options.clock_drift, now)?;
 
     // Ensure the header validator hashes match the given validators
-    vp.validator_sets_match(&untrusted, &*hasher)?;
+    vp.validator_sets_match(untrusted, &*hasher)?;
 
     // Ensure the header next validator hashes match the given next validators
-    vp.next_validators_match(&untrusted, &*hasher)?;
+    vp.next_validators_match(untrusted, &*hasher)?;
 
     // Ensure the header matches the commit
     vp.header_matches_commit(&untrusted.signed_header, hasher)?;
@@ -266,7 +266,7 @@ pub fn verify(
     if untrusted.height() == trusted_next_height {
         // If the untrusted block is the very next block after the trusted block,
         // check that their (next) validator sets hashes match.
-        vp.valid_next_validator_set(&untrusted, trusted)?;
+        vp.valid_next_validator_set(untrusted, trusted)?;
     } else {
         // Otherwise, ensure that the untrusted block has a greater height than
         // the trusted block.

--- a/light-client/src/store/memory.rs
+++ b/light-client/src/store/memory.rs
@@ -81,6 +81,7 @@ impl LightStore for MemoryStore {
             .map(|(_, e)| e.light_block.clone())
     }
 
+    #[allow(clippy::needless_collect)]
     fn all(&self, status: Status) -> Box<dyn Iterator<Item = LightBlock>> {
         let light_blocks: Vec<_> = self
             .store

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -320,7 +320,7 @@ impl Supervisor {
             .collect();
 
         self.fork_detector
-            .detect_forks(verified_block, &trusted_block, witnesses)
+            .detect_forks(verified_block, trusted_block, witnesses)
     }
 
     /// Run the supervisor event loop in the same thread.

--- a/tendermint/src/abci/tag.rs
+++ b/tendermint/src/abci/tag.rs
@@ -82,7 +82,7 @@ mod test {
     #[test]
     fn tag_serde() {
         let json = r#"{"key": "cGFja2V0X3RpbWVvdXRfaGVpZ2h0", "value": "MC00ODQw"}"#;
-        let tag: Tag = serde_json::from_str(&json).unwrap();
+        let tag: Tag = serde_json::from_str(json).unwrap();
         assert_eq!("packet_timeout_height", tag.key.0);
         assert_eq!("0-4840", tag.value.0);
     }

--- a/tendermint/src/chain/id.rs
+++ b/tendermint/src/chain/id.rs
@@ -55,7 +55,7 @@ impl Id {
 
     /// Get the chain ID as a raw bytes.
     pub fn as_bytes(&self) -> &[u8] {
-        &self.0.as_str().as_bytes()
+        self.0.as_str().as_bytes()
     }
 }
 

--- a/testgen/src/tester.rs
+++ b/testgen/src/tester.rs
@@ -269,7 +269,7 @@ impl Tester {
         T: 'static + DeserializeOwned + UnwindSafe,
         F: Fn(T) + UnwindSafe + RefUnwindSafe + 'static,
     {
-        let test_fn = move |_path: &str, input: &str| match parse_as::<T>(&input) {
+        let test_fn = move |_path: &str, input: &str| match parse_as::<T>(input) {
             Ok(test_case) => Tester::capture_test(|| {
                 test(test_case);
             }),
@@ -288,7 +288,7 @@ impl Tester {
     {
         let test_env = self.env().unwrap();
         let output_env = self.output_env().unwrap();
-        let test_fn = move |path: &str, input: &str| match parse_as::<T>(&input) {
+        let test_fn = move |path: &str, input: &str| match parse_as::<T>(input) {
             Ok(test_case) => Tester::capture_test(|| {
                 // It is OK to unwrap() here: in case of unwrapping failure, the test will fail.
                 let dir = TempDir::new().unwrap();
@@ -311,7 +311,7 @@ impl Tester {
         T: 'static + DeserializeOwned,
         F: Fn(T) -> Vec<(String, String)> + 'static,
     {
-        let batch_fn = move |_path: &str, input: &str| match parse_as::<T>(&input) {
+        let batch_fn = move |_path: &str, input: &str| match parse_as::<T>(input) {
             Ok(test_batch) => Some(batch(test_batch)),
             Err(_) => None,
         };

--- a/testgen/src/validator_set.rs
+++ b/testgen/src/validator_set.rs
@@ -48,7 +48,7 @@ impl Generator<validator::Set> for ValidatorSet {
     }
 
     fn generate(&self) -> Result<validator::Set, SimpleError> {
-        let vals = generate_validators(&self.validators.as_ref().unwrap())?;
+        let vals = generate_validators(self.validators.as_ref().unwrap())?;
         Ok(validator::Set::without_proposer(vals))
     }
 }


### PR DESCRIPTION
Some new clippy errors have appeared recently on `master` (most likely due to upgrading to Rust 1.54). This PR aims to fix them.

See https://github.com/informalsystems/tendermint-rs/runs/3242281271

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
