### PR TITLE
Fix nightly clippy errors 

### DIFF
--- a/light-client/src/store/sled.rs
+++ b/light-client/src/store/sled.rs
@@ -23,7 +23,6 @@ pub struct SledStore {
     verified_db: HeightIndexedDb<LightBlock>,
     trusted_db: HeightIndexedDb<LightBlock>,
     failed_db: HeightIndexedDb<LightBlock>,
-    db: sled::Db,
 }
 
 impl SledStore {
@@ -39,7 +38,6 @@ impl SledStore {
             verified_db: HeightIndexedDb::new(db.open_tree(VERIFIED).unwrap()),
             trusted_db: HeightIndexedDb::new(db.open_tree(TRUSTED).unwrap()),
             failed_db: HeightIndexedDb::new(db.open_tree(FAILED).unwrap()),
-            db,
         }
     }
 

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -521,10 +521,7 @@ mod tests {
         let mut peer_list = PeerList::builder();
 
         if let Some(primary) = primary {
-            let io = MockIo::new(
-                primary[0].signed_header.header.chain_id.to_string(),
-                primary.clone(),
-            );
+            let io = MockIo::new(primary.clone());
 
             let primary_instance =
                 make_instance(primary[0].provider, trust_options.clone(), io, now);
@@ -535,10 +532,7 @@ mod tests {
         if let Some(witnesses) = witnesses {
             for provider in witnesses.into_iter() {
                 let peer_id = provider[0].provider;
-                let io = MockIo::new(
-                    provider[0].signed_header.header.chain_id.to_string(),
-                    provider,
-                );
+                let io = MockIo::new(provider);
                 let instance = make_instance(peer_id, trust_options.clone(), io.clone(), now);
                 peer_list.witness(peer_id, instance);
             }

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -84,13 +84,12 @@ impl Clock for MockClock {
 
 #[derive(Clone)]
 pub struct MockIo {
-    chain_id: String,
     light_blocks: HashMap<Height, LightBlock>,
     latest_height: Height,
 }
 
 impl MockIo {
-    pub fn new(chain_id: String, light_blocks: Vec<LightBlock>) -> Self {
+    pub fn new(light_blocks: Vec<LightBlock>) -> Self {
         let latest_height = light_blocks.iter().map(|lb| lb.height()).max().unwrap();
 
         let light_blocks = light_blocks
@@ -99,7 +98,6 @@ impl MockIo {
             .collect();
 
         Self {
-            chain_id,
             light_blocks,
             latest_height,
         }

--- a/light-client/tests/backward.rs
+++ b/light-client/tests/backward.rs
@@ -45,7 +45,6 @@ struct TestCase {
 
 fn make(chain: LightChain, trusted_height: Height) -> (LightClient, State) {
     let primary = default_peer_id();
-    let chain_id = "testchain-1".parse().unwrap();
 
     let clock = MockClock {
         /// Set the current time to be ahead of the latest block in the chain
@@ -65,7 +64,7 @@ fn make(chain: LightChain, trusted_height: Height) -> (LightClient, State) {
         .map(testgen_to_lb)
         .collect();
 
-    let io = MockIo::new(chain_id, light_blocks);
+    let io = MockIo::new(light_blocks);
 
     let trusted_state = io
         .fetch_light_block(AtHeight::At(trusted_height))

--- a/light-client/tests/light_client.rs
+++ b/light-client/tests/light_client.rs
@@ -48,7 +48,7 @@ fn run_test(tc: LightClientTest<LightBlock>) -> BisectionTestResult {
     };
 
     let provider = tc.primary;
-    let io = MockIo::new(provider.chain_id, provider.lite_blocks);
+    let io = MockIo::new(provider.lite_blocks);
 
     let trusted_height = tc.trust_options.height;
     let trusted_state = io

--- a/light-client/tests/supervisor.rs
+++ b/light-client/tests/supervisor.rs
@@ -69,7 +69,7 @@ fn run_multipeer_test(tc: LightClientTest<LightBlock>) {
         None => false,
     };
 
-    let io = MockIo::new(tc.primary.chain_id, tc.primary.lite_blocks);
+    let io = MockIo::new(tc.primary.lite_blocks);
     let primary_instance = make_instance(primary, tc.trust_options.clone(), io.clone(), tc.now);
 
     let mut peer_list = PeerList::builder();
@@ -78,7 +78,7 @@ fn run_multipeer_test(tc: LightClientTest<LightBlock>) {
     for provider in tc.witnesses.into_iter() {
         let peer_id = provider.value.lite_blocks[0].provider;
         println!("Witness: {}", peer_id);
-        let io = MockIo::new(provider.value.chain_id, provider.value.lite_blocks);
+        let io = MockIo::new(provider.value.lite_blocks);
         let instance = make_instance(peer_id, tc.trust_options.clone(), io.clone(), tc.now);
         peer_list.witness(peer_id, instance);
     }


### PR DESCRIPTION
In working towards #978, some new clippy errors are popping up in CI with the latest Rust nightly. See https://github.com/informalsystems/tendermint-rs/pull/978/checks?check_run_id=3635238166 for an example.

This PR attempts to address these errors. If acceptable, I'll merge to `master` and then pull these changes into #978.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
