### PR TITLE
Execute CI workflows on version-specific branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
     branches:
       - master
+      - 'v*.*.*'
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
     branches:
       - master
+      - 'v*.*.*'
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
     branches:
       - master
+      - 'v*.*.*'
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
At present, it appears as though our workflows don't run when we merge to version-specific branches like `v0.23.x`. This attempts to fix that.