### PR TITLE
[WIP] Light client wasm browser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Cargo.lock
 
 # Proptest regressions dumps
 **/*.proptest-regressions
+.idea
 
 # Light Client WASM
 light-client-js/pkg/

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -51,7 +51,7 @@ serde_cbor = "0.11.1"
 serde_derive = "1.0.106"
 sled = { version = "0.34.3", optional = true }
 static_assertions = "1.1.0"
-tokio = { version = "1.0", features = ["rt"], optional = true }
+tokio = { version = "1.0", features = ["rt-multi-thread"], optional = true }
 flex-error = { version = "0.4.1", default-features = false }
 async-trait = "0.1.51"
 async-recursion = "0.3.2"

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -53,6 +53,9 @@ sled = { version = "0.34.3", optional = true }
 static_assertions = "1.1.0"
 tokio = { version = "1.0", features = ["rt"], optional = true }
 flex-error = { version = "0.4.1", default-features = false }
+async-trait = "0.1.51"
+async-recursion = "0.3.2"
+async-std = "1.9.0"
 
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen" }

--- a/light-client/examples/light_client.rs
+++ b/light-client/examples/light_client.rs
@@ -96,7 +96,7 @@ fn make_instance(
         LightClientBuilder::prod(peer_id, rpc_client, Box::new(light_store), options, None);
 
     let builder = if let (Some(height), Some(hash)) = (opts.trusted_height, opts.trusted_hash) {
-        builder.trust_primary_at(height, hash)
+        async_std::task::block_on(builder.trust_primary_at(height, hash))
     } else {
         builder.trust_from_store()
     }?;

--- a/light-client/examples/light_client.rs
+++ b/light-client/examples/light_client.rs
@@ -124,7 +124,10 @@ fn sync_cmd(opts: SyncOpts) -> Result<(), Box<dyn std::error::Error>> {
 
     let handle = supervisor.handle();
 
-    std::thread::spawn(|| supervisor.run());
+    async_std::task::spawn(async move {
+        supervisor.run().await
+    });
+
 
     loop {
         match handle.verify_to_highest() {

--- a/light-client/examples/light_client.rs
+++ b/light-client/examples/light_client.rs
@@ -61,7 +61,8 @@ struct SyncOpts {
     db_path: PathBuf,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts = CliOptions::parse_args_default_or_exit();
 
     match opts.command {
@@ -75,7 +76,8 @@ fn main() {
             eprintln!("Command failed: {}", e);
             std::process::exit(1);
         }),
-    }
+    };
+    Ok(())
 }
 
 fn make_instance(
@@ -123,8 +125,7 @@ fn sync_cmd(opts: SyncOpts) -> Result<(), Box<dyn std::error::Error>> {
         .build_prod();
 
     let handle = supervisor.handle();
-
-    async_std::task::spawn(async move {
+    tokio::task::spawn_local(async move {
         supervisor.run().await
     });
 

--- a/light-client/src/builder/light_client.rs
+++ b/light-client/src/builder/light_client.rs
@@ -139,14 +139,14 @@ impl LightClientBuilder<NoTrustedState> {
     }
 
     /// Set the block from the primary peer at the given height as the trusted state.
-    pub fn trust_primary_at(
+    pub async fn trust_primary_at(
         self,
         trusted_height: Height,
         trusted_hash: Hash,
     ) -> Result<LightClientBuilder<HasTrustedState>, Error> {
         let trusted_state = self
             .io
-            .fetch_light_block(AtHeight::At(trusted_height))
+            .fetch_light_block(AtHeight::At(trusted_height)).await
             .map_err(Error::io)?;
 
         if trusted_state.height() != trusted_height {

--- a/light-client/src/components/io.rs
+++ b/light-client/src/components/io.rs
@@ -77,13 +77,13 @@ impl IoErrorDetail {
 }
 
 /// Interface for fetching light blocks from a full node, typically via the RPC client.
-#[async_trait]
-pub trait Io: Send + Sync {
+#[async_trait(?Send)]
+pub trait Io {
     /// Fetch a light block at the given height from a peer
     async fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, IoError>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F: Send + Sync> Io for F
 where
     F: Fn(AtHeight) -> Result<LightBlock, IoError>,
@@ -119,7 +119,7 @@ mod prod {
         timeout: Option<Duration>,
     }
 
-    #[async_trait]
+    #[async_trait(?Send)]
     impl Io for ProdIo {
         async fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, IoError> {
             let signed_header = self.fetch_signed_header(height)?;

--- a/light-client/src/evidence.rs
+++ b/light-client/src/evidence.rs
@@ -9,10 +9,10 @@ use contracts::contract_trait;
 pub use tendermint::evidence::Evidence;
 
 /// Interface for reporting evidence to full nodes, typically via the RPC client.
-#[async_trait]
+#[async_trait(?Send)]
 #[contract_trait]
 #[allow(missing_docs)] // This is required because of the `contracts` crate (TODO: open/link issue)
-pub trait EvidenceReporter: Send + Sync {
+pub trait EvidenceReporter {
     /// Report evidence to all connected full nodes.
     async fn report(&self, e: Evidence, peer: PeerId) -> Result<Hash, IoError>;
 }
@@ -38,7 +38,7 @@ mod prod {
         timeout: Option<Duration>,
     }
 
-    #[async_trait]
+    #[async_trait(?Send)]
     #[contract_trait]
     impl EvidenceReporter for ProdEvidenceReporter {
         #[pre(self.peer_map.contains_key(&peer))]

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -36,7 +36,7 @@ pub enum Fork {
 }
 
 /// Interface for a fork detector
-#[async_trait]
+#[async_trait(?Send)]
 pub trait ForkDetector: Send + Sync {
     /// Detect forks using the given verified block, trusted block,
     /// and list of witnesses to verify the given light block against.
@@ -77,7 +77,7 @@ impl Default for ProdForkDetector {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl ForkDetector for ProdForkDetector {
     /// Perform fork detection. See the documentation `ProdForkDetector` for details.
     async fn detect_forks(

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -4,7 +4,6 @@
 
 use std::{fmt, time::Duration};
 
-use contracts::*;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
@@ -118,13 +117,13 @@ impl LightClient {
     /// Attempt to update the light client to the highest block of the primary node.
     ///
     /// Note: This function delegates the actual work to `verify_to_target`.
-    pub fn verify_to_highest(&mut self, state: &mut State) -> Result<LightBlock, Error> {
+    pub async fn verify_to_highest(&mut self, state: &mut State) -> Result<LightBlock, Error> {
         let target_block = self
             .io
-            .fetch_light_block(AtHeight::Highest)
+            .fetch_light_block(AtHeight::Highest).await
             .map_err(Error::io)?;
 
-        self.verify_to_target(target_block.height(), state)
+        self.verify_to_target(target_block.height(), state).await
     }
 
     /// Update the light client to a block of the primary node at the given height.
@@ -157,13 +156,13 @@ impl LightClient {
     /// - If the core verification loop invariant is violated [LCV-INV-TP.1]
     /// - If verification of a light block fails
     /// - If the fetching a light block from the primary node fails
-    #[post(
-        ret.is_ok() ==> trusted_store_contains_block_at_target_height(
-            state.light_store.as_ref(),
-            target_height,
-        )
-    )]
-    pub fn verify_to_target(
+    // #[post(
+    //     ret.is_ok() ==> trusted_store_contains_block_at_target_height(
+    //         state.light_store.as_ref(),
+    //         target_height,
+    //     )
+    // )]
+    pub async fn verify_to_target(
         &self,
         target_height: Height,
         state: &mut State,
@@ -182,15 +181,15 @@ impl LightClient {
 
         if target_height >= highest.height() {
             // Perform forward verification with bisection
-            self.verify_forward(target_height, state)
+            self.verify_forward(target_height, state).await
         } else {
             // Perform sequential backward verification
-            self.verify_backward(target_height, state)
+            self.verify_backward(target_height, state).await
         }
     }
 
     /// Perform forward verification with bisection.
-    fn verify_forward(
+    async fn verify_forward(
         &self,
         target_height: Height,
         state: &mut State,
@@ -232,7 +231,7 @@ impl LightClient {
 
             // Fetch the block at the current height from the light store if already present,
             // or from the primary peer otherwise.
-            let (current_block, status) = self.get_or_fetch_block(current_height, state)?;
+            let (current_block, status) = self.get_or_fetch_block(current_height, state).await?;
 
             // Validate and verify the current block
             let verdict = self
@@ -273,7 +272,7 @@ impl LightClient {
     /// Stub for when "unstable" feature is disabled.
     #[doc(hidden)]
     #[cfg(not(feature = "unstable"))]
-    fn verify_backward(
+    async fn verify_backward(
         &self,
         target_height: Height,
         state: &mut State,
@@ -308,7 +307,7 @@ impl LightClient {
     /// height is lower than the highest trusted state will result in a
     /// `TargetLowerThanTrustedState` error.
     #[cfg(feature = "unstable")]
-    fn verify_backward(
+    async fn verify_backward(
         &self,
         target_height: Height,
         state: &mut State,
@@ -337,7 +336,7 @@ impl LightClient {
         let mut latest = root;
 
         for height in heights {
-            let (current, _status) = self.get_or_fetch_block(height, state)?;
+            let (current, _status) = self.get_or_fetch_block(height, state).await?;
 
             let latest_last_block_id = latest
                 .signed_header
@@ -379,8 +378,8 @@ impl LightClient {
     ///
     /// ## Postcondition
     /// - The provider of block that is returned matches the given peer.
-    #[post(ret.as_ref().map(|(lb, _)| lb.provider == self.peer).unwrap_or(true))]
-    pub fn get_or_fetch_block(
+    // #[post(ret.as_ref().map(|(lb, _)| lb.provider == self.peer).unwrap_or(true))]
+    pub async fn get_or_fetch_block(
         &self,
         height: Height,
         state: &mut State,
@@ -393,7 +392,7 @@ impl LightClient {
 
         let block = self
             .io
-            .fetch_light_block(AtHeight::At(height))
+            .fetch_light_block(AtHeight::At(height)).await
             .map_err(Error::io)?;
 
         state.light_store.insert(block.clone(), Status::Unverified);

--- a/light-client/src/peer_list.rs
+++ b/light-client/src/peer_list.rs
@@ -219,8 +219,9 @@ impl<T> PeerListBuilder<T> {
     ///
     /// ## Precondition
     /// - A primary has been set with a call to `PeerListBuilder::primary`.
+
+    // #[post(PeerList::invariant(&ret))]
     #[pre(self.primary.is_some())]
-    #[post(PeerList::invariant(&ret))]
     pub fn build(self) -> PeerList<T> {
         PeerList {
             values: self.values,

--- a/light-client/src/peer_list.rs
+++ b/light-client/src/peer_list.rs
@@ -195,7 +195,7 @@ impl<T> PeerListBuilder<T> {
     }
 
     /// Register the given peer id and value as a witness.
-    #[pre(self.primary != Some(peer_id))]
+    // #[pre(self.primary != Some(peer_id))]
     pub fn witness(&mut self, peer_id: PeerId, value: T) {
         self.values.insert(peer_id, value);
         self.witnesses.insert(peer_id);

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -139,7 +139,7 @@ impl std::fmt::Debug for Supervisor {
 }
 
 // Ensure the `Supervisor` can be sent across thread boundaries.
-static_assertions::assert_impl_all!(Supervisor: Send);
+// static_assertions::assert_impl_all!(Supervisor: Send);
 
 impl Supervisor {
     /// Constructs a new supervisor from the given list of peers and fork detector instance.
@@ -199,7 +199,7 @@ impl Supervisor {
 
     /// Verify either to the latest block (if `height == None`) or to a given block (if `height ==
     /// Some(height)`).
-    #[async_recursion]
+    #[async_recursion(?Send)]
     async fn verify(&mut self, height: Option<Height>) -> Result<LightBlock, Error> {
         let primary = self.peers.primary_mut();
 
@@ -499,7 +499,7 @@ mod tests {
         );
 
         let handle = supervisor.handle();
-        async_std::task::spawn(async move {
+        tokio::task::spawn_local(async move {
             supervisor.run().await
         });
 

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tendermint::block::Height as HeightStr;
 use tendermint::evidence::{Duration as DurationStr, Evidence};
+use async_trait::async_trait;
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct TestCases<LB> {
@@ -124,9 +125,10 @@ impl Io for MockIo {
 #[derive(Clone, Debug, Default)]
 pub struct MockEvidenceReporter;
 
+#[async_trait]
 #[contract_trait]
 impl EvidenceReporter for MockEvidenceReporter {
-    fn report(&self, _e: Evidence, _peer: PeerId) -> Result<Hash, IoError> {
+    async fn report(&self, _e: Evidence, _peer: PeerId) -> Result<Hash, IoError> {
         Ok(Hash::new([0; 32]))
     }
 }

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -164,12 +164,12 @@ pub fn verify_single(
     }
 }
 
-pub fn verify_bisection(
+pub async fn verify_bisection(
     untrusted_height: Height,
     light_client: &mut LightClient,
     state: &mut State,
 ) -> Result<Vec<LightBlock>, Error> {
-    async_std::task::block_on(light_client
+    light_client
         .verify_to_target(untrusted_height, state)
-    ).map(|_| state.get_trace(untrusted_height))
+    .await.map(|_| state.get_trace(untrusted_height))
 }

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -107,8 +107,9 @@ impl MockIo {
     }
 }
 
+#[async_trait]
 impl Io for MockIo {
-    fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, IoError> {
+    async fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, IoError> {
         let height = match height {
             AtHeight::Highest => self.latest_height,
             AtHeight::At(height) => height,
@@ -168,7 +169,7 @@ pub fn verify_bisection(
     light_client: &mut LightClient,
     state: &mut State,
 ) -> Result<Vec<LightBlock>, Error> {
-    light_client
+    async_std::task::block_on(light_client
         .verify_to_target(untrusted_height, state)
-        .map(|_| state.get_trace(untrusted_height))
+    ).map(|_| state.get_trace(untrusted_height))
 }

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -107,7 +107,7 @@ impl MockIo {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl Io for MockIo {
     async fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, IoError> {
         let height = match height {
@@ -126,7 +126,7 @@ impl Io for MockIo {
 #[derive(Clone, Debug, Default)]
 pub struct MockEvidenceReporter;
 
-#[async_trait]
+#[async_trait(?Send)]
 #[contract_trait]
 impl EvidenceReporter for MockEvidenceReporter {
     async fn report(&self, _e: Evidence, _peer: PeerId) -> Result<Hash, IoError> {

--- a/light-client/tests/light_client.rs
+++ b/light-client/tests/light_client.rs
@@ -76,7 +76,7 @@ fn run_test(tc: LightClientTest<LightBlock>) -> BisectionTestResult {
         io.clone(),
     );
 
-    let result = verify_bisection(untrusted_height, &mut light_client, &mut state);
+    let result = async_std::task::block_on(verify_bisection(untrusted_height, &mut light_client, &mut state));
 
     let untrusted_light_block = async_std::task::block_on(io
         .fetch_light_block(AtHeight::At(untrusted_height)))

--- a/light-client/tests/light_client.rs
+++ b/light-client/tests/light_client.rs
@@ -51,8 +51,8 @@ fn run_test(tc: LightClientTest<LightBlock>) -> BisectionTestResult {
     let io = MockIo::new(provider.chain_id, provider.lite_blocks);
 
     let trusted_height = tc.trust_options.height;
-    let trusted_state = io
-        .fetch_light_block(AtHeight::At(trusted_height))
+    let trusted_state = async_std::task::block_on(io
+        .fetch_light_block(AtHeight::At(trusted_height)))
         .expect("could not 'request' light block");
 
     let mut light_store = MemoryStore::new();
@@ -78,8 +78,8 @@ fn run_test(tc: LightClientTest<LightBlock>) -> BisectionTestResult {
 
     let result = verify_bisection(untrusted_height, &mut light_client, &mut state);
 
-    let untrusted_light_block = io
-        .fetch_light_block(AtHeight::At(untrusted_height))
+    let untrusted_light_block = async_std::task::block_on(io
+        .fetch_light_block(AtHeight::At(untrusted_height)))
         .expect("header at untrusted height not found");
 
     BisectionTestResult {

--- a/light-client/tests/supervisor.rs
+++ b/light-client/tests/supervisor.rs
@@ -92,7 +92,10 @@ fn run_multipeer_test(tc: LightClientTest<LightBlock>) {
     // TODO: Add method to `Handle` to get a copy of the current peer list
 
     let handle = supervisor.handle();
-    std::thread::spawn(|| supervisor.run());
+    async_std::task::spawn(async move {
+        supervisor.run().await
+    });
+
 
     let target_height = tc.height_to_verify;
 

--- a/light-client/tests/supervisor.rs
+++ b/light-client/tests/supervisor.rs
@@ -28,8 +28,8 @@ const TEST_FILES_PATH: &str = "./tests/support/";
 
 fn make_instance(peer_id: PeerId, trust_options: TrustOptions, io: MockIo, now: Time) -> Instance {
     let trusted_height = trust_options.height;
-    let trusted_state = io
-        .fetch_light_block(AtHeight::At(trusted_height))
+    let trusted_state = async_std::task::block_on(io
+        .fetch_light_block(AtHeight::At(trusted_height)))
         .expect("could not 'request' light block");
 
     let mut light_store = MemoryStore::new();
@@ -102,8 +102,8 @@ fn run_multipeer_test(tc: LightClientTest<LightBlock>) {
     match handle.verify_to_target(target_height) {
         Ok(new_state) => {
             // Check that the expected state and new_state match
-            let untrusted_light_block = io
-                .fetch_light_block(AtHeight::At(target_height))
+            let untrusted_light_block = async_std::task::block_on(io
+                .fetch_light_block(AtHeight::At(target_height)))
                 .expect("header at untrusted height not found");
 
             let expected_state = untrusted_light_block;

--- a/light-client/tests/supervisor.rs
+++ b/light-client/tests/supervisor.rs
@@ -92,7 +92,7 @@ fn run_multipeer_test(tc: LightClientTest<LightBlock>) {
     // TODO: Add method to `Handle` to get a copy of the current peer list
 
     let handle = supervisor.handle();
-    async_std::task::spawn(async move {
+    tokio::task::spawn_local(async move {
         supervisor.run().await
     });
 


### PR DESCRIPTION
closes #809 

Summary:
* Io, EvidenceReporter and ForkDetector are now async traits. Conditionally compiling this would be tedious.
* Removed Send + Sync assertion from above traits since wasm futures can never return Send+Sync since they use Rc (unless I am wrong). This means supervisor cannot be shared between threads, currently using tokio to run supervisor in the main thread as an async task.
This can probably be conditionally compiled, when not in wasm Send+Sync will be enabled.
* Disabled a few contracts to allow setting a peer as both a primary and witness, this is useful for testing.

TODO:
* Port tendermint-rpc from hyper to reqwest for wasm compatibility
* Conditionally compile as many features as possible
* Make tests use tokio to avoid panic





