### PR TITLE
Update tendermint-proto to 0.23 and Prost 0.9

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -33,8 +33,8 @@ std = [
 
 [dependencies]
 bytes = { version = "1.0", default-features = false }
-prost = { package = "informalsystems-prost", version = "0.8.1", default-features = false }
-tendermint-proto = { version = "0.22.0", default-features = false, path = "../proto" }
+prost = { version = "0.9", default-features = false }
+tendermint-proto = { version = "0.23.0", default-features = false, path = "../proto" }
 tracing = { version = "0.1", default-features = false }
 flex-error = { version = "0.4.3", default-features = false }
 structopt = { version = "0.3", optional = true, default-features = false }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -37,7 +37,7 @@ eyre = { version = "0.6", default-features = false }
 flume = { version = "0.10.7", default-features = false }
 hkdf = { version = "0.10.0", default-features = false }
 merlin = { version = "2", default-features = false }
-prost = { package = "informalsystems-prost", version = "0.8.1", default-features = false }
+prost = { version = "0.9", default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["std"] }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2", default-features = false }
@@ -49,8 +49,8 @@ flex-error = { version = "0.4.3", default-features = false }
 
 # path dependencies
 tendermint = { path = "../tendermint", version = "0.22.0" }
-tendermint-proto = { path = "../proto", version = "0.22.0" }
+tendermint-proto = { path = "../proto", version = "0.23.0" }
 tendermint-std-ext = { path = "../std-ext", version = "0.22.0" }
 
 # optional dependencies
-prost-derive = { package = "informalsystems-prost-derive", version = "0.8.1", optional = true }
+prost-derive = { version = "0.9", optional = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tendermint-proto"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,8 +17,8 @@ description = """
 all-features = true
 
 [dependencies]
-prost = { package = "informalsystems-prost", version = "0.8.1", default-features = false }
-prost-types = { package = "informalsystems-prost-types", version = "0.8.1", default-features = false }
+prost = { version = "0.9", default-features = false }
+prost-types = { version = "0.9", default-features = false }
 bytes = { version = "1.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_bytes = { version = "0.11", default-features = false, features = ["alloc"] }

--- a/proto/src/prost/google.protobuf.rs
+++ b/proto/src/prost/google.protobuf.rs
@@ -331,7 +331,7 @@ pub struct MethodDescriptorProto {
 //   extension number. You can declare multiple options with only one extension
 //   number by putting them in a sub-message. See the Custom Options section of
 //   the docs for examples:
-//   https://developers.google.com/protocol-buffers/docs/proto#options
+//   <https://developers.google.com/protocol-buffers/docs/proto#options>
 //   If this turns out to be popular, a web service will be set up
 //   to automatically assign option numbers.
 

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -1,6 +1,6 @@
-// This file is copied from http://github.com/tendermint/abci
+// This file is copied from <http://github.com/tendermint/abci>
 // NOTE: When using custom types, mind the warnings.
-// https://github.com/gogo/protobuf/blob/master/custom_types.md#warnings-and-issues
+// <https://github.com/gogo/protobuf/blob/master/custom_types.md#warnings-and-issues>
 
 //----------------------------------------
 // Request types
@@ -490,7 +490,7 @@ pub struct Validator {
     /// The first 20 bytes of SHA256(public key)
     #[prost(bytes="vec", tag="1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
-    /// PubKey pub_key = 2 [(gogoproto.nullable)=false];
+    /// PubKey pub_key = 2 \[(gogoproto.nullable)=false\];
     ///
     /// The voting power
     #[prost(int64, tag="3")]
@@ -527,7 +527,7 @@ pub struct Evidence {
     pub time: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     /// Total voting power of the validator set in case the ABCI application does
     /// not store historical validators.
-    /// https://github.com/tendermint/tendermint/issues/4581
+    /// <https://github.com/tendermint/tendermint/issues/4581>
     #[prost(int64, tag="5")]
     pub total_voting_power: i64,
 }

--- a/proto/src/prost/tendermint.crypto.rs
+++ b/proto/src/prost/tendermint.crypto.rs
@@ -1,24 +1,3 @@
-/// PublicKey defines the keys available for use with Tendermint Validators
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PublicKey {
-    #[prost(oneof="public_key::Sum", tags="1, 2")]
-    pub sum: ::core::option::Option<public_key::Sum>,
-}
-/// Nested message and enum types in `PublicKey`.
-pub mod public_key {
-    #[derive(::serde::Deserialize, ::serde::Serialize)]
-    #[serde(tag = "type", content = "value")]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(bytes, tag="1")]
-        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
-        Ed25519(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag="2")]
-        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
-        Secp256k1(::prost::alloc::vec::Vec<u8>),
-    }
-}
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
@@ -70,4 +49,25 @@ pub struct ProofOp {
 pub struct ProofOps {
     #[prost(message, repeated, tag="1")]
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
+}
+/// PublicKey defines the keys available for use with Tendermint Validators
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublicKey {
+    #[prost(oneof="public_key::Sum", tags="1, 2")]
+    pub sum: ::core::option::Option<public_key::Sum>,
+}
+/// Nested message and enum types in `PublicKey`.
+pub mod public_key {
+    #[derive(::serde::Deserialize, ::serde::Serialize)]
+    #[serde(tag = "type", content = "value")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(bytes, tag="1")]
+        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
+        Ed25519(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag="2")]
+        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
+        Secp256k1(::prost::alloc::vec::Vec<u8>),
+    }
 }

--- a/proto/src/prost/tendermint.p2p.rs
+++ b/proto/src/prost/tendermint.p2p.rs
@@ -1,4 +1,43 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PacketPing {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PacketPong {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PacketMsg {
+    #[prost(int32, tag="1")]
+    pub channel_id: i32,
+    #[prost(bool, tag="2")]
+    pub eof: bool,
+    #[prost(bytes="vec", tag="3")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Packet {
+    #[prost(oneof="packet::Sum", tags="1, 2, 3")]
+    pub sum: ::core::option::Option<packet::Sum>,
+}
+/// Nested message and enum types in `Packet`.
+pub mod packet {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(message, tag="1")]
+        PacketPing(super::PacketPing),
+        #[prost(message, tag="2")]
+        PacketPong(super::PacketPong),
+        #[prost(message, tag="3")]
+        PacketMsg(super::PacketMsg),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthSigMessage {
+    #[prost(message, optional, tag="1")]
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
+    #[prost(bytes="vec", tag="2")]
+    pub sig: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetAddress {
     #[prost(string, tag="1")]
     pub id: ::prost::alloc::string::String,
@@ -64,43 +103,4 @@ pub mod message {
         #[prost(message, tag="2")]
         PexAddrs(super::PexAddrs),
     }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PacketPing {
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PacketPong {
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PacketMsg {
-    #[prost(int32, tag="1")]
-    pub channel_id: i32,
-    #[prost(bool, tag="2")]
-    pub eof: bool,
-    #[prost(bytes="vec", tag="3")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Packet {
-    #[prost(oneof="packet::Sum", tags="1, 2, 3")]
-    pub sum: ::core::option::Option<packet::Sum>,
-}
-/// Nested message and enum types in `Packet`.
-pub mod packet {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(message, tag="1")]
-        PacketPing(super::PacketPing),
-        #[prost(message, tag="2")]
-        PacketPong(super::PacketPong),
-        #[prost(message, tag="3")]
-        PacketMsg(super::PacketMsg),
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AuthSigMessage {
-    #[prost(message, optional, tag="1")]
-    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
-    #[prost(bytes="vec", tag="2")]
-    pub sig: ::prost::alloc::vec::Vec<u8>,
 }

--- a/proto/src/prost/tendermint.types.rs
+++ b/proto/src/prost/tendermint.types.rs
@@ -276,71 +276,6 @@ pub enum SignedMsgType {
     /// Proposals
     Proposal = 32,
 }
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalBlockId {
-    #[prost(bytes="vec", tag="1")]
-    pub hash: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="2")]
-    #[serde(alias = "parts")]
-    pub part_set_header: ::core::option::Option<CanonicalPartSetHeader>,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalPartSetHeader {
-    #[prost(uint32, tag="1")]
-    pub total: u32,
-    #[prost(bytes="vec", tag="2")]
-    pub hash: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalProposal {
-    /// type alias for byte
-    #[prost(enumeration="SignedMsgType", tag="1")]
-    pub r#type: i32,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="2")]
-    pub height: i64,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="3")]
-    pub round: i64,
-    #[prost(int64, tag="4")]
-    pub pol_round: i64,
-    #[prost(message, optional, tag="5")]
-    pub block_id: ::core::option::Option<CanonicalBlockId>,
-    #[prost(message, optional, tag="6")]
-    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="7")]
-    pub chain_id: ::prost::alloc::string::String,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CanonicalVote {
-    /// type alias for byte
-    #[prost(enumeration="SignedMsgType", tag="1")]
-    pub r#type: i32,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="2")]
-    pub height: i64,
-    /// canonicalization requires fixed size encoding here
-    #[prost(sfixed64, tag="3")]
-    pub round: i64,
-    #[prost(message, optional, tag="4")]
-    pub block_id: ::core::option::Option<CanonicalBlockId>,
-    #[prost(message, optional, tag="5")]
-    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="6")]
-    pub chain_id: ::prost::alloc::string::String,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EventDataRoundState {
-    #[prost(int64, tag="1")]
-    pub height: i64,
-    #[prost(int32, tag="2")]
-    pub round: i32,
-    #[prost(string, tag="3")]
-    pub step: ::prost::alloc::string::String,
-}
 /// ConsensusParams contains consensus critical parameters that determine the
 /// validity of blocks.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -386,7 +321,7 @@ pub struct EvidenceParams {
     ///
     /// It should correspond with an app's "unbonding period" or other similar
     /// mechanism for handling [Nothing-At-Stake
-    /// attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
+    /// attacks](<https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed>).
     #[prost(message, optional, tag="2")]
     pub max_age_duration: ::core::option::Option<super::super::google::protobuf::Duration>,
     /// This sets the maximum size of total evidence in bytes that can be committed in a single block.
@@ -418,6 +353,15 @@ pub struct HashedParams {
     pub block_max_bytes: i64,
     #[prost(int64, tag="2")]
     pub block_max_gas: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EventDataRoundState {
+    #[prost(int64, tag="1")]
+    pub height: i64,
+    #[prost(int32, tag="2")]
+    pub round: i32,
+    #[prost(string, tag="3")]
+    pub step: ::prost::alloc::string::String,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
@@ -489,4 +433,60 @@ pub struct Block {
     pub evidence: ::core::option::Option<EvidenceList>,
     #[prost(message, optional, tag="4")]
     pub last_commit: ::core::option::Option<Commit>,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalBlockId {
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    #[serde(alias = "parts")]
+    pub part_set_header: ::core::option::Option<CanonicalPartSetHeader>,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalPartSetHeader {
+    #[prost(uint32, tag="1")]
+    pub total: u32,
+    #[prost(bytes="vec", tag="2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalProposal {
+    /// type alias for byte
+    #[prost(enumeration="SignedMsgType", tag="1")]
+    pub r#type: i32,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="2")]
+    pub height: i64,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="3")]
+    pub round: i64,
+    #[prost(int64, tag="4")]
+    pub pol_round: i64,
+    #[prost(message, optional, tag="5")]
+    pub block_id: ::core::option::Option<CanonicalBlockId>,
+    #[prost(message, optional, tag="6")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="7")]
+    pub chain_id: ::prost::alloc::string::String,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanonicalVote {
+    /// type alias for byte
+    #[prost(enumeration="SignedMsgType", tag="1")]
+    pub r#type: i32,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="2")]
+    pub height: i64,
+    /// canonicalization requires fixed size encoding here
+    #[prost(sfixed64, tag="3")]
+    pub round: i64,
+    #[prost(message, optional, tag="4")]
+    pub block_id: ::core::option::Option<CanonicalBlockId>,
+    #[prost(message, optional, tag="5")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="6")]
+    pub chain_id: ::prost::alloc::string::String,
 }

--- a/proto/src/tendermint.rs
+++ b/proto/src/tendermint.rs
@@ -4,22 +4,12 @@ pub mod consensus {
     include!("prost/tendermint.consensus.rs");
 }
 
-pub mod types {
-    include!("prost/tendermint.types.rs");
+pub mod abci {
+    include!("prost/tendermint.abci.rs");
 }
 
-pub mod mempool {
-    include!("prost/tendermint.mempool.rs");
-}
-
-pub mod rpc {
-    pub mod grpc {
-        include!("prost/tendermint.rpc.grpc.rs");
-    }
-}
-
-pub mod blockchain {
-    include!("prost/tendermint.blockchain.rs");
+pub mod state {
+    include!("prost/tendermint.state.rs");
 }
 
 pub mod libs {
@@ -28,32 +18,42 @@ pub mod libs {
     }
 }
 
-pub mod state {
-    include!("prost/tendermint.state.rs");
-}
-
-pub mod version {
-    include!("prost/tendermint.version.rs");
+pub mod types {
+    include!("prost/tendermint.types.rs");
 }
 
 pub mod store {
     include!("prost/tendermint.store.rs");
 }
 
-pub mod privval {
-    include!("prost/tendermint.privval.rs");
+pub mod rpc {
+    pub mod grpc {
+        include!("prost/tendermint.rpc.grpc.rs");
+    }
+}
+
+pub mod version {
+    include!("prost/tendermint.version.rs");
+}
+
+pub mod blockchain {
+    include!("prost/tendermint.blockchain.rs");
 }
 
 pub mod statesync {
     include!("prost/tendermint.statesync.rs");
 }
 
+pub mod privval {
+    include!("prost/tendermint.privval.rs");
+}
+
 pub mod p2p {
     include!("prost/tendermint.p2p.rs");
 }
 
-pub mod abci {
-    include!("prost/tendermint.abci.rs");
+pub mod mempool {
+    include!("prost/tendermint.mempool.rs");
 }
 
 pub mod crypto {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -75,7 +75,7 @@ serde_bytes = "0.11"
 serde_json = "1"
 tendermint-config = { version = "0.22.0", path = "../config" }
 tendermint = { version = "0.22.0", path = "../tendermint" }
-tendermint-proto = { version = "0.22.0", path = "../proto" }
+tendermint-proto = { version = "0.23.0", path = "../proto" }
 thiserror = "1"
 uuid = { version = "0.8", default-features = false }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -41,8 +41,8 @@ ed25519-dalek = { version = "1", default-features = false, features = ["u64_back
 futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.3", default-features = false }
-prost = { package = "informalsystems-prost", version = "0.8.1", default-features = false }
-prost-types = { package = "informalsystems-prost-types", version = "0.8.1", default-features = false }
+prost = { version = "0.9", default-features = false }
+prost-types = { version = "0.9", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }
@@ -51,7 +51,7 @@ sha2 = { version = "0.9", default-features = false }
 signature = { version = "1.2", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
-tendermint-proto = { version = "0.22.0", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.23.0", default-features = false, path = "../proto" }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.3", default-features = false }
 k256 = { version = "0.9", optional = true, default-features = false, features = ["ecdsa", "sha256"] }

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 walkdir         = { version = "2.3" }
-prost-build     = { version = "0.7" }
+prost-build     = { version = "0.9" }
 git2            = { version = "0.13" }
 tempfile        = { version = "3.2.0" }
 subtle-encoding = { version = "0.5" }


### PR DESCRIPTION
This PR rebuilds the proto definitions with the new prost 0.9 instead of informalsystems-prost 0.8.1. It also bumps the Tendermint proto version to 0.23
