### PR TITLE
Bump `k256` to v0.10

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -51,7 +51,7 @@ tendermint-proto = { version = "0.23.0", default-features = false, path = "../pr
 time = { version = "0.3.5", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
-k256 = { version = "0.9", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
+k256 = { version = "0.10", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
 ripemd160 = { version = "0.9", default-features = false, optional = true }
 
 [features]


### PR DESCRIPTION
Updates `k256` crate to the latest version.

Release notes: https://github.com/RustCrypto/elliptic-curves/pull/485
