### PR TITLE
Fix clippy warnings in rpc-probe

### DIFF
--- a/tools/rpc-probe/src/quick.rs
+++ b/tools/rpc-probe/src/quick.rs
@@ -8,7 +8,6 @@ use tokio::time::Duration;
 
 pub fn quick_probe_plan(output_path: &Path, request_wait: Duration) -> Result<Plan> {
     Plan::new(
-        "quick-probe",
         output_path,
         request_wait,
         vec![


### PR DESCRIPTION
Minor tweak to remove/use private fields in the rpc-probe's `PlanConfig` struct.