### PR TITLE
Derive `Hash` on `tendermint::Time`

### DIFF
--- a/.changelog/unreleased/improvements/1054-derive-hash-on-time.md
+++ b/.changelog/unreleased/improvements/1054-derive-hash-on-time.md
@@ -1,0 +1,2 @@
+- `Hash` is implemented for `tendermint::Time`
+  ([#1054](https://github.com/informalsystems/tendermint-rs/pull/1054))

--- a/.changelog/unreleased/improvements/1054-derive-hash-on-time.md
+++ b/.changelog/unreleased/improvements/1054-derive-hash-on-time.md
@@ -1,2 +1,2 @@
-- `Hash` is implemented for `tendermint::Time`
+- `[tendermint]` `Hash` is implemented for `tendermint::Time`
   ([#1054](https://github.com/informalsystems/tendermint-rs/pull/1054))

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -34,7 +34,7 @@ use crate::error::Error;
 // For memory efficiency, the inner member is `PrimitiveDateTime`, with assumed
 // UTC offset. The `assume_utc` method is used to get the operational
 // `OffsetDateTime` value.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(try_from = "Timestamp", into = "Timestamp")]
 pub struct Time(PrimitiveDateTime);
 


### PR DESCRIPTION
Now that we're backed by a data structure with unambiguously unique values, we can make time moments hashable.

* [ ] Referenced an issue explaining the need for the change
* ~Updated all relevant documentation in docs~
* ~Updated all code comments where relevant~
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
