### PR TITLE
rpc: Switch hyper-proxy to use rustls (backport to v0.23.x)

### DIFF
--- a/.changelog/unreleased/dependencies/1068-remove-native-tls.md
+++ b/.changelog/unreleased/dependencies/1068-remove-native-tls.md
@@ -1,0 +1,3 @@
+- `[tendermint-rpc]`: Switch `hyper-proxy` to use `rustls`, eliminating
+  the only use of `native-tls` in tendermint-rs dependencies
+  ([#1068](https://github.com/informalsystems/tendermint-rs/pull/1068))

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -85,7 +85,7 @@ async-tungstenite = { version = "0.12", default-features = false, features = ["t
 futures = { version = "0.3", optional = true, default-features = false }
 http = { version = "0.2", optional = true, default-features = false }
 hyper = { version = "0.14", optional = true, default-features = false, features = ["client", "http1", "http2"] }
-hyper-proxy = { version = "0.9", optional = true, default-features = false, features = ["tls"] }
+hyper-proxy = { version = "0.9.1", optional = true, default-features = false, features = ["rustls"] }
 hyper-rustls = { version = "0.22.1", optional = true, default-features = false, features = ["rustls-native-certs", "webpki-roots", "tokio-runtime"] }
 structopt = { version = "0.3", optional = true, default-features = false }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["rt-multi-thread"] }


### PR DESCRIPTION
Backport of #1068 to v0.23.x