### PR TITLE
Bump time dependency version to 0.3.5

### DIFF
--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -49,7 +49,7 @@ serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"
 serde_derive = { version = "1.0.106", default-features = false }
 sled = { version = "0.34.3", optional = true, default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
-time = { version = "0.3", default-features = false, features = ["std"] }
+time = { version = "0.3.5", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = ["rt"], optional = true }
 flex-error = { version = "0.4.4", default-features = false }
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -25,7 +25,7 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 subtle-encoding = { version = "0.5", default-features = false, features = ["hex", "base64", "alloc"] }
 num-traits = { version = "0.2", default-features = false }
 num-derive = { version = "0.3", default-features = false }
-time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3.5", default-features = false, features = ["macros", "parsing"] }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -72,7 +72,7 @@ tendermint-config = { version = "0.23.0", path = "../config", default-features =
 tendermint = { version = "0.23.0", default-features = false, path = "../tendermint" }
 tendermint-proto = { version = "0.23.0", default-features = false, path = "../proto" }
 thiserror = { version = "1", default-features = false }
-time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3.5", default-features = false, features = ["macros", "parsing"] }
 uuid = { version = "0.8", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 url = { version = "2.2", default-features = false }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -51,7 +51,7 @@ signature = { version = "1.2", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.23.0", default-features = false, path = "../proto" }
-time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3.5", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.9", optional = true, default-features = false, features = ["ecdsa", "sha256"] }

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -23,7 +23,7 @@ ed25519-dalek = { version = "1", default-features = false }
 gumdrop = { version = "0.8.0", default-features = false }
 simple-error = { version = "0.2.1", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }
-time = { package = "time", version = "0.3", default-features = false, features = ["std"] }
+time = { version = "0.3.5", default-features = false, features = ["std"] }
 
 [[bin]]
 name = "tendermint-testgen"


### PR DESCRIPTION
tendermint uses `checked_add`/`checked_sub` methods which were added
in time 0.3.5.

See also #1048 for the v0.23.x branch.

* [ ] Referenced an issue explaining the need for the change
* ~Updated all relevant documentation in docs~
* ~Updated all code comments where relevant~
* ~Wrote tests~
* ~Added entry in `.changelog/`~
