### PR TITLE
light-client refactor: Re-export new verifier crate from `tendermint-light-client`

### DIFF
--- a/.changelog/unreleased/breaking-changes/1027-light-client-verifier.md
+++ b/.changelog/unreleased/breaking-changes/1027-light-client-verifier.md
@@ -1,0 +1,5 @@
+- `[tendermint-light-client]` Split out the verification functionality from the
+  `tendermint-light-client` crate into its own `no_std`-compatible crate:
+  `tendermint-light-client-verifier`. This helps move us closer to `no_std`
+  compliance in both tendermint-rs and ibc-rs
+  ([#1027](https://github.com/informalsystems/tendermint-rs/issues/1027))

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = { version = "1.0", default-features = false }
 # TODO(thane): Remove once https://github.com/rustwasm/wasm-bindgen/issues/2508 is resolved
 syn = { version = "=1.0.65", default-features = false }
 tendermint = { version = "0.23.0", default-features = false, path = "../tendermint" }
-tendermint-light-client = { version = "0.23.0", default-features = false, path = "../light-client" }
 tendermint-light-client-verifier = { version = "0.23.0", default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }
 

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use tendermint::Time;
 use tendermint_light_client_verifier::options::Options;
 use tendermint_light_client_verifier::types::{LightBlock, TrustThreshold};
-use tendermint_light_client_verifier::verifier::{ProdVerifier, Verifier};
+use tendermint_light_client_verifier::{ProdVerifier, Verifier};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -1,12 +1,12 @@
 //! Tendermint Light Client JavaScript/WASM interface.
 //!
-//! This crate exposes some of the [`tendermint-light-client`] crate's
+//! This crate exposes some of the [`tendermint-light-client-verifier`] crate's
 //! functionality to be used from the JavaScript ecosystem.
 //!
 //! For a detailed example, please see the [`verifier-web` example] in the
 //! repository.
 //!
-//! [`tendermint-light-client`]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client
+//! [`tendermint-light-client-verifier`]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client-verifier
 //! [`verifier-web` example]: https://github.com/informalsystems/tendermint-rs/tree/master/light-client-js/examples/verifier-web
 
 mod utils;

--- a/light-client-js/tests/web.rs
+++ b/light-client-js/tests/web.rs
@@ -6,7 +6,7 @@ extern crate wasm_bindgen_test;
 use tendermint::Time;
 use tendermint_light_client_js::{verify, Error, JsOptions};
 use tendermint_light_client_verifier::types::LightBlock;
-use tendermint_light_client_verifier::verifier::Verdict;
+use tendermint_light_client_verifier::Verdict;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 

--- a/light-client-verifier/src/lib.rs
+++ b/light-client-verifier/src/lib.rs
@@ -9,4 +9,6 @@ pub mod operations;
 pub mod options;
 pub mod predicates;
 pub mod types;
-pub mod verifier;
+mod verifier;
+
+pub use verifier::{PredicateVerifier, ProdVerifier, Verdict, Verifier};

--- a/light-client/examples/light_client.rs
+++ b/light-client/examples/light_client.rs
@@ -4,12 +4,12 @@ use gumdrop::Options;
 
 use tendermint::Hash;
 use tendermint_light_client::supervisor::{Handle as _, Instance};
+use tendermint_light_client::verifier::options::Options as LightClientOptions;
+use tendermint_light_client::verifier::types::{Height, PeerId, TrustThreshold};
 use tendermint_light_client::{
     builder::{LightClientBuilder, SupervisorBuilder},
     store::memory::MemoryStore,
 };
-use tendermint_light_client_verifier::options::Options as LightClientOptions;
-use tendermint_light_client_verifier::types::{Height, PeerId, TrustThreshold};
 use tendermint_rpc as rpc;
 
 #[derive(Debug, Options)]

--- a/light-client/src/builder/error.rs
+++ b/light-client/src/builder/error.rs
@@ -3,9 +3,9 @@
 use flex_error::define_error;
 use tendermint::block::Height;
 use tendermint::Hash;
-use tendermint_light_client_verifier::errors::VerificationError;
 
 use crate::components::io::IoError;
+use crate::verifier::errors::VerificationError;
 
 define_error! {
     Error {

--- a/light-client/src/builder/light_client.rs
+++ b/light-client/src/builder/light_client.rs
@@ -1,9 +1,6 @@
 //! DSL for building a light client [`Instance`]
 
 use tendermint::{block::Height, Hash};
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{LightBlock, PeerId, Status};
-use tendermint_light_client_verifier::verifier::Verifier;
 
 use crate::builder::error::Error;
 use crate::components::clock::Clock;
@@ -13,18 +10,19 @@ use crate::light_client::LightClient;
 use crate::state::{State, VerificationTrace};
 use crate::store::LightStore;
 use crate::supervisor::Instance;
-use tendermint_light_client_verifier::operations::Hasher;
-use tendermint_light_client_verifier::predicates::VerificationPredicates;
+use crate::verifier::operations::Hasher;
+use crate::verifier::options::Options;
+use crate::verifier::predicates::VerificationPredicates;
+use crate::verifier::types::{LightBlock, PeerId, Status};
+use crate::verifier::Verifier;
 
 #[cfg(feature = "rpc-client")]
 use {
     crate::components::clock::SystemClock,
     crate::components::io::ProdIo,
     crate::components::scheduler,
+    crate::verifier::{operations::ProdHasher, predicates::ProdPredicates, ProdVerifier},
     core::time::Duration,
-    tendermint_light_client_verifier::{
-        operations::ProdHasher, predicates::ProdPredicates, verifier::ProdVerifier,
-    },
     tendermint_rpc as rpc,
 };
 

--- a/light-client/src/builder/supervisor.rs
+++ b/light-client/src/builder/supervisor.rs
@@ -1,9 +1,9 @@
 use core::time::Duration;
-use tendermint_light_client_verifier::types::PeerId;
 
 use crate::builder::error::Error;
 use crate::peer_list::{PeerList, PeerListBuilder};
 use crate::supervisor::Instance;
+use crate::verifier::types::PeerId;
 
 #[cfg(feature = "rpc-client")]
 use {

--- a/light-client/src/components/clock.rs
+++ b/light-client/src/components/clock.rs
@@ -1,7 +1,7 @@
 //! Provides an interface and a default implementation of the `Clock` component
 
+use crate::verifier::types::Time;
 use std::convert::TryInto;
-use tendermint_light_client_verifier::types::Time;
 use time::OffsetDateTime;
 
 /// Abstracts over the current time.

--- a/light-client/src/components/io.rs
+++ b/light-client/src/components/io.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 #[cfg(feature = "rpc-client")]
 use tendermint_rpc::Client;
 
-use tendermint_light_client_verifier::types::{Height, LightBlock};
+use crate::verifier::types::{Height, LightBlock};
 use tendermint_rpc as rpc;
 
 #[cfg(feature = "tokio")]
@@ -99,7 +99,7 @@ mod prod {
     use std::time::Duration;
 
     use crate::utils::block_on;
-    use tendermint_light_client_verifier::types::PeerId;
+    use crate::verifier::types::PeerId;
 
     use tendermint::account::Id as TMAccountId;
     use tendermint::block::signed_header::SignedHeader as TMSignedHeader;

--- a/light-client/src/components/scheduler.rs
+++ b/light-client/src/components/scheduler.rs
@@ -3,8 +3,8 @@
 use contracts::*;
 
 use crate::store::LightStore;
+use crate::verifier::types::Height;
 use core::convert::TryInto;
-use tendermint_light_client_verifier::types::Height;
 
 /// The scheduler decides what block to verify next given the current and target heights.
 ///

--- a/light-client/src/contracts.rs
+++ b/light-client/src/contracts.rs
@@ -1,8 +1,7 @@
 //! Predicates used in components contracts.
 
-use tendermint_light_client_verifier::types::{Height, LightBlock, Status, Time};
-
 use crate::store::LightStore;
+use crate::verifier::types::{Height, LightBlock, Status, Time};
 
 use std::time::Duration;
 

--- a/light-client/src/errors.rs
+++ b/light-client/src/errors.rs
@@ -3,11 +3,11 @@
 use std::fmt::Debug;
 use std::time::Duration;
 
+use crate::verifier::errors::{ErrorExt, VerificationErrorDetail};
+use crate::verifier::operations::voting_power::VotingPowerTally;
+use crate::verifier::options::Options;
+use crate::verifier::types::{Hash, Height, LightBlock, PeerId, Status};
 use crossbeam_channel as crossbeam;
-use tendermint_light_client_verifier::errors::{ErrorExt, VerificationErrorDetail};
-use tendermint_light_client_verifier::operations::voting_power::VotingPowerTally;
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{Hash, Height, LightBlock, PeerId, Status};
 
 use crate::components::io::IoError;
 use flex_error::{define_error, DisplayError, TraceError};

--- a/light-client/src/evidence.rs
+++ b/light-client/src/evidence.rs
@@ -1,10 +1,10 @@
 //! Fork evidence data structures and interfaces.
 
 use contracts::contract_trait;
-use tendermint_light_client_verifier::types::PeerId;
 use tendermint_rpc::abci::transaction::Hash;
 
 use crate::components::io::IoError;
+use crate::verifier::types::PeerId;
 
 pub use tendermint::evidence::Evidence;
 

--- a/light-client/src/fork_detector.rs
+++ b/light-client/src/fork_detector.rs
@@ -1,8 +1,8 @@
 //! Fork detection data structures and implementation.
 
-use tendermint_light_client_verifier::errors::ErrorExt;
-use tendermint_light_client_verifier::operations::{Hasher, ProdHasher};
-use tendermint_light_client_verifier::types::{LightBlock, PeerId, Status};
+use crate::verifier::errors::ErrorExt;
+use crate::verifier::operations::{Hasher, ProdHasher};
+use crate::verifier::types::{LightBlock, PeerId, Status};
 
 use crate::{
     errors::{Error, ErrorDetail},

--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -30,5 +30,8 @@ pub mod supervisor;
 
 pub(crate) mod utils;
 
+// Re-export `tendermint-light-client-verifier` crate.
+pub use tendermint_light_client_verifier as verifier;
+
 #[doc(hidden)]
 pub mod tests;

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -4,16 +4,18 @@
 
 use contracts::*;
 use core::fmt;
-use tendermint_light_client_verifier::operations::Hasher;
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{Height, LightBlock, PeerId, Status};
-use tendermint_light_client_verifier::verifier::{Verdict, Verifier};
 
 use crate::{
     components::{clock::Clock, io::*, scheduler::*},
     contracts::*,
     errors::Error,
     state::State,
+    verifier::{
+        operations::Hasher,
+        options::Options,
+        types::{Height, LightBlock, PeerId, Status},
+        Verdict, Verifier,
+    },
 };
 
 /// The light client implements a read operation of a header from the blockchain,

--- a/light-client/src/peer_list.rs
+++ b/light-client/src/peer_list.rs
@@ -2,9 +2,9 @@
 
 use contracts::{post, pre};
 use std::collections::{BTreeSet, HashMap};
-use tendermint_light_client_verifier::types::PeerId;
 
 use crate::errors::Error;
+use crate::verifier::types::PeerId;
 
 /// A generic container mapping `PeerId`s to some type `T`,
 /// which keeps track of the primary peer, witnesses, full nodes,

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -1,8 +1,7 @@
 //! State maintained by the light client.
 
-use tendermint_light_client_verifier::types::{Height, LightBlock, Status};
-
 use crate::store::LightStore;
+use crate::verifier::types::{Height, LightBlock, Status};
 
 use contracts::*;
 use std::collections::{HashMap, HashSet};

--- a/light-client/src/store.rs
+++ b/light-client/src/store.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use crate::utils::std_ext;
-use tendermint_light_client_verifier::types::{Height, LightBlock, Status};
+use crate::verifier::types::{Height, LightBlock, Status};
 
 pub mod memory;
 

--- a/light-client/src/store/memory.rs
+++ b/light-client/src/store/memory.rs
@@ -1,10 +1,10 @@
 //! Transient in-memory store
 
 use crate::store::{LightStore, Status};
+use crate::verifier::types::{Height, LightBlock};
 
 use std::collections::btree_map::Entry::*;
 use std::collections::BTreeMap;
-use tendermint_light_client_verifier::types::{Height, LightBlock};
 
 /// Internal entry for the memory store
 #[derive(Clone, Debug, PartialEq)]

--- a/light-client/src/store/sled.rs
+++ b/light-client/src/store/sled.rs
@@ -3,8 +3,8 @@
 pub mod utils;
 use utils::HeightIndexedDb;
 
+use crate::verifier::types::{Height, LightBlock};
 use std::path::Path;
-use tendermint_light_client_verifier::types::{Height, LightBlock};
 
 use super::{LightStore, Status};
 

--- a/light-client/src/store/sled/utils.rs
+++ b/light-client/src/store/sled/utils.rs
@@ -5,9 +5,9 @@
 use std::marker::PhantomData;
 
 use serde::{de::DeserializeOwned, Serialize};
-use tendermint_light_client_verifier::types::Height;
 
 use crate::errors::Error;
+use crate::verifier::types::Height;
 
 /// Provides a view over the database for storing key/value pairs at the given prefix.
 #[derive(Clone, Debug)]

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -3,7 +3,6 @@
 use crossbeam_channel as channel;
 
 use tendermint::evidence::{ConflictingHeadersEvidence, Evidence};
-use tendermint_light_client_verifier::types::{Height, LatestStatus, LightBlock, PeerId, Status};
 
 use crate::errors::Error;
 use crate::evidence::EvidenceReporter;
@@ -11,6 +10,7 @@ use crate::fork_detector::{Fork, ForkDetection, ForkDetector};
 use crate::light_client::LightClient;
 use crate::peer_list::PeerList;
 use crate::state::State;
+use crate::verifier::types::{Height, LatestStatus, LightBlock, PeerId, Status};
 
 /// Provides an interface to the supervisor for use in downstream code.
 pub trait Handle: Send + Sync {
@@ -434,16 +434,16 @@ mod tests {
         tests::{MockClock, MockEvidenceReporter, MockIo, TrustOptions},
     };
 
+    use crate::verifier::operations::ProdHasher;
+    use crate::verifier::options::Options;
+    use crate::verifier::types::Time;
+    use crate::verifier::ProdVerifier;
     use core::convert::{Into, TryFrom};
     use core::time::Duration;
     use std::collections::HashMap;
     use tendermint::block::Height;
     use tendermint::evidence::Duration as DurationStr;
     use tendermint::trust_threshold::TrustThresholdFraction;
-    use tendermint_light_client_verifier::operations::ProdHasher;
-    use tendermint_light_client_verifier::options::Options;
-    use tendermint_light_client_verifier::types::Time;
-    use tendermint_light_client_verifier::verifier::ProdVerifier;
     use tendermint_rpc::{
         self as rpc,
         response_error::{Code, ResponseError},

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -1,11 +1,6 @@
 //! Utilities and datatypes for use in tests.
 
 use serde::{Deserialize, Serialize};
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{
-    Height, LightBlock, PeerId, SignedHeader, Time, TrustThreshold, ValidatorSet,
-};
-use tendermint_light_client_verifier::verifier::{ProdVerifier, Verdict, Verifier};
 use tendermint_rpc as rpc;
 use tendermint_rpc::abci::transaction::Hash;
 
@@ -15,6 +10,11 @@ use crate::errors::Error;
 use crate::evidence::EvidenceReporter;
 use crate::light_client::LightClient;
 use crate::state::State;
+use crate::verifier::options::Options;
+use crate::verifier::types::{
+    Height, LightBlock, PeerId, SignedHeader, Time, TrustThreshold, ValidatorSet,
+};
+use crate::verifier::{ProdVerifier, Verdict, Verifier};
 use contracts::contract_trait;
 use std::collections::HashMap;
 use std::time::Duration;

--- a/light-client/tests/backward.rs
+++ b/light-client/tests/backward.rs
@@ -3,10 +3,6 @@
 use std::{collections::HashMap, time::Duration};
 
 use tendermint::{hash::Algorithm, Hash};
-use tendermint_light_client_verifier::operations::ProdHasher;
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{Height, LightBlock, Status};
-use tendermint_light_client_verifier::verifier::ProdVerifier;
 
 use tendermint_light_client::{
     components::{
@@ -18,6 +14,12 @@ use tendermint_light_client::{
     state::State,
     store::{memory::MemoryStore, LightStore},
     tests::{MockClock, MockIo},
+    verifier::{
+        operations::ProdHasher,
+        options::Options,
+        types::{Height, LightBlock, Status},
+        ProdVerifier,
+    },
 };
 
 use tendermint_testgen::{

--- a/light-client/tests/light_client.rs
+++ b/light-client/tests/light_client.rs
@@ -1,11 +1,6 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use tendermint_light_client_verifier::operations::ProdHasher;
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{LightBlock, Status};
-use tendermint_light_client_verifier::verifier::ProdVerifier;
-
 use tendermint_light_client::{
     components::{
         io::{AtHeight, Io},
@@ -16,6 +11,12 @@ use tendermint_light_client::{
     state::State,
     store::{memory::MemoryStore, LightStore},
     tests::*,
+    verifier::{
+        operations::ProdHasher,
+        options::Options,
+        types::{LightBlock, Status},
+        ProdVerifier,
+    },
 };
 
 use tendermint_testgen::light_block::default_peer_id;

--- a/light-client/tests/model_based.rs
+++ b/light-client/tests/model_based.rs
@@ -9,8 +9,10 @@ mod mbt {
     use std::time::Duration;
     use tendermint::validator::Set;
     use tendermint_light_client::tests::*;
-    use tendermint_light_client_verifier::types::{LightBlock, Time, TrustThreshold, ValidatorSet};
-    use tendermint_light_client_verifier::verifier::Verdict;
+    use tendermint_light_client::verifier::types::{
+        LightBlock, Time, TrustThreshold, ValidatorSet,
+    };
+    use tendermint_light_client::verifier::Verdict;
     use tendermint_testgen::light_block::default_peer_id;
     use tendermint_testgen::{
         apalache::*, jsonatr::*, light_block::TmLightBlock, validator::generate_validators,

--- a/light-client/tests/supervisor.rs
+++ b/light-client/tests/supervisor.rs
@@ -1,8 +1,3 @@
-use tendermint_light_client_verifier::operations::ProdHasher;
-use tendermint_light_client_verifier::options::Options;
-use tendermint_light_client_verifier::types::{LightBlock, PeerId, Status, Time};
-use tendermint_light_client_verifier::verifier::ProdVerifier;
-
 use tendermint_light_client::{
     components::{
         io::{AtHeight, Io},
@@ -14,6 +9,12 @@ use tendermint_light_client::{
     state::State,
     store::LightStore,
     supervisor::{Handle, Instance, Supervisor},
+    verifier::{
+        operations::ProdHasher,
+        options::Options,
+        types::{LightBlock, PeerId, Status, Time},
+        ProdVerifier,
+    },
 };
 
 use std::collections::HashMap;

--- a/tools/kvstore-test/tests/light-client.rs
+++ b/tools/kvstore-test/tests/light-client.rs
@@ -12,8 +12,6 @@
 //!
 //! (Make sure you install cargo-make using `cargo install cargo-make` first.)
 
-use tendermint_light_client_verifier::types::{Height, PeerId, Status, TrustThreshold};
-use tendermint_light_client_verifier::options::Options as LightClientOptions;
 use tendermint_light_client::{
     builder::{LightClientBuilder, SupervisorBuilder},
     components::io::{AtHeight, Io, IoError, ProdIo},
@@ -21,6 +19,10 @@ use tendermint_light_client::{
     evidence::{Evidence, EvidenceReporter},
     store::{memory::MemoryStore, LightStore},
     supervisor::{Handle, Instance, Supervisor},
+    verifier::{
+        options::Options as LightClientOptions,
+        types::{Height, PeerId, Status, TrustThreshold},
+    },
 };
 
 use tendermint_rpc as rpc;


### PR DESCRIPTION
Some suggestions for #1071.

This PR re-exports the `tendermint-light-client-verifier` crate from `tendermint-light-client` to allow users of the `tendermint-light-client` crate easy access to the verifier.

It also adds some minor documentation updates and a changelog entry.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
