### PR TITLE
Update to deprecations in ed25519 1.3

### DIFF
--- a/.changelog/unreleased/improvements/1023-ed25519-deprecations.md
+++ b/.changelog/unreleased/improvements/1023-ed25519-deprecations.md
@@ -1,0 +1,3 @@
+- `[tendermint]` Deprecated `signature::ED25519_SIGNATURE_SIZE`
+  in favor of `Ed25519Signature::BYTE_SIZE`
+  ([#1023](https://github.com/informalsystems/tendermint-rs/issues/1023))

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib", "rlib"]
 async-trait = { version = "0.1", default-features = false }
 bytes = { version = "1.0", default-features = false }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
-ed25519 = { version = "1", default-features = false }
+ed25519 = { version = "1.3", default-features = false }
 ed25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }
 futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/tendermint/src/proposal.rs
+++ b/tendermint/src/proposal.rs
@@ -121,8 +121,8 @@ mod tests {
     use crate::hash::{Algorithm, Hash};
     use crate::prelude::*;
     use crate::proposal::SignProposalRequest;
-    use crate::signature::{Ed25519Signature, ED25519_SIGNATURE_SIZE};
-    use crate::{proposal::Type, Proposal, Signature};
+    use crate::test::dummy_signature;
+    use crate::{proposal::Type, Proposal};
     use chrono::{DateTime, Utc};
     use core::str::FromStr;
     use tendermint_proto::Protobuf;
@@ -152,9 +152,7 @@ mod tests {
                 .unwrap(),
             }),
             timestamp: Some(dt.into()),
-            signature: Some(Signature::from(Ed25519Signature::new(
-                [0; ED25519_SIGNATURE_SIZE],
-            ))),
+            signature: Some(dummy_signature()),
         };
 
         let mut got = vec![];
@@ -236,9 +234,7 @@ mod tests {
                 .unwrap(),
             }),
             timestamp: Some(dt.into()),
-            signature: Some(Signature::from(Ed25519Signature::new(
-                [0; ED25519_SIGNATURE_SIZE],
-            ))),
+            signature: Some(dummy_signature()),
         };
 
         let mut got = vec![];
@@ -322,9 +318,7 @@ mod tests {
                 )
                 .unwrap(),
             }),
-            signature: Some(Signature::from(Ed25519Signature::new(
-                [0; ED25519_SIGNATURE_SIZE],
-            ))),
+            signature: Some(dummy_signature()),
         };
         let want = SignProposalRequest {
             proposal,

--- a/tendermint/src/signature.rs
+++ b/tendermint/src/signature.rs
@@ -1,6 +1,6 @@
 //! Cryptographic (a.k.a. digital) signatures
 
-pub use ed25519::{Signature as Ed25519Signature, SIGNATURE_LENGTH as ED25519_SIGNATURE_SIZE};
+pub use ed25519::Signature as Ed25519Signature;
 pub use signature::{Signer, Verifier};
 
 #[cfg(feature = "secp256k1")]
@@ -11,6 +11,9 @@ use core::convert::TryFrom;
 use tendermint_proto::Protobuf;
 
 use crate::error::Error;
+
+#[deprecated(since = "0.23.1", note = "use Ed25519Signature::BYTE_SIZE instead")]
+pub const ED25519_SIGNATURE_SIZE: usize = Ed25519Signature::BYTE_SIZE;
 
 /// The expected length of all currently supported signatures, in bytes.
 pub const SIGNATURE_LENGTH: usize = 64;

--- a/tendermint/src/test.rs
+++ b/tendermint/src/test.rs
@@ -1,6 +1,8 @@
 use core::fmt::Debug;
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::signature::{Ed25519Signature, Signature};
+
 /// Test that a struct `T` can be:
 ///
 /// - parsed out of the provided JSON data
@@ -24,4 +26,9 @@ where
     let parsed1 = parsed1.unwrap();
 
     assert_eq!(parsed0, parsed1);
+}
+
+/// Produces a dummy signature value for use as a placeholder in tests.
+pub fn dummy_signature() -> Signature {
+    Signature::from(Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap())
 }

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -15,8 +15,6 @@ use core::fmt;
 use core::str::FromStr;
 
 use bytes::BufMut;
-use ed25519::Signature as Ed25519Signature;
-use ed25519::SIGNATURE_LENGTH as ED25519_SIGNATURE_LENGTH;
 use serde::{Deserialize, Serialize};
 
 use tendermint_proto::types::Vote as RawVote;
@@ -27,6 +25,7 @@ use crate::consensus::State;
 use crate::error::Error;
 use crate::hash;
 use crate::prelude::*;
+use crate::signature::Ed25519Signature;
 use crate::{account, block, Signature, Time};
 
 /// Votes are signed messages from validators for a particular block which
@@ -159,6 +158,7 @@ impl Vote {
 }
 
 /// Default trait. Used in tests.
+// FIXME: Does it need to be in public crate API? If not, replace with a helper fn in crate::test?
 impl Default for Vote {
     fn default() -> Self {
         Vote {
@@ -169,9 +169,11 @@ impl Default for Vote {
             timestamp: Some(Time::unix_epoch()),
             validator_address: account::Id::new([0; account::LENGTH]),
             validator_index: ValidatorIndex::try_from(0_i32).unwrap(),
-            signature: Some(Signature::from(Ed25519Signature::new(
-                [0; ED25519_SIGNATURE_LENGTH],
-            ))),
+            // Could have reused crate::test::dummy_signature, except that
+            // this Default impl is defined outside of #[cfg(test)].
+            signature: Some(Signature::from(
+                Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap(),
+            )),
         }
     }
 }

--- a/tendermint/src/vote/sign_vote.rs
+++ b/tendermint/src/vote/sign_vote.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::chain::Id as ChainId;
     use crate::hash::Algorithm;
     use crate::prelude::*;
-    use crate::signature::{Signature, ED25519_SIGNATURE_SIZE};
+    use crate::signature::{Ed25519Signature, Signature};
     use crate::vote::{CanonicalVote, ValidatorIndex};
     use crate::vote::{SignVoteRequest, Type};
     use crate::Hash;
@@ -429,7 +429,7 @@ mod tests {
                 )
                 .unwrap(),
             }),
-            signature: Signature::new(vec![1; ED25519_SIGNATURE_SIZE]).unwrap(),
+            signature: Signature::new(vec![1; Ed25519Signature::BYTE_SIZE]).unwrap(),
         };
         let want = SignVoteRequest {
             vote,

--- a/testgen/src/vote.rs
+++ b/testgen/src/vote.rs
@@ -5,7 +5,7 @@ use simple_error::*;
 use std::convert::TryFrom;
 use tendermint::{
     block::{self, parts::Header as PartSetHeader},
-    signature::{Signature, Signer, ED25519_SIGNATURE_SIZE},
+    signature::{Ed25519Signature, Signature, Signer},
     vote,
     vote::ValidatorIndex,
 };
@@ -130,7 +130,7 @@ impl Generator<vote::Vote> for Vote {
             timestamp: Some(timestamp),
             validator_address: block_validator.address,
             validator_index: ValidatorIndex::try_from(validator_index as u32).unwrap(),
-            signature: Signature::new(vec![0_u8; ED25519_SIGNATURE_SIZE])
+            signature: Signature::new(vec![0_u8; Ed25519Signature::BYTE_SIZE])
                 .map_err(|e| SimpleError::new(e.to_string()))?,
         };
 


### PR DESCRIPTION
Fixes: #1023

As of release 1.3.0, `ed25519` deprecates the standalone `SIGNATURE_LENGTH` constant in favor of the `Signature::BYTE_SIZE` associated item. Also, the `Signature::new` constructor is deprecated in favor of `Signature::from_bytes`.
Update the code to not trigger the deprecation lints.

In turn, deprecate what was formerly the reexport of that constant in the tendermint API.

* [x] Referenced an issue explaining the need for the change
* [ ] ~Updated all relevant documentation in docs~
* [x] Updated all code comments where relevant
* [x] ~Wrote tests~ - pure refactoring, exercised by existing tests.
* [x] Added entry in `.changelog/`
