### PR TITLE
Use Time instead of u64 seconds in tendermint-testgen Header (v0.23)

### DIFF
--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -585,7 +585,10 @@ mod tests {
 
         let peer_id = provider.unwrap_or("0BEFEEDC0C0ADEADBEBADFADADEFC0FFEEFACADE");
 
-        let header = Header::new(&vals).height(1).chain_id(chain).time(1);
+        let header = Header::new(&vals)
+            .height(1)
+            .chain_id(chain)
+            .time(Time::from_unix_timestamp(1, 0).unwrap());
         let commit = Commit::new(header.clone(), 1);
         let mut lb = TestgenLightBlock::new(header, commit).provider(peer_id);
 
@@ -722,8 +725,7 @@ mod tests {
             .collect::<Vec<LightBlock>>();
 
         let mut header = chain.light_blocks[4].header.clone().unwrap();
-        let mut time = header.time.unwrap();
-        time += 3;
+        let time = (header.time.unwrap() + Duration::from_secs(3)).unwrap();
         header.time = Some(time);
         chain.light_blocks[4].header = Some(header.clone());
         chain.light_blocks[4].commit = Some(Commit::new(header, 1));

--- a/light-client/tests/backward.rs
+++ b/light-client/tests/backward.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use tendermint::{hash::Algorithm, Hash};
+use tendermint::{hash::Algorithm, Hash, Time};
 
 use tendermint_light_client::{
     components::{
@@ -156,7 +156,7 @@ fn corrupt_hash(mut tc: TestCase, mut rng: TestRng) -> TestCase {
     let block = tc.chain.block_mut(height).unwrap();
 
     if let Some(header) = block.header.as_mut() {
-        header.time = Some(1610105021);
+        header.time = Some(Time::from_unix_timestamp(1610105021, 0).unwrap());
     }
 
     tc

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -16,7 +16,7 @@ description = """
     """
 
 [dependencies]
-tendermint = { version = "0.23.4", path = "../tendermint" }
+tendermint = { version = "0.23.4", path = "../tendermint", features = ["clock"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 ed25519-dalek = { version = "1", default-features = false }

--- a/testgen/src/commit.rs
+++ b/testgen/src/commit.rs
@@ -169,6 +169,7 @@ impl Generator<block::Commit> for Commit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tendermint::Time;
 
     #[test]
     fn test_commit() {
@@ -186,7 +187,7 @@ mod tests {
         let header = Header::new(&valset1)
             .next_validators(&valset2)
             .height(10)
-            .time(11);
+            .time(Time::from_unix_timestamp(11, 0).unwrap());
 
         let commit = Commit::new(header.clone(), 3);
 

--- a/testgen/src/light_block.rs
+++ b/testgen/src/light_block.rs
@@ -8,7 +8,9 @@ use crate::{Commit, Generator, Header, Validator};
 use tendermint::node::Id as PeerId;
 use tendermint::validator;
 use tendermint::validator::Set as ValidatorSet;
+use tendermint::Time;
 use tendermint::{block::signed_header::SignedHeader, Hash};
+
 /// A light block is the core data structure used by the light client.
 /// It records everything the light client needs to know about a block.
 /// NOTE: This struct & associated `impl` below are a copy of light-client's `LightBlock`.
@@ -92,7 +94,7 @@ impl LightBlock {
             .height(height)
             .chain_id("test-chain")
             .next_validators(&validators)
-            .time(height); // just wanted to initialize time with some value
+            .time(Time::from_unix_timestamp(height as i64, 0).unwrap()); // just wanted to initialize time with some value
 
         let commit = Commit::new(header.clone(), 1);
 
@@ -105,7 +107,7 @@ impl LightBlock {
         }
     }
 
-    pub fn new_default_with_time_and_chain_id(chain_id: String, time: u64, height: u64) -> Self {
+    pub fn new_default_with_time_and_chain_id(chain_id: String, time: Time, height: u64) -> Self {
         let validators = [
             Validator::new("1").voting_power(50),
             Validator::new("2").voting_power(50),
@@ -295,7 +297,7 @@ mod tests {
         let header_6 = Header::new(&validators)
             .next_validators(&validators)
             .height(10)
-            .time(10)
+            .time(Time::from_unix_timestamp(10, 0).unwrap())
             .chain_id("test-chain");
         let commit_6 = Commit::new(header_6.clone(), 1);
         let light_block_6 = LightBlock::new(header_6.clone(), commit_6);

--- a/testgen/src/vote.rs
+++ b/testgen/src/vote.rs
@@ -163,7 +163,7 @@ mod tests {
         let header = Header::new(&valset1)
             .next_validators(&valset2)
             .height(10)
-            .time(10);
+            .time(tendermint::Time::from_unix_timestamp(10, 0).unwrap());
 
         let val = &valset1[1];
         let vote = Vote::new(val.clone(), header.clone()).round(2);


### PR DESCRIPTION
Fixes https://github.com/informalsystems/ibc-rs/issues/1687

The current tendermint-testgen header records time as `u64` in second precision. This means that any sub-second update will trim to the same second, causing the light client verification to fail if two headers fall in the same second. Using the proper `Time` struct will resolve this issue, allowing the header of a new block to have lower than a second difference than the previous block.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
