### PR TITLE
Fix up deprecation version for ED25519_SIGNATURE_SIZE

### DIFF
--- a/tendermint/src/signature.rs
+++ b/tendermint/src/signature.rs
@@ -12,7 +12,7 @@ use tendermint_proto::Protobuf;
 
 use crate::error::Error;
 
-#[deprecated(since = "0.23.1", note = "use Ed25519Signature::BYTE_SIZE instead")]
+#[deprecated(since = "0.23.2", note = "use Ed25519Signature::BYTE_SIZE instead")]
 pub const ED25519_SIGNATURE_SIZE: usize = Ed25519Signature::BYTE_SIZE;
 
 /// The expected length of all currently supported signatures, in bytes.


### PR DESCRIPTION
0.23.1 was released before #1023 or its backport to v0.23.x (#1031) were merged.