### PR TITLE
ci: Bump nightly Rust to 2022-01-11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-11-10
+          toolchain: nightly-2022-01-11
           override: true
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Minor PR to update nightly Rust in CI.