### PR TITLE
lowercase hex node ID

### DIFF
--- a/.changelog/unreleased/bug-fixes/1016-lowercase-node-id.md
+++ b/.changelog/unreleased/bug-fixes/1016-lowercase-node-id.md
@@ -1,2 +1,1 @@
-- `[tendermint]` The `tendermint::node::Id` `Display` implementation now prints the hexadecimal string in lowercase ([#971](https://github.com/informalsystems/tendermint-
-  rs/issues/971))
+- `[tendermint]` The `tendermint::node::Id` `Display` implementation now prints the hexadecimal string in lowercase ([#971](https://github.com/informalsystems/tendermint-rs/issues/971))

--- a/.changelog/unreleased/bug-fixes/1016-lowercase-node-id.md
+++ b/.changelog/unreleased/bug-fixes/1016-lowercase-node-id.md
@@ -1,0 +1,2 @@
+- `[tendermint]` The `tendermint::node::Id` `Display` implementation now prints the hexadecimal string in lowercase ([#971](https://github.com/informalsystems/tendermint-
+  rs/issues/971))

--- a/config/tests/mod.rs
+++ b/config/tests/mod.rs
@@ -204,7 +204,7 @@ fn node_key_parser() {
     let node_key = NodeKey::parse_json(&raw_node_key).unwrap();
     assert_eq!(
         node_key.node_id().to_string(),
-        "1A7B6BCF3D6FB055AB3AEBCA415847531B626699"
+        "1a7b6bcf3d6fb055ab3aebca415847531b626699"
     );
 }
 

--- a/tendermint/src/node/id.rs
+++ b/tendermint/src/node/id.rs
@@ -52,7 +52,7 @@ impl ConstantTimeEq for Id {
 impl Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in &self.0 {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{:02x}", byte)?;
         }
         Ok(())
     }

--- a/test/src/test/unit/p2p/secret_connection/public_key.rs
+++ b/test/src/test/unit/p2p/secret_connection/public_key.rs
@@ -12,6 +12,6 @@ fn test_secret_connection_pubkey_serialization() {
 
     assert_eq!(
         example_key.to_string(),
-        "117C95C4FD7E636C38D303493302D2C271A39669"
+        "117c95c4fd7e636c38d303493302d2c271a39669"
     );
 }


### PR DESCRIPTION
closes #971 

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] ~Wrote~ updated tests
* [x] Added entry in `.changelog/`
