### PR TITLE
light-client: Disable `lightstore-sled` feature by default

### DIFF
--- a/.changelog/unreleased/breaking-changes/disable-sled-lightstore.md
+++ b/.changelog/unreleased/breaking-changes/disable-sled-lightstore.md
@@ -1,0 +1,1 @@
+- `[light-client]` Disable the `lightstore-sled` feature by default ([#976](https://github.com/informalsystems/tendermint-rs/issues/976))

--- a/.changelog/unreleased/breaking-changes/disable-sled-lightstore.md
+++ b/.changelog/unreleased/breaking-changes/disable-sled-lightstore.md
@@ -1,1 +1,1 @@
-- `[light-client]` Disable the `lightstore-sled` feature by default ([#976](https://github.com/informalsystems/tendermint-rs/issues/976))
+- `[tendermint-light-client]` Disable the `lightstore-sled` feature by default ([#976](https://github.com/informalsystems/tendermint-rs/issues/976))

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["std", "eyre_tracer", "rpc-client", "lightstore-sled"]
+default = ["std", "eyre_tracer", "rpc-client"]
 eyre_tracer = ["flex-error/eyre_tracer"]
 rpc-client = ["tokio", "tendermint-rpc/http-client"]
 secp256k1 = ["tendermint/secp256k1", "tendermint-rpc/secp256k1"]


### PR DESCRIPTION
Closes: #976

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
