### PR TITLE
Fix minor error surfaced by clippy in Rust 1.56

### DIFF
--- a/testgen/src/tester.rs
+++ b/testgen/src/tester.rs
@@ -460,9 +460,7 @@ impl Tester {
                             let path = format!("{}", entry.path().display());
                             let rel_path = self.env().unwrap().rel_path(&path).unwrap();
                             if kind.is_file() || kind.is_symlink() {
-                                if !rel_path.ends_with(".json") {
-                                    return;
-                                } else {
+                                if rel_path.ends_with(".json") {
                                     self.run_for_file(&rel_path);
                                 }
                             } else if kind.is_dir() {


### PR DESCRIPTION
Running `cargo clippy --all-features --all-targets -- -Dwarnings -Drust-2018-idioms` with Rust 1.56 results in:

```
error: unneeded `return` statement
   --> testgen/src/tester.rs:464:37
    |
464 | ...                   return;
    |                       ^^^^^^^ help: remove `return`
    |
    = note: `-D clippy::needless-return` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
```

This minor PR fixes that error.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
