### PR TITLE
Change `hash` parameter of `/tx` RPC endpoint encoding to base64

### DIFF
--- a/.changelog/unreleased/breaking-changes/942-rpc-tx-hash-field.md
+++ b/.changelog/unreleased/breaking-changes/942-rpc-tx-hash-field.md
@@ -1,0 +1,3 @@
+- `[tendermint-rpc]` The `/tx` endpoint's `Request::hash` field has been changed
+  from `String` to `tendermint::abci::transaction::Hash`
+  ([#942](https://github.com/informalsystems/tendermint-rs/issues/942))

--- a/.changelog/unreleased/bug-fixes/942-rpc-tx-encoding.md
+++ b/.changelog/unreleased/bug-fixes/942-rpc-tx-encoding.md
@@ -1,0 +1,4 @@
+- `[tendermint-rpc]` The encoding of the `hash` field for requests to the `/tx`
+  endpoint has been changed to base64 (from hex) to accommodate discrepancies in
+  how the Tendermint RPC encodes this field for different RPC interfaces
+  ([#942](https://github.com/informalsystems/tendermint-rs/issues/942))

--- a/rpc/src/endpoint/tx.rs
+++ b/rpc/src/endpoint/tx.rs
@@ -8,17 +8,21 @@ use tendermint_proto::types::TxProof;
 /// Request for finding a transaction by its hash.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Request {
-    pub hash: String,
+    /// The hash of the transaction we want to find.
+    ///
+    /// Serialized internally into a base64-encoded string before sending to
+    /// the RPC server.
+    #[serde(with = "tendermint::serializers::hash_base64")]
+    pub hash: abci::transaction::Hash,
+    /// Whether or not to include the proofs of the transaction's inclusion in
+    /// the block.
     pub prove: bool,
 }
 
 impl Request {
     /// Constructor.
     pub fn new(hash: abci::transaction::Hash, prove: bool) -> Self {
-        Self {
-            hash: format!("0x{}", &hash),
-            prove,
-        }
+        Self { hash, prove }
     }
 }
 
@@ -34,6 +38,11 @@ impl crate::SimpleRequest for Request {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Response {
+    /// The hash of the transaction.
+    ///
+    /// Deserialized from a hex-encoded string (there is a discrepancy between
+    /// the format used for the request and the format used for the response in
+    /// the Tendermint RPC).
     pub hash: abci::transaction::Hash,
     pub height: block::Height,
     pub index: u32,

--- a/rpc/src/endpoint/tx_search.rs
+++ b/rpc/src/endpoint/tx_search.rs
@@ -54,7 +54,3 @@ pub struct Response {
 }
 
 impl crate::Response for Response {}
-
-// TODO: remove this after the next breaking release
-#[deprecated(note = "use endpoint::tx::Response instead")]
-pub type ResultTx = tx::Response;

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 use std::{fs, path::PathBuf};
 use subtle_encoding::{base64, hex};
+use tendermint::abci::transaction::Hash;
 use tendermint_rpc::{
     endpoint,
     error::{Error, ErrorDetail},
@@ -228,6 +229,19 @@ fn outgoing_fixtures() {
                     wrapped.params().tx.as_bytes(),
                     base64::decode("dHg1PXZhbHVl").unwrap()
                 );
+            }
+            "tx" => {
+                let wrapped =
+                    serde_json::from_str::<RequestWrapper<endpoint::tx::Request>>(&content)
+                        .unwrap();
+                assert_eq!(
+                    wrapped.params().hash,
+                    Hash::new([
+                        214, 63, 156, 35, 121, 30, 97, 4, 16, 181, 118, 216, 194, 123, 181, 174,
+                        172, 147, 204, 26, 88, 82, 36, 40, 167, 179, 42, 18, 118, 8, 88, 96
+                    ])
+                );
+                assert!(!wrapped.params().prove);
             }
             "tx_search_no_prove" => {
                 let wrapped =
@@ -1312,6 +1326,17 @@ fn incoming_fixtures() {
                     tendermint::abci::transaction::Hash::new([0; 32])
                 );
                 assert!(result.log.value().is_empty());
+            }
+            "tx" => {
+                let result = endpoint::tx::Response::from_string(content).unwrap();
+                assert_eq!(
+                    result.hash,
+                    Hash::new([
+                        214, 63, 156, 35, 121, 30, 97, 4, 16, 181, 118, 216, 194, 123, 181, 174,
+                        172, 147, 204, 26, 88, 82, 36, 40, 167, 179, 42, 18, 118, 8, 88, 96
+                    ])
+                );
+                assert_eq!(u64::from(result.height), 12u64);
             }
             "tx_search_no_prove" => {
                 let result = endpoint::tx_search::Response::from_string(content).unwrap();

--- a/rpc/tests/kvstore_fixtures/incoming/tx.json
+++ b/rpc/tests/kvstore_fixtures/incoming/tx.json
@@ -1,0 +1,46 @@
+{
+  "id": "aeca4fe2-9a71-4906-8a8e-91ea4114ea4b",
+  "jsonrpc": "2.0",
+  "result": {
+    "hash": "D63F9C23791E610410B576D8C27BB5AEAC93CC1A58522428A7B32A1276085860",
+    "height": "12",
+    "index": 2,
+    "tx": "Y29tbWl0LWtleT12YWx1ZQ==",
+    "tx_result": {
+      "code": 0,
+      "codespace": "",
+      "data": null,
+      "events": [
+        {
+          "attributes": [
+            {
+              "index": true,
+              "key": "Y3JlYXRvcg==",
+              "value": "Q29zbW9zaGkgTmV0b3dva28="
+            },
+            {
+              "index": true,
+              "key": "a2V5",
+              "value": "Y29tbWl0LWtleQ=="
+            },
+            {
+              "index": true,
+              "key": "aW5kZXhfa2V5",
+              "value": "aW5kZXggaXMgd29ya2luZw=="
+            },
+            {
+              "index": false,
+              "key": "bm9pbmRleF9rZXk=",
+              "value": "aW5kZXggaXMgd29ya2luZw=="
+            }
+          ],
+          "type": "app"
+        }
+      ],
+      "gas_used": "0",
+      "gas_wanted": "0",
+      "info": "",
+      "log": ""
+    }
+  }
+}

--- a/rpc/tests/kvstore_fixtures/outgoing/tx.json
+++ b/rpc/tests/kvstore_fixtures/outgoing/tx.json
@@ -1,0 +1,9 @@
+{
+  "id": "aeca4fe2-9a71-4906-8a8e-91ea4114ea4b",
+  "jsonrpc": "2.0",
+  "method": "tx",
+  "params": {
+    "hash": "1j+cI3keYQQQtXbYwnu1rqyTzBpYUiQop7MqEnYIWGA=",
+    "prove": false
+  }
+}

--- a/tendermint/src/abci/transaction.rs
+++ b/tendermint/src/abci/transaction.rs
@@ -2,7 +2,7 @@
 
 mod hash;
 
-pub use self::hash::Hash;
+pub use self::hash::{Hash, LENGTH as HASH_LENGTH};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, slice};
 use subtle_encoding::base64;

--- a/tendermint/src/abci/transaction/hash.rs
+++ b/tendermint/src/abci/transaction/hash.rs
@@ -12,8 +12,8 @@ use subtle_encoding::hex;
 /// Size of a transaction hash in bytes
 pub const LENGTH: usize = 32;
 
-/// Trannsaction hashes
-#[derive(Copy, Clone, Hash, PartialEq)]
+/// Transaction hashes
+#[derive(Copy, Clone, Hash, Eq)]
 pub struct Hash([u8; LENGTH]);
 
 impl Hash {
@@ -38,6 +38,12 @@ impl ConstantTimeEq for Hash {
     #[inline]
     fn ct_eq(&self, other: &Hash) -> subtle::Choice {
         self.as_bytes().ct_eq(other.as_bytes())
+    }
+}
+
+impl PartialEq for Hash {
+    fn eq(&self, other: &Hash) -> bool {
+        self.ct_eq(other).into()
     }
 }
 

--- a/tendermint/src/abci/transaction/hash.rs
+++ b/tendermint/src/abci/transaction/hash.rs
@@ -13,7 +13,7 @@ use subtle_encoding::hex;
 pub const LENGTH: usize = 32;
 
 /// Transaction hashes
-#[derive(Copy, Clone, Hash, Eq)]
+#[derive(Copy, Clone, Eq)]
 pub struct Hash([u8; LENGTH]);
 
 impl Hash {
@@ -38,6 +38,15 @@ impl ConstantTimeEq for Hash {
     #[inline]
     fn ct_eq(&self, other: &Hash) -> subtle::Choice {
         self.as_bytes().ct_eq(other.as_bytes())
+    }
+}
+
+impl core::hash::Hash for Hash {
+    fn hash<H>(&self, hasher: &mut H)
+    where
+        H: std::hash::Hasher,
+    {
+        self.0.hash(hasher)
     }
 }
 

--- a/tendermint/src/serializers.rs
+++ b/tendermint/src/serializers.rs
@@ -9,5 +9,6 @@ pub use tendermint_proto::serializers::*;
 
 pub mod apphash;
 pub mod hash;
+pub mod hash_base64;
 pub mod option_hash;
 pub mod time;

--- a/tendermint/src/serializers/hash_base64.rs
+++ b/tendermint/src/serializers/hash_base64.rs
@@ -1,0 +1,32 @@
+//! Encoding/decoding ABCI transaction hashes to/from base64.
+
+use crate::abci::transaction::{Hash, HASH_LENGTH};
+use serde::{Deserialize, Deserializer, Serializer};
+use subtle_encoding::base64;
+
+/// Deserialize a base64-encoded string into a Hash
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    let decoded = base64::decode(&s).map_err(serde::de::Error::custom)?;
+    if decoded.len() != HASH_LENGTH {
+        return Err(serde::de::Error::custom(
+            "unexpected transaction length for hash",
+        ));
+    }
+    let mut decoded_bytes = [0u8; HASH_LENGTH];
+    decoded_bytes.copy_from_slice(decoded.as_ref());
+    Ok(Hash::new(decoded_bytes))
+}
+
+/// Serialize from a Hash into a base64-encoded string
+pub fn serialize<S>(value: &Hash, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let base64_bytes = base64::encode(value.as_bytes());
+    let base64_string = String::from_utf8(base64_bytes).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&base64_string)
+}

--- a/tools/kvstore-test/tests/tendermint.rs
+++ b/tools/kvstore-test/tests/tendermint.rs
@@ -236,6 +236,7 @@ mod rpc {
         simple_transaction_subscription().await;
         concurrent_subscriptions().await;
         tx_search().await;
+        tx_search_by_hash().await;
     }
 
     async fn transaction_by_hash() {
@@ -421,6 +422,26 @@ mod rpc {
 
         subs_client.close().unwrap();
         driver_handle.await.unwrap().unwrap();
+    }
+
+    async fn tx_search_by_hash() {
+        let client = localhost_http_client();
+
+        let tx = Transaction::from(String::from("tx_search_by=hash").into_bytes());
+        let r = client.broadcast_tx_commit(tx).await.unwrap();
+        let hash = r.hash;
+
+        let r = client
+            .tx_search(
+                Query::eq("tx.hash", hash.to_string()),
+                false,
+                1,
+                10,
+                Order::Ascending,
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.total_count, 1);
     }
 
     async fn broadcast_tx(

--- a/tools/kvstore-test/tests/tendermint.rs
+++ b/tools/kvstore-test/tests/tendermint.rs
@@ -433,7 +433,7 @@ mod rpc {
 
         let r = client
             .tx_search(
-                Query::eq("tx.hash", hash.to_string()),
+                Query::from(EventType::Tx).and_eq("tx.hash", hash.to_string()),
                 false,
                 1,
                 10,


### PR DESCRIPTION
Closes #942 

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
