### PR TITLE
Fix clippy 0.1.57 lints (backport to 0.23.x)

### DIFF
--- a/abci/src/application/echo.rs
+++ b/abci/src/application/echo.rs
@@ -3,13 +3,7 @@
 use crate::Application;
 
 /// Trivial echo application, mainly for testing purposes.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct EchoApp;
-
-impl Default for EchoApp {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl Application for EchoApp {}

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -20,6 +20,8 @@ pub enum ForkDetection {
 
 /// Types of fork
 #[derive(Debug)]
+// To be fixed in 0.24
+#[allow(clippy::large_enum_variant)]
 pub enum Fork {
     /// An actual fork was found for this `LightBlock`
     Forked {

--- a/rpc/src/client/transport/mock.rs
+++ b/rpc/src/client/transport/mock.rs
@@ -199,7 +199,7 @@ pub trait MockRequestMatcher: Send + Sync {
 /// requests with specific methods to responses.
 ///
 /// [`MockRequestMatcher`]: trait.MockRequestMatcher.html
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MockRequestMethodMatcher {
     mappings: HashMap<Method, Result<String, Error>>,
 }
@@ -213,14 +213,6 @@ impl MockRequestMatcher for MockRequestMethodMatcher {
             Ok(json) => R::Response::from_string(json),
             Err(e) => Err(e.clone()),
         })
-    }
-}
-
-impl Default for MockRequestMethodMatcher {
-    fn default() -> Self {
-        Self {
-            mappings: HashMap::new(),
-        }
     }
 }
 

--- a/rpc/src/client/transport/router.rs
+++ b/rpc/src/client/transport/router.rs
@@ -21,7 +21,7 @@ pub type SubscriptionIdRef<'a> = &'a str;
 ///
 /// [`Subscription`]: struct.Subscription.html
 /// [`Event`]: ./event/struct.Event.html
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SubscriptionRouter {
     /// A map of subscription queries to collections of subscription IDs and
     /// their result channels. Used for publishing events relating to a specific
@@ -125,14 +125,6 @@ impl SubscriptionRouter {
             .get(&query.to_string())
             .map(|subs_for_query| subs_for_query.len())
             .unwrap_or(0)
-    }
-}
-
-impl Default for SubscriptionRouter {
-    fn default() -> Self {
-        Self {
-            subscriptions: HashMap::new(),
-        }
     }
 }
 

--- a/rpc/src/endpoint/validators.rs
+++ b/rpc/src/endpoint/validators.rs
@@ -9,7 +9,7 @@ use tendermint::{block, validator};
 pub const DEFAULT_VALIDATORS_PER_PAGE: u8 = 30;
 
 /// List validators for a specific block
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct Request {
     /// The height at which to retrieve the validator set. If not specified,
@@ -39,18 +39,6 @@ impl Request {
             height,
             page,
             per_page,
-        }
-    }
-}
-
-impl Default for Request {
-    fn default() -> Self {
-        // By default we get the latest validators list, page 1, maximum 30
-        // items per page (the RPC defaults).
-        Self {
-            height: None,
-            page: None,
-            per_page: None,
         }
     }
 }

--- a/rpc/src/event.rs
+++ b/rpc/src/event.rs
@@ -41,6 +41,8 @@ impl Event {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type", content = "value")]
+// To be fixed in 0.24
+#[allow(clippy::large_enum_variant)]
 pub enum EventData {
     #[serde(alias = "tendermint/event/NewBlock")]
     NewBlock {

--- a/tendermint/src/abci/info.rs
+++ b/tendermint/src/abci/info.rs
@@ -3,7 +3,7 @@ use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
 
 /// ABCI info
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Info(String);
 
 impl AsRef<str> for Info {
@@ -15,11 +15,5 @@ impl AsRef<str> for Info {
 impl Display for Info {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl Default for Info {
-    fn default() -> Self {
-        Self(String::new())
     }
 }

--- a/tendermint/src/abci/responses.rs
+++ b/tendermint/src/abci/responses.rs
@@ -130,7 +130,7 @@ where
 }
 
 /// Codespace
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Codespace(String);
 
 impl AsRef<str> for Codespace {
@@ -142,11 +142,5 @@ impl AsRef<str> for Codespace {
 impl Display for Codespace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl Default for Codespace {
-    fn default() -> Self {
-        Self(String::new())
     }
 }

--- a/tendermint/src/block/round.rs
+++ b/tendermint/src/block/round.rs
@@ -9,7 +9,7 @@ use core::{
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Block round for a particular chain
-#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Round(u32);
 
 impl TryFrom<i32> for Round {
@@ -69,12 +69,6 @@ impl Round {
 impl Debug for Round {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "block::Round({})", self.0)
-    }
-}
-
-impl Default for Round {
-    fn default() -> Self {
-        Round(0)
     }
 }
 

--- a/tendermint/src/evidence.rs
+++ b/tendermint/src/evidence.rs
@@ -24,6 +24,8 @@ use tendermint_proto::Protobuf;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 //#[serde(tag = "type", content = "value")]
 #[serde(try_from = "RawEvidence", into = "RawEvidence")] // Used by RPC /broadcast_evidence endpoint
+// To be fixed in 0.24
+#[allow(clippy::large_enum_variant)]
 pub enum Evidence {
     /// Duplicate vote evidence
     //#[serde(rename = "tendermint/DuplicateVoteEvidence")]

--- a/testgen/src/tester.rs
+++ b/testgen/src/tester.rs
@@ -29,7 +29,7 @@ impl TestEnv {
     pub fn push(&self, child: &str) -> Option<Self> {
         let mut path = PathBuf::from(&self.current_dir);
         path.push(child);
-        path.to_str().and_then(|path| TestEnv::new(path))
+        path.to_str().and_then(TestEnv::new)
     }
 
     pub fn current_dir(&self) -> &str {
@@ -256,7 +256,7 @@ impl Tester {
                 *result = Failure { message, location };
             })
         });
-        let result = panic::catch_unwind(|| test());
+        let result = panic::catch_unwind(test);
         panic::set_hook(old_hook);
         match result {
             Ok(_) => Success,


### PR DESCRIPTION
Backport of #1041 to v0.23.x

Overrides `clippy::large_enum_variant` instead of changing the enums.