### PR TITLE
Refactor Light Client verification predicates interface for use from IBC

### DIFF
--- a/.changelog/unreleased/breaking-changes/956-light-client-predicates-ibc.md
+++ b/.changelog/unreleased/breaking-changes/956-light-client-predicates-ibc.md
@@ -1,0 +1,4 @@
+- `[tendermint_light_client]` The light client verification functionality has
+  been refactored (including breaking changes to the API) such that it can be
+  more easily used from both `tendermint_light_client` and `ibc-rs`
+  ([#956](https://github.com/informalsystems/tendermint-rs/issues/956))

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -33,8 +33,8 @@ pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &J
         |(untrusted, trusted, options, now)| {
             let verifier = ProdVerifier::default();
             verifier.verify(
-                untrusted.verify_params(),
-                trusted.verify_params(),
+                untrusted.as_untrusted_state(),
+                trusted.as_trusted_state(),
                 &options,
                 now,
             )

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -32,7 +32,12 @@ pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &J
     let result = deserialize_params(untrusted, trusted, options, now).map(
         |(untrusted, trusted, options, now)| {
             let verifier = ProdVerifier::default();
-            verifier.verify(untrusted.state(), trusted.state(), &options, now)
+            verifier.verify(
+                untrusted.verification_state(),
+                trusted.verification_state(),
+                &options,
+                now,
+            )
         },
     );
     JsValue::from_serde(&result).unwrap()

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -33,8 +33,8 @@ pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &J
         |(untrusted, trusted, options, now)| {
             let verifier = ProdVerifier::default();
             verifier.verify(
-                untrusted.verification_state(),
-                trusted.verification_state(),
+                untrusted.verify_params(),
+                trusted.verify_params(),
                 &options,
                 now,
             )

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -32,7 +32,7 @@ pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &J
     let result = deserialize_params(untrusted, trusted, options, now).map(
         |(untrusted, trusted, options, now)| {
             let verifier = ProdVerifier::default();
-            verifier.verify(&untrusted, &trusted, &options, now)
+            verifier.verify(untrusted.state(), trusted.state(), &options, now)
         },
     );
     JsValue::from_serde(&result).unwrap()

--- a/light-client/src/builder/light_client.rs
+++ b/light-client/src/builder/light_client.rs
@@ -178,11 +178,19 @@ impl LightClientBuilder<NoTrustedState> {
             .map_err(Error::invalid_light_block)?;
 
         self.predicates
-            .validator_sets_match(light_block, &*self.hasher)
+            .validator_sets_match(
+                &light_block.validators,
+                light_block.signed_header.header.validators_hash,
+                &*self.hasher,
+            )
             .map_err(Error::invalid_light_block)?;
 
         self.predicates
-            .next_validators_match(light_block, &*self.hasher)
+            .next_validators_match(
+                &light_block.next_validators,
+                light_block.signed_header.header.next_validators_hash,
+                &*self.hasher,
+            )
             .map_err(Error::invalid_light_block)?;
 
         Ok(())

--- a/light-client/src/builder/light_client.rs
+++ b/light-client/src/builder/light_client.rs
@@ -170,11 +170,11 @@ impl LightClientBuilder<NoTrustedState> {
         let now = self.clock.now();
 
         self.predicates
-            .is_within_trust_period(header, self.options.trusting_period, now)
+            .is_within_trust_period(header.time, self.options.trusting_period, now)
             .map_err(Error::invalid_light_block)?;
 
         self.predicates
-            .is_header_from_past(header, self.options.clock_drift, now)
+            .is_header_from_past(header.time, self.options.clock_drift, now)
             .map_err(Error::invalid_light_block)?;
 
         self.predicates

--- a/light-client/src/components/verifier.rs
+++ b/light-client/src/components/verifier.rs
@@ -2,7 +2,7 @@
 
 use crate::operations::voting_power::VotingPowerTally;
 use crate::predicates as preds;
-use crate::types::VerificationState;
+use crate::types::VerifyParams;
 use crate::{
     errors::ErrorExt,
     light_client::Options,
@@ -56,8 +56,8 @@ pub trait Verifier: Send + Sync {
     /// Perform the verification.
     fn verify(
         &self,
-        untrusted: VerificationState<'_>,
-        trusted: VerificationState<'_>,
+        untrusted: VerifyParams<'_>,
+        trusted: VerifyParams<'_>,
         options: &Options,
         now: Time,
     ) -> Verdict;
@@ -138,8 +138,8 @@ where
     ///   the trusted block.
     fn verify(
         &self,
-        untrusted: VerificationState<'_>,
-        trusted: VerificationState<'_>,
+        untrusted: VerifyParams<'_>,
+        trusted: VerifyParams<'_>,
         options: &Options,
         now: Time,
     ) -> Verdict {

--- a/light-client/src/components/verifier.rs
+++ b/light-client/src/components/verifier.rs
@@ -2,6 +2,7 @@
 
 use crate::operations::voting_power::VotingPowerTally;
 use crate::predicates as preds;
+use crate::types::LightBlockState;
 use crate::{
     errors::ErrorExt,
     light_client::Options,
@@ -9,7 +10,7 @@ use crate::{
         CommitValidator, Hasher, ProdCommitValidator, ProdHasher, ProdVotingPowerCalculator,
         VotingPowerCalculator,
     },
-    types::{LightBlock, Time},
+    types::Time,
 };
 use preds::{
     errors::{VerificationError, VerificationErrorDetail},
@@ -55,75 +56,178 @@ pub trait Verifier: Send + Sync {
     /// Perform the verification.
     fn verify(
         &self,
-        untrusted: &LightBlock,
-        trusted: &LightBlock,
+        untrusted: LightBlockState<'_>,
+        trusted: LightBlockState<'_>,
         options: &Options,
         now: Time,
     ) -> Verdict;
 }
 
-/// Production implementation of the verifier.
-///
-/// For testing purposes, this implementation is parametrized by:
-/// - A set of predicates used to validate a light block
-/// - A voting power calculator
-/// - A commit validator
-/// - A header hasher
-///
-/// For regular use, one can construct a standard implementation with `ProdVerifier::default()`.
-pub struct ProdVerifier {
-    predicates: Box<dyn VerificationPredicates>,
-    voting_power_calculator: Box<dyn VotingPowerCalculator>,
-    commit_validator: Box<dyn CommitValidator>,
-    hasher: Box<dyn Hasher>,
+macro_rules! verdict {
+    ($e:expr) => {
+        let result = $e;
+        if result.is_err() {
+            return result.into();
+        }
+    };
 }
 
-impl ProdVerifier {
-    /// Constructs a new instance of this struct
-    pub fn new(
-        predicates: impl VerificationPredicates + 'static,
-        voting_power_calculator: impl VotingPowerCalculator + 'static,
-        commit_validator: impl CommitValidator + 'static,
-        hasher: impl Hasher + 'static,
-    ) -> Self {
+/// Predicate verifier encapsulating components necessary to facilitate
+/// verification.
+pub struct PredicateVerifier<P, C, V, H> {
+    predicates: P,
+    voting_power_calculator: C,
+    commit_validator: V,
+    hasher: H,
+}
+
+impl<P, C, V, H> Default for PredicateVerifier<P, C, V, H>
+where
+    P: Default,
+    C: Default,
+    V: Default,
+    H: Default,
+{
+    fn default() -> Self {
         Self {
-            predicates: Box::new(predicates),
-            voting_power_calculator: Box::new(voting_power_calculator),
-            commit_validator: Box::new(commit_validator),
-            hasher: Box::new(hasher),
+            predicates: P::default(),
+            voting_power_calculator: C::default(),
+            commit_validator: V::default(),
+            hasher: H::default(),
         }
     }
 }
 
-impl Default for ProdVerifier {
-    fn default() -> Self {
-        Self::new(
-            ProdPredicates::default(),
-            ProdVotingPowerCalculator::default(),
-            ProdCommitValidator::default(),
-            ProdHasher::default(),
-        )
+impl<P, C, V, H> PredicateVerifier<P, C, V, H>
+where
+    P: VerificationPredicates,
+    C: VotingPowerCalculator,
+    V: CommitValidator,
+    H: Hasher,
+{
+    /// Constructor.
+    pub fn new(predicates: P, voting_power_calculator: C, commit_validator: V, hasher: H) -> Self {
+        Self {
+            predicates,
+            voting_power_calculator,
+            commit_validator,
+            hasher,
+        }
     }
 }
 
-impl Verifier for ProdVerifier {
+impl<P, C, V, H> Verifier for PredicateVerifier<P, C, V, H>
+where
+    P: VerificationPredicates,
+    C: VotingPowerCalculator,
+    V: CommitValidator,
+    H: Hasher,
+{
+    /// Validate the given light block.
+    ///
+    /// - Ensure the latest trusted header hasn't expired
+    /// - Ensure the header validator hashes match the given validators
+    /// - Ensure the header next validator hashes match the given next
+    ///   validators
+    /// - Additional implementation specific validation via `commit_validator`
+    /// - Check that the untrusted block is more recent than the trusted state
+    /// - If the untrusted block is the very next block after the trusted block,
+    ///   check that their (next) validator sets hashes match.
+    /// - Otherwise, ensure that the untrusted block has a greater height than
+    ///   the trusted block.
     fn verify(
         &self,
-        untrusted: &LightBlock,
-        trusted: &LightBlock,
+        untrusted: LightBlockState<'_>,
+        trusted: LightBlockState<'_>,
         options: &Options,
         now: Time,
     ) -> Verdict {
-        preds::verify(
-            &*self.predicates,
-            &*self.voting_power_calculator,
-            &*self.commit_validator,
-            &*self.hasher,
-            trusted,
-            untrusted,
-            options,
+        // Ensure the latest trusted header hasn't expired
+        verdict!(self.predicates.is_within_trust_period(
+            &trusted.signed_header.header,
+            options.trusting_period,
             now,
-        )
-        .into()
+        ));
+
+        // Ensure the header isn't from a future time
+        verdict!(self.predicates.is_header_from_past(
+            &untrusted.signed_header.header,
+            options.clock_drift,
+            now,
+        ));
+
+        // Ensure the header validator hashes match the given validators
+        verdict!(self.predicates.validator_sets_match(
+            untrusted.validators,
+            untrusted.signed_header.header.validators_hash,
+            &self.hasher,
+        ));
+
+        // Ensure the header next validator hashes match the given next validators
+        verdict!(self.predicates.next_validators_match(
+            untrusted.next_validators,
+            untrusted.signed_header.header.next_validators_hash,
+            &self.hasher,
+        ));
+
+        // Ensure the header matches the commit
+        verdict!(self.predicates.header_matches_commit(
+            &untrusted.signed_header.header,
+            untrusted.signed_header.commit.block_id.hash,
+            &self.hasher,
+        ));
+
+        // Additional implementation specific validation
+        verdict!(self.predicates.valid_commit(
+            untrusted.signed_header,
+            untrusted.validators,
+            &self.commit_validator,
+        ));
+
+        // Check that the untrusted block is more recent than the trusted state
+        verdict!(self.predicates.is_monotonic_bft_time(
+            &untrusted.signed_header.header,
+            &trusted.signed_header.header,
+        ));
+
+        let trusted_next_height = trusted.height().increment();
+
+        if untrusted.height() == trusted_next_height {
+            // If the untrusted block is the very next block after the trusted block,
+            // check that their (next) validator sets hashes match.
+            verdict!(self.predicates.valid_next_validator_set(
+                &untrusted.signed_header.header,
+                &trusted.signed_header.header,
+            ));
+        } else {
+            // Otherwise, ensure that the untrusted block has a greater height than
+            // the trusted block.
+            verdict!(self.predicates.is_monotonic_height(
+                &untrusted.signed_header.header,
+                &trusted.signed_header.header,
+            ));
+
+            // Check there is enough overlap between the validator sets of
+            // the trusted and untrusted blocks.
+            verdict!(self.predicates.has_sufficient_validators_overlap(
+                untrusted.signed_header,
+                trusted.next_validators,
+                &options.trust_threshold,
+                &self.voting_power_calculator,
+            ));
+        }
+
+        // Verify that more than 2/3 of the validators correctly committed the block.
+        verdict!(self.predicates.has_sufficient_signers_overlap(
+            untrusted.signed_header,
+            untrusted.validators,
+            &self.voting_power_calculator,
+        ));
+
+        Verdict::Success
     }
 }
+
+/// The default production implementation of the [`PredicateVerifier`].
+pub type ProdVerifier =
+    PredicateVerifier<ProdPredicates, ProdVotingPowerCalculator, ProdCommitValidator, ProdHasher>;

--- a/light-client/src/components/verifier.rs
+++ b/light-client/src/components/verifier.rs
@@ -2,7 +2,7 @@
 
 use crate::operations::voting_power::VotingPowerTally;
 use crate::predicates as preds;
-use crate::types::LightBlockState;
+use crate::types::VerificationState;
 use crate::{
     errors::ErrorExt,
     light_client::Options,
@@ -56,8 +56,8 @@ pub trait Verifier: Send + Sync {
     /// Perform the verification.
     fn verify(
         &self,
-        untrusted: LightBlockState<'_>,
-        trusted: LightBlockState<'_>,
+        untrusted: VerificationState<'_>,
+        trusted: VerificationState<'_>,
         options: &Options,
         now: Time,
     ) -> Verdict;
@@ -74,6 +74,7 @@ macro_rules! verdict {
 
 /// Predicate verifier encapsulating components necessary to facilitate
 /// verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PredicateVerifier<P, C, V, H> {
     predicates: P,
     voting_power_calculator: C,
@@ -123,7 +124,7 @@ where
     V: CommitValidator,
     H: Hasher,
 {
-    /// Validate the given light block.
+    /// Validate the given light block state.
     ///
     /// - Ensure the latest trusted header hasn't expired
     /// - Ensure the header validator hashes match the given validators
@@ -137,8 +138,8 @@ where
     ///   the trusted block.
     fn verify(
         &self,
-        untrusted: LightBlockState<'_>,
-        trusted: LightBlockState<'_>,
+        untrusted: VerificationState<'_>,
+        trusted: VerificationState<'_>,
         options: &Options,
         now: Time,
     ) -> Verdict {

--- a/light-client/src/components/verifier.rs
+++ b/light-client/src/components/verifier.rs
@@ -136,6 +136,10 @@ where
     ///   check that their (next) validator sets hashes match.
     /// - Otherwise, ensure that the untrusted block has a greater height than
     ///   the trusted block.
+    ///
+    /// **NOTE**: If the untrusted state's `next_validators` field is `None`,
+    /// this will not (and will not be able to) check whether the untrusted
+    /// state's `next_validators_hash` field is valid.
     fn verify(
         &self,
         untrusted: UntrustedBlockState<'_>,

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -236,8 +236,8 @@ impl LightClient {
 
             // Validate and verify the current block
             let verdict = self.verifier.verify(
-                current_block.verification_state(),
-                trusted_state.verification_state(),
+                current_block.verify_params(),
+                trusted_state.verify_params(),
                 &self.options,
                 now,
             );

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -235,9 +235,12 @@ impl LightClient {
             let (current_block, status) = self.get_or_fetch_block(current_height, state)?;
 
             // Validate and verify the current block
-            let verdict = self
-                .verifier
-                .verify(&current_block, &trusted_state, &self.options, now);
+            let verdict = self.verifier.verify(
+                current_block.state(),
+                trusted_state.state(),
+                &self.options,
+                now,
+            );
 
             match verdict {
                 Verdict::Success => {

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -236,8 +236,8 @@ impl LightClient {
 
             // Validate and verify the current block
             let verdict = self.verifier.verify(
-                current_block.state(),
-                trusted_state.state(),
+                current_block.verification_state(),
+                trusted_state.verification_state(),
                 &self.options,
                 now,
             );

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -201,22 +201,22 @@ impl LightClient {
             let now = self.clock.now();
 
             // Get the latest trusted state
-            let trusted_state = state
+            let trusted_block = state
                 .light_store
                 .highest_trusted_or_verified()
                 .ok_or_else(Error::no_initial_trusted_state)?;
 
-            if target_height < trusted_state.height() {
+            if target_height < trusted_block.height() {
                 return Err(Error::target_lower_than_trusted_state(
                     target_height,
-                    trusted_state.height(),
+                    trusted_block.height(),
                 ));
             }
 
             // Check invariant [LCV-INV-TP.1]
-            if !is_within_trust_period(&trusted_state, self.options.trusting_period, now) {
+            if !is_within_trust_period(&trusted_block, self.options.trusting_period, now) {
                 return Err(Error::trusted_state_outside_trusting_period(
-                    Box::new(trusted_state),
+                    Box::new(trusted_block),
                     self.options,
                 ));
             }
@@ -226,8 +226,8 @@ impl LightClient {
 
             // If the trusted state is now at a height equal to the target height, we are done.
             // [LCV-DIST-LIFE.1]
-            if target_height == trusted_state.height() {
-                return Ok(trusted_state);
+            if target_height == trusted_block.height() {
+                return Ok(trusted_block);
             }
 
             // Fetch the block at the current height from the light store if already present,
@@ -236,8 +236,8 @@ impl LightClient {
 
             // Validate and verify the current block
             let verdict = self.verifier.verify(
-                current_block.verify_params(),
-                trusted_state.verify_params(),
+                current_block.as_untrusted_state(),
+                trusted_block.as_trusted_state(),
                 &self.options,
                 now,
             );

--- a/light-client/src/operations/commit_validator.rs
+++ b/light-client/src/operations/commit_validator.rs
@@ -26,17 +26,16 @@ pub trait CommitValidator: Send + Sync {
 }
 
 /// Production-ready implementation of a commit validator
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProdCommitValidator {
-    hasher: Box<dyn Hasher>,
+    hasher: ProdHasher,
 }
 
 impl ProdCommitValidator {
     /// Create a new commit validator using the given [`Hasher`]
     /// to compute the hash of headers and validator sets.
-    pub fn new(hasher: impl Hasher + 'static) -> Self {
-        Self {
-            hasher: Box::new(hasher),
-        }
+    pub fn new(hasher: ProdHasher) -> Self {
+        Self { hasher }
     }
 }
 

--- a/light-client/src/operations/hasher.rs
+++ b/light-client/src/operations/hasher.rs
@@ -2,34 +2,23 @@
 
 use crate::types::{Header, ValidatorSet};
 
-use tendermint::{merkle, Hash};
+use tendermint::Hash;
 
 /// Hashing for headers and validator sets
 pub trait Hasher: Send + Sync {
     /// Hash the given header
-    fn hash_header(&self, header: &Header) -> Hash;
+    fn hash_header(&self, header: &Header) -> Hash {
+        header.hash()
+    }
 
     /// Hash the given validator set
-    fn hash_validator_set(&self, validator_set: &ValidatorSet) -> Hash;
+    fn hash_validator_set(&self, validator_set: &ValidatorSet) -> Hash {
+        validator_set.hash()
+    }
 }
 
 /// Default implementation of a hasher
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ProdHasher;
 
-impl Hasher for ProdHasher {
-    fn hash_header(&self, header: &Header) -> Hash {
-        header.hash()
-    }
-
-    /// Compute the Merkle root of the validator set
-    fn hash_validator_set(&self, validator_set: &ValidatorSet) -> Hash {
-        let validator_bytes: Vec<Vec<u8>> = validator_set
-            .validators()
-            .iter()
-            .map(|validator| validator.hash_bytes())
-            .collect();
-
-        Hash::Sha256(merkle::simple_hash_from_byte_vectors(validator_bytes))
-    }
-}
+impl Hasher for ProdHasher {}

--- a/light-client/src/operations/hasher.rs
+++ b/light-client/src/operations/hasher.rs
@@ -18,7 +18,7 @@ pub trait Hasher: Send + Sync {
 }
 
 /// Default implementation of a hasher
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ProdHasher;
 
 impl Hasher for ProdHasher {}

--- a/light-client/src/operations/voting_power.rs
+++ b/light-client/src/operations/voting_power.rs
@@ -98,7 +98,7 @@ pub trait VotingPowerCalculator: Send + Sync {
 }
 
 /// Default implementation of a `VotingPowerCalculator`
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ProdVotingPowerCalculator;
 
 impl VotingPowerCalculator for ProdVotingPowerCalculator {

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -14,7 +14,7 @@ pub mod errors;
 
 /// Production predicates, using the default implementation
 /// of the `VerificationPredicates` trait.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ProdPredicates;
 impl VerificationPredicates for ProdPredicates {}
 

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -189,8 +189,8 @@ pub trait VerificationPredicates: Send + Sync {
     /// the hash of the validator set in the untrusted one.
     fn valid_next_validator_set(
         &self,
-        trusted_header: &Header,
         untrusted_header: &Header,
+        trusted_header: &Header,
     ) -> Result<(), VerificationError> {
         if trusted_header.next_validators_hash == untrusted_header.validators_hash {
             Ok(())
@@ -271,8 +271,8 @@ pub fn verify(
         // If the untrusted block is the very next block after the trusted block,
         // check that their (next) validator sets hashes match.
         vp.valid_next_validator_set(
-            &trusted.signed_header.header,
             &untrusted.signed_header.header,
+            &trusted.signed_header.header,
         )?;
     } else {
         // Otherwise, ensure that the untrusted block has a greater height than
@@ -660,8 +660,8 @@ mod tests {
         // Test scenarios -->
         // 1. next_validator_set hash matches
         let result_ok = vp.valid_next_validator_set(
-            &light_block2.signed_header.header,
             &light_block1.signed_header.header,
+            &light_block2.signed_header.header,
         );
 
         assert!(result_ok.is_ok());
@@ -677,8 +677,8 @@ mod tests {
             .into();
 
         let result_err = vp.valid_next_validator_set(
-            &light_block2.signed_header.header,
             &light_block3.signed_header.header,
+            &light_block2.signed_header.header,
         );
 
         match result_err {

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -138,7 +138,7 @@ impl MockEvidenceReporter {
 }
 
 pub fn verify_single(
-    trusted_state: LightBlock,
+    trusted_block: LightBlock,
     input: LightBlock,
     trust_threshold: TrustThreshold,
     trusting_period: Duration,
@@ -154,8 +154,8 @@ pub fn verify_single(
     };
 
     let result = verifier.verify(
-        input.verify_params(),
-        trusted_state.verify_params(),
+        input.as_untrusted_state(),
+        trusted_block.as_trusted_state(),
         &options,
         now,
     );

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -153,7 +153,7 @@ pub fn verify_single(
         clock_drift,
     };
 
-    let result = verifier.verify(&input, &trusted_state, &options, now);
+    let result = verifier.verify(input.state(), trusted_state.state(), &options, now);
 
     match result {
         Verdict::Success => Ok(input),

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -153,7 +153,12 @@ pub fn verify_single(
         clock_drift,
     };
 
-    let result = verifier.verify(input.state(), trusted_state.state(), &options, now);
+    let result = verifier.verify(
+        input.verification_state(),
+        trusted_state.verification_state(),
+        &options,
+        now,
+    );
 
     match result {
         Verdict::Success => Ok(input),

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -154,8 +154,8 @@ pub fn verify_single(
     };
 
     let result = verifier.verify(
-        input.verification_state(),
-        trusted_state.verification_state(),
+        input.verify_params(),
+        trusted_state.verify_params(),
         &options,
         now,
     );

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -77,6 +77,7 @@ impl Status {
     }
 }
 
+/// Trusted block parameters needed for light client verification.
 pub struct TrustedBlockState<'a> {
     pub header_time: Time,
     pub height: Height,
@@ -84,6 +85,7 @@ pub struct TrustedBlockState<'a> {
     pub next_validators_hash: Hash,
 }
 
+/// Untrusted block parameters needed for light client verification.
 pub struct UntrustedBlockState<'a> {
     pub signed_header: &'a SignedHeader,
     pub validators: &'a ValidatorSet,
@@ -138,7 +140,8 @@ impl LightBlock {
         self.signed_header.header.height
     }
 
-    /// Obtain the verification parameters for the light block.
+    /// Obtain the verification parameters for the light block when using it as
+    /// trusted state.
     pub fn as_trusted_state(&self) -> TrustedBlockState<'_> {
         TrustedBlockState {
             header_time: self.signed_header.header.time,
@@ -148,6 +151,8 @@ impl LightBlock {
         }
     }
 
+    /// Obtain the verification parameters for the light block when using it as
+    /// untrusted state.
     pub fn as_untrusted_state(&self) -> UntrustedBlockState<'_> {
         UntrustedBlockState {
             signed_header: &self.signed_header,

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -77,15 +77,28 @@ impl Status {
     }
 }
 
-/// Encapsulated reference to the state of a [`LightBlock`] without its
-/// provider. Primarily used in Light Client verification.
-pub struct LightBlockState<'a> {
+/// The minimal state required to perform Light Client verification at a
+/// particular height.
+pub struct VerificationState<'a> {
     pub signed_header: &'a SignedHeader,
     pub validators: &'a ValidatorSet,
     pub next_validators: &'a ValidatorSet,
 }
 
-impl<'a> LightBlockState<'a> {
+impl<'a> VerificationState<'a> {
+    /// Constructor.
+    pub fn new(
+        signed_header: &'a SignedHeader,
+        validators: &'a ValidatorSet,
+        next_validators: &'a ValidatorSet,
+    ) -> Self {
+        Self {
+            signed_header,
+            validators,
+            next_validators,
+        }
+    }
+
     /// Convenience method to expose the height of the associated header.
     pub fn height(&self) -> Height {
         self.signed_header.header.height
@@ -133,13 +146,9 @@ impl LightBlock {
         self.signed_header.header.height
     }
 
-    /// Obtain the state of the light block, without its provider.
-    pub fn state(&self) -> LightBlockState<'_> {
-        LightBlockState {
-            signed_header: &self.signed_header,
-            validators: &self.validators,
-            next_validators: &self.next_validators,
-        }
+    /// Obtain the verification state of the light block.
+    pub fn verification_state(&self) -> VerificationState<'_> {
+        VerificationState::new(&self.signed_header, &self.validators, &self.next_validators)
     }
 }
 

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -79,13 +79,13 @@ impl Status {
 
 /// The minimal state required to perform Light Client verification at a
 /// particular height.
-pub struct VerificationState<'a> {
+pub struct VerifyParams<'a> {
     pub signed_header: &'a SignedHeader,
     pub validators: &'a ValidatorSet,
     pub next_validators: &'a ValidatorSet,
 }
 
-impl<'a> VerificationState<'a> {
+impl<'a> VerifyParams<'a> {
     /// Constructor.
     pub fn new(
         signed_header: &'a SignedHeader,
@@ -146,9 +146,9 @@ impl LightBlock {
         self.signed_header.header.height
     }
 
-    /// Obtain the verification state of the light block.
-    pub fn verification_state(&self) -> VerificationState<'_> {
-        VerificationState::new(&self.signed_header, &self.validators, &self.next_validators)
+    /// Obtain the verification parameters for the light block.
+    pub fn verify_params(&self) -> VerifyParams<'_> {
+        VerifyParams::new(&self.signed_header, &self.validators, &self.next_validators)
     }
 }
 

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -77,6 +77,21 @@ impl Status {
     }
 }
 
+/// Encapsulated reference to the state of a [`LightBlock`] without its
+/// provider. Primarily used in Light Client verification.
+pub struct LightBlockState<'a> {
+    pub signed_header: &'a SignedHeader,
+    pub validators: &'a ValidatorSet,
+    pub next_validators: &'a ValidatorSet,
+}
+
+impl<'a> LightBlockState<'a> {
+    /// Convenience method to expose the height of the associated header.
+    pub fn height(&self) -> Height {
+        self.signed_header.header.height
+    }
+}
+
 /// A light block is the core data structure used by the light client.
 /// It records everything the light client needs to know about a block.
 #[derive(Clone, Debug, Display, PartialEq, Serialize, Deserialize)]
@@ -116,6 +131,15 @@ impl LightBlock {
     /// This is a shorthand for `block.signed_header.header.height`.
     pub fn height(&self) -> Height {
         self.signed_header.header.height
+    }
+
+    /// Obtain the state of the light block, without its provider.
+    pub fn state(&self) -> LightBlockState<'_> {
+        LightBlockState {
+            signed_header: &self.signed_header,
+            validators: &self.validators,
+            next_validators: &self.next_validators,
+        }
     }
 }
 

--- a/tendermint/src/block/signed_header.rs
+++ b/tendermint/src/block/signed_header.rs
@@ -4,7 +4,7 @@
 use crate::{block, Error};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
-use tendermint_proto::types::SignedHeader as RawSignedHeader;
+use tendermint_proto::{types::SignedHeader as RawSignedHeader, Protobuf};
 
 /// Signed block headers
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -41,6 +41,8 @@ impl From<SignedHeader> for RawSignedHeader {
         }
     }
 }
+
+impl Protobuf<RawSignedHeader> for SignedHeader {}
 
 impl SignedHeader {
     /// Constructor.

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -9,7 +9,7 @@ use std::io::Error as IoError;
 use time::OutOfRangeError;
 
 define_error! {
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     Error {
         Crypto
             |_| { format_args!("cryptographic error") },


### PR DESCRIPTION
Closes #956 

The main aim of this PR is to remove references to the `LightBlock` type from the verification predicates, as the `LightBlock` type isn't used in https://github.com/informalsystems/ibc-rs/pull/1252

Tomorrow I'll try working on refactoring that PR to make use of this code to see if it will work.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
