### PR TITLE
light-client refactor: Merge latest changes from v0.23.x

### DIFF
--- a/.changelog/v0.23.4/dependencies/1068-remove-native-tls.md
+++ b/.changelog/v0.23.4/dependencies/1068-remove-native-tls.md
@@ -1,0 +1,3 @@
+- `[tendermint-rpc]`: Switch `hyper-proxy` to use `rustls`, eliminating
+  the only use of `native-tls` in tendermint-rs dependencies
+  ([#1068](https://github.com/informalsystems/tendermint-rs/pull/1068))

--- a/.changelog/v0.23.4/summary.md
+++ b/.changelog/v0.23.4/summary.md
@@ -1,0 +1,5 @@
+*Jan 11, 2022*
+
+This release exclusively focuses on removing `native-tls`/`openssl` from the
+dependency tree and replacing it with `rustls`. This was previously incorrectly
+configured in our `hyper-proxy` dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## v0.23.4
+
+*Jan 11, 2022*
+
+This release exclusively focuses on removing `native-tls`/`openssl` from the
+dependency tree and replacing it with `rustls`. This was previously incorrectly
+configured in our `hyper-proxy` dependency.
+
+### DEPENDENCIES
+
+- `[tendermint-rpc]`: Switch `hyper-proxy` to use `rustls`, eliminating
+  the only use of `native-tls` in tendermint-rs dependencies
+  ([#1068](https://github.com/informalsystems/tendermint-rs/pull/1068))
+
 ## v0.23.3
 
 *Dec 20, 2021*

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-abci"
-version     = "0.23.3"
+version     = "0.23.4"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2018"
 license     = "Apache-2.0"
@@ -33,7 +33,7 @@ binary = [
 [dependencies]
 bytes = { version = "1.0", default-features = false }
 prost = { version = "0.9", default-features = false }
-tendermint-proto = { version = "0.23.3", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.23.4", default-features = false, path = "../proto" }
 tracing = { version = "0.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 structopt = { version = "0.3", optional = true, default-features = false }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-config"
-version    = "0.23.3" # Also update `html_root_url` in lib.rs and
+version    = "0.23.4" # Also update `html_root_url` in lib.rs and
                                # depending crates (rpc, light-node, ..) when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
@@ -25,7 +25,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-tendermint = { version = "0.23.3", default-features = false, path = "../tendermint" }
+tendermint = { version = "0.23.4", default-features = false, path = "../tendermint" }
 flex-error = { version = "0.4.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-light-client-js"
-version     = "0.23.3"
+version     = "0.23.4"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2018"
 license     = "Apache-2.0"
@@ -24,8 +24,8 @@ serde = { version = "1.0", default-features = false, features = [ "derive" ] }
 serde_json = { version = "1.0", default-features = false }
 # TODO(thane): Remove once https://github.com/rustwasm/wasm-bindgen/issues/2508 is resolved
 syn = { version = "=1.0.65", default-features = false }
-tendermint = { version = "0.23.3", default-features = false, path = "../tendermint" }
-tendermint-light-client-verifier = { version = "0.23.3", default-features = false, path = "../light-client-verifier" }
+tendermint = { version = "0.23.4", default-features = false, path = "../tendermint" }
+tendermint-light-client-verifier = { version = "0.23.4", default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client-verifier"
-version    = "0.23.3"
+version    = "0.23.4"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -26,8 +26,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["flex-error/std", "flex-error/eyre_tracer"]
 
 [dependencies]
-tendermint = { version = "0.23.3", path = "../tendermint", default-features = false }
-tendermint-rpc = { version = "0.23.3", path = "../rpc", default-features = false }
+tendermint = { version = "0.23.4", path = "../tendermint", default-features = false }
+tendermint-rpc = { version = "0.23.4", path = "../rpc", default-features = false }
 
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }
 serde = { version = "1.0.106", default-features = false }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client"
-version    = "0.23.3"
+version    = "0.23.4"
 edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -34,9 +34,9 @@ unstable = []
 mbt = []
 
 [dependencies]
-tendermint = { version = "0.23.3", path = "../tendermint", default-features = false }
-tendermint-rpc = { version = "0.23.3", path = "../rpc", default-features = false }
-tendermint-light-client-verifier = { version = "0.23.3", path = "../light-client-verifier", default-features = false }
+tendermint = { version = "0.23.4", path = "../tendermint", default-features = false }
+tendermint-rpc = { version = "0.23.4", path = "../rpc", default-features = false }
+tendermint-light-client-verifier = { version = "0.23.4", path = "../light-client-verifier", default-features = false }
 
 contracts = { version = "0.4.0", default-features = false }
 crossbeam-channel = { version = "0.4.2", default-features = false }

--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -9,7 +9,7 @@
     nonstandard_style
 )]
 #![doc(
-    html_root_url = "https://docs.rs/tendermint-light-client/0.23.3",
+    html_root_url = "https://docs.rs/tendermint-light-client/0.23.4",
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-p2p"
-version     = "0.23.3"
+version     = "0.23.4"
 edition     = "2018"
 license     = "Apache-2.0"
 repository  = "https://github.com/informalsystems/tendermint-rs"
@@ -44,9 +44,9 @@ aead = { version = "0.4.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 # path dependencies
-tendermint = { path = "../tendermint", version = "0.23.3", default-features = false }
-tendermint-proto = { path = "../proto", version = "0.23.3", default-features = false }
-tendermint-std-ext = { path = "../std-ext", version = "0.23.3", default-features = false }
+tendermint = { path = "../tendermint", version = "0.23.4", default-features = false }
+tendermint-proto = { path = "../proto", version = "0.23.4", default-features = false }
+tendermint-std-ext = { path = "../std-ext", version = "0.23.4", default-features = false }
 
 # optional dependencies
 prost-derive = { version = "0.9", optional = true }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -20,7 +20,7 @@
     unused_qualifications
 )]
 #![doc(
-    html_root_url = "https://docs.rs/tendermint-p2p/0.23.3",
+    html_root_url = "https://docs.rs/tendermint-p2p/0.23.4",
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tendermint-pbt-gen"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2018"
 license     = "Apache-2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tendermint-proto"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/tendermint-proto/0.23.3")]
+#![doc(html_root_url = "https://docs.rs/tendermint-proto/0.23.4")]
 
 extern crate alloc;
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-rpc"
-version    = "0.23.3"
+version    = "0.23.4"
 edition    = "2018"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
@@ -68,9 +68,9 @@ pin-project = { version = "1.0.1", default-features = false }
 serde = { version = "1", default-features = false, features = [ "derive" ] }
 serde_bytes = { version = "0.11", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["std"] }
-tendermint-config = { version = "0.23.3", path = "../config", default-features = false }
-tendermint = { version = "0.23.3", default-features = false, path = "../tendermint" }
-tendermint-proto = { version = "0.23.3", default-features = false, path = "../proto" }
+tendermint-config = { version = "0.23.4", path = "../config", default-features = false }
+tendermint = { version = "0.23.4", default-features = false, path = "../tendermint" }
+tendermint-proto = { version = "0.23.4", default-features = false, path = "../proto" }
 thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 uuid = { version = "0.8", default-features = false }
@@ -85,7 +85,7 @@ async-tungstenite = { version = "0.12", default-features = false, features = ["t
 futures = { version = "0.3", optional = true, default-features = false }
 http = { version = "0.2", optional = true, default-features = false }
 hyper = { version = "0.14", optional = true, default-features = false, features = ["client", "http1", "http2"] }
-hyper-proxy = { version = "0.9", optional = true, default-features = false, features = ["tls"] }
+hyper-proxy = { version = "0.9.1", optional = true, default-features = false, features = ["rustls"] }
 hyper-rustls = { version = "0.22.1", optional = true, default-features = false, features = ["rustls-native-certs", "webpki-roots", "tokio-runtime"] }
 structopt = { version = "0.3", optional = true, default-features = false }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["rt-multi-thread"] }

--- a/std-ext/Cargo.toml
+++ b/std-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-std-ext"
-version    = "0.23.3"
+version    = "0.23.4"
 edition    = "2018"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.23.3" # Also update `html_root_url` in lib.rs and
+version    = "0.23.4" # Also update `html_root_url` in lib.rs and
                                # depending crates (rpc, light-node, ..) when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
@@ -47,7 +47,7 @@ sha2 = { version = "0.9", default-features = false }
 signature = { version = "1.2", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
-tendermint-proto = { version = "0.23.3", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.23.4", default-features = false, path = "../proto" }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -15,7 +15,7 @@
 )]
 #![forbid(unsafe_code)]
 #![doc(
-    html_root_url = "https://docs.rs/tendermint/0.23.3",
+    html_root_url = "https://docs.rs/tendermint/0.23.4",
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tendermint-test"
 description = "Tendermint workspace tests and common utilities for testing."
-version     = "0.23.3"
+version     = "0.23.4"
 edition     = "2018"
 license     = "Apache-2.0"
 categories  = ["development", "test", "tools"]

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-testgen"
-version     = "0.23.3"
+version     = "0.23.4"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2018"
 readme      = "README.md"
@@ -16,7 +16,7 @@ description = """
     """
 
 [dependencies]
-tendermint = { version = "0.23.3", path = "../tendermint" }
+tendermint = { version = "0.23.4", path = "../tendermint" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 ed25519-dalek = { version = "1", default-features = false }

--- a/tools/abci-test/Cargo.toml
+++ b/tools/abci-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abci-test"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2018"
 description = """
@@ -14,9 +14,9 @@ description = """
 flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 futures = "0.3"
 structopt = "0.3"
-tendermint = { version = "0.23.3", path = "../../tendermint" }
-tendermint-config = { version = "0.23.3", path = "../../config" }
-tendermint-rpc = { version = "0.23.3", path = "../../rpc", features = [ "websocket-client" ] }
+tendermint = { version = "0.23.4", path = "../../tendermint" }
+tendermint-config = { version = "0.23.4", path = "../../config" }
+tendermint-rpc = { version = "0.23.4", path = "../../rpc", features = [ "websocket-client" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { version = "1", features = ["full"] }

--- a/tools/kvstore-test/Cargo.toml
+++ b/tools/kvstore-test/Cargo.toml
@@ -10,10 +10,9 @@ edition = "2018"
 
 [dev-dependencies]
 futures = "0.3"
-tendermint = { version = "0.23.3", path = "../../tendermint" }
-tendermint-light-client = { version = "0.23.3", path = "../../light-client", features = ["unstable"] }
-tendermint-light-client-verifier = { version = "0.23.3", path = "../../light-client-verifier" }
-tendermint-rpc = { version = "0.23.3", path = "../../rpc", features = [ "http-client", "websocket-client" ] }
+tendermint = { version = "0.23.4", path = "../../tendermint" }
+tendermint-light-client = { version = "0.23.4", path = "../../light-client", features = ["unstable"] }
+tendermint-rpc = { version = "0.23.4", path = "../../rpc", features = [ "http-client", "websocket-client" ] }
 tokio = { version = "1.0", features = [ "rt-multi-thread", "macros" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/tools/kvstore-test/tests/light-client.rs
+++ b/tools/kvstore-test/tests/light-client.rs
@@ -24,8 +24,6 @@ use tendermint_light_client::{
         types::{Height, PeerId, Status, TrustThreshold},
     },
 };
-use tendermint_light_client_verifier::options::Options as LightClientOptions;
-use tendermint_light_client_verifier::types::{Height, PeerId, Status, TrustThreshold};
 
 use tendermint::abci::transaction::Hash as TxHash;
 use tendermint_rpc as rpc;

--- a/tools/rpc-probe/Cargo.toml
+++ b/tools/rpc-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tendermint-rpc-probe"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2018"
 license    = "Apache-2.0"


### PR DESCRIPTION
Fixes merge conflicts in #1072 and harmonizes versioning with the `v0.23.x` branch (which has since been bumped to v0.23.4).