### PR TITLE
Roll back time-rs dependency and remove methods that require version 0.3.5

### DIFF
--- a/.changelog/unreleased/improvements/1030-new-time-api.md
+++ b/.changelog/unreleased/improvements/1030-new-time-api.md
@@ -1,11 +1,11 @@
 - Remove dependencies on the `chrono` crate.
   ([#1030](https://github.com/informalsystems/tendermint-rs/issues/1030))
 - `[tendermint]` Improve `tendermint::Time`
-  ([#1030](https://github.com/informalsystems/tendermint-rs/issues/1030)):
+  ([#1036](https://github.com/informalsystems/tendermint-rs/issues/1036),
+   revised by [#1048](https://github.com/informalsystems/tendermint-rs/pull/1048)):
   * Restrict the validity range of `Time` to dates with years in the range
     1-9999, to match the specification of protobuf message `Timestamp`.
     Add an `ErrorDetail` variant `DateOutOfRange` to report when this
     restriction is not met.
   * Added a conversion to, and a fallible conversion from,
     `OffsetDateTime` of the `time` crate.
-  * Added `Time` methods `checked_add` and `checked_sub`.

--- a/light-client/src/predicates.rs
+++ b/light-client/src/predicates.rs
@@ -329,7 +329,7 @@ mod tests {
         assert!(result_ok.is_ok());
 
         // 2. ensure it fails if header is from a future time
-        let now = now.checked_sub(one_second * 15).unwrap();
+        let now = (now - one_second * 15).unwrap();
         let result_err = vp.is_header_from_past(header.time, one_second, now);
 
         match result_err {

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -19,8 +19,8 @@ description = """
 default = ["time"]
 
 [dependencies]
-time = { version = "0.3.5", default-features = false, optional = true }
+time = { version = "0.3", default-features = false, optional = true }
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-time = { version = "0.3.5", features = ["macros"] }
+time = { version = "0.3", features = ["macros"] }

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -112,20 +112,6 @@ impl Time {
     pub fn to_rfc3339(&self) -> String {
         timestamp::to_rfc3339_nanos(self.0.assume_utc())
     }
-
-    /// Computes `self + duration`, returning `None` if an overflow occurred.
-    pub fn checked_add(self, duration: Duration) -> Option<Self> {
-        let duration = duration.try_into().ok()?;
-        let t = self.0.checked_add(duration)?;
-        Self::from_utc(t.assume_utc()).ok()
-    }
-
-    /// Computes `self - duration`, returning `None` if an overflow occurred.
-    pub fn checked_sub(self, duration: Duration) -> Option<Self> {
-        let duration = duration.try_into().ok()?;
-        let t = self.0.checked_sub(duration)?;
-        Self::from_utc(t.assume_utc()).ok()
-    }
 }
 
 impl fmt::Display for Time {
@@ -306,6 +292,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
     fn duration_from_nanos(whole_nanos: u128) -> Duration {
         let secs: u64 = (whole_nanos / 1_000_000_000).try_into().unwrap();
         let nanos = (whole_nanos % 1_000_000_000) as u32;
@@ -368,33 +355,5 @@ mod tests {
             }
     }
 
-    proptest! {
-        #[test]
-        fn checked_add_regular((dt, d) in args_for_regular_add()) {
-            let t: Time = dt.try_into().unwrap();
-            let t = t.checked_add(d).unwrap();
-            let res: OffsetDateTime = t.into();
-            assert_eq!(res, dt + d);
-        }
-
-        #[test]
-        fn checked_sub_regular((dt, d) in args_for_regular_sub()) {
-            let t: Time = dt.try_into().unwrap();
-            let t = t.checked_sub(d).unwrap();
-            let res: OffsetDateTime = t.into();
-            assert_eq!(res, dt - d);
-        }
-
-        #[test]
-        fn checked_add_overflow((dt, d) in args_for_overflowed_add()) {
-            let t: Time = dt.try_into().unwrap();
-            assert_eq!(t.checked_add(d), None);
-        }
-
-        #[test]
-        fn checked_sub_overflow((dt, d) in args_for_overflowed_sub()) {
-            let t: Time = dt.try_into().unwrap();
-            assert_eq!(t.checked_sub(d), None);
-        }
-    }
+    // TODO: add tests for additive ops using the strategies above
 }


### PR DESCRIPTION
Fixes: #1047

Do not require time 0.3.5, because ibc-rs has another dependency that
pins time at =0.3.2.

This means the recently added methods `Time::checked_add` and
`Time::checked_sub` have to be removed. Fortunately, they haven't made it
into a 0.23.x release yet.

* [x] Referenced an issue explaining the need for the change
* ~Updated all relevant documentation in docs~
* [x] Updated all code comments where relevant
* ~Wrote tests~
* [x] Added entry in `.changelog/`
