### PR TITLE
rpc: Remove ErrorDetail::Server

### DIFF
--- a/.changelog/unreleased/breaking-changes/1040-rpc-remove-server-error.md
+++ b/.changelog/unreleased/breaking-changes/1040-rpc-remove-server-error.md
@@ -1,0 +1,2 @@
+- `[tendermint-rpc]` Remove the `ErrorDetail::Server` variant
+  ([#1039](https://github.com/informalsystems/tendermint-rs/issues/1039))

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -98,14 +98,6 @@ define_error! {
                 format_args!("parse error: {}", e.reason)
             },
 
-        Server
-            {
-                reason: String
-            }
-            | e | {
-                format_args!("server error: {}", e.reason)
-            },
-
         ClientInternal
             {
                 reason: String


### PR DESCRIPTION
This does not seem to be produced anywhere.

Fixes: #1039

* [x] Referenced an issue explaining the need for the change
* ~Updated all relevant documentation in docs~
* ~Updated all code comments where relevant~
* ~Wrote tests~
* [x] Added entry in `.changelog/`
