### PR TITLE
tendermint: Derive `Clone` for `tendermint::PrivateKey`

### DIFF
--- a/.changelog/unreleased/improvements/1077-private-key-clone.md
+++ b/.changelog/unreleased/improvements/1077-private-key-clone.md
@@ -1,0 +1,2 @@
+- `[tendermint]` Implement `Clone` for `PrivateKey`
+  ([#1077](https://github.com/informalsystems/tendermint-rs/issues/1077))

--- a/tendermint/src/private_key.rs
+++ b/tendermint/src/private_key.rs
@@ -12,7 +12,7 @@ use zeroize::Zeroizing;
 pub const ED25519_KEYPAIR_SIZE: usize = 64;
 
 /// Private keys as parsed from configuration files
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[non_exhaustive]
 #[serde(tag = "type", content = "value")] // JSON custom serialization for priv_validator_key.json
 pub enum PrivateKey {


### PR DESCRIPTION
Closes #1077 

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
