### PR TITLE
backport: `block_results` RPC endpoint changes from #1061

### DIFF
--- a/.changelog/unreleased/workarounds/1021-rpc-block_results.md
+++ b/.changelog/unreleased/workarounds/1021-rpc-block_results.md
@@ -1,0 +1,4 @@
+- `[tendermint-rpc]` Allow deserialization of public keys from validator updates
+  from `block_results` endpoint in multiple JSON formats until this is fixed in
+  Tendermint
+  ([#1021](https://github.com/informalsystems/tendermint-rs/issues/1021))

--- a/rpc/src/request.rs
+++ b/rpc/src/request.rs
@@ -1,7 +1,7 @@
 //! JSON-RPC requests
 
 use super::{Id, Method, Version};
-use crate::prelude::*;
+use crate::{prelude::*, Error};
 use core::fmt::Debug;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -16,6 +16,12 @@ pub trait Request: Debug + DeserializeOwned + Serialize + Sized + Send {
     /// Serialize this request as JSON
     fn into_json(self) -> String {
         Wrapper::new(self).into_json()
+    }
+
+    /// Parse a JSON-RPC request from a JSON string.
+    fn from_string(s: impl AsRef<[u8]>) -> Result<Self, Error> {
+        let wrapper: Wrapper<Self> = serde_json::from_slice(s.as_ref()).map_err(Error::serde)?;
+        Ok(wrapper.params)
     }
 }
 

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -8,12 +8,13 @@ mod pub_key_request;
 mod pub_key_response;
 pub use pub_key_request::PubKeyRequest;
 pub use pub_key_response::PubKeyResponse;
+use serde_json::Value;
 
 use crate::prelude::*;
 use crate::{error::Error, signature::Signature};
 use core::convert::TryFrom;
 use core::{cmp::Ordering, fmt, ops::Deref, str::FromStr};
-use serde::{de, ser, Deserialize, Serialize};
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 use subtle_encoding::{base64, bech32, hex};
 use tendermint_proto::crypto::public_key::Sum;
 use tendermint_proto::crypto::PublicKey as RawPublicKey;
@@ -54,6 +55,69 @@ pub enum PublicKey {
         deserialize_with = "deserialize_secp256k1_base64"
     )]
     Secp256k1(Secp256k1),
+}
+
+// Internal thunk type to facilitate deserialization from the raw Protobuf data
+// structure's JSON representation.
+#[derive(Serialize, Deserialize)]
+struct ProtobufPublicKeyWrapper {
+    #[serde(rename = "Sum")]
+    sum: ProtobufPublicKey,
+}
+
+impl From<ProtobufPublicKeyWrapper> for PublicKey {
+    fn from(wrapper: ProtobufPublicKeyWrapper) -> Self {
+        match wrapper.sum {
+            ProtobufPublicKey::Ed25519 { ed25519 } => PublicKey::Ed25519(ed25519),
+            #[cfg(feature = "secp256k1")]
+            ProtobufPublicKey::Secp256k1 { secp256k1 } => PublicKey::Secp256k1(secp256k1),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")] // JSON custom serialization for priv_validator_key.json
+enum ProtobufPublicKey {
+    #[serde(rename = "tendermint.crypto.PublicKey_Ed25519")]
+    Ed25519 {
+        #[serde(
+            serialize_with = "serialize_ed25519_base64",
+            deserialize_with = "deserialize_ed25519_base64"
+        )]
+        ed25519: Ed25519,
+    },
+
+    #[cfg(feature = "secp256k1")]
+    #[serde(rename = "tendermint.crypto.PublicKey_Secp256K1")]
+    Secp256k1 {
+        #[serde(
+            serialize_with = "serialize_secp256k1_base64",
+            deserialize_with = "deserialize_secp256k1_base64"
+        )]
+        secp256k1: Secp256k1,
+    },
+}
+
+/// Custom deserialization for public keys to handle multiple potential JSON
+/// formats from Tendermint.
+///
+/// See <https://github.com/informalsystems/tendermint-rs/issues/1021> for
+/// context.
+// TODO(thane): Remove this once the serialization in Tendermint has been fixed.
+pub fn deserialize_public_key<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = Value::deserialize(deserializer)?;
+    if v.as_object()
+        .map(|obj| obj.contains_key("Sum"))
+        .unwrap_or(false)
+    {
+        serde_json::from_value::<ProtobufPublicKeyWrapper>(v).map(Into::into)
+    } else {
+        serde_json::from_value::<PublicKey>(v)
+    }
+    .map_err(serde::de::Error::custom)
 }
 
 impl Protobuf<RawPublicKey> for PublicKey {}
@@ -326,7 +390,7 @@ impl Serialize for Algorithm {
 }
 
 impl<'de> Deserialize<'de> for Algorithm {
-    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
         let s = String::deserialize(deserializer)?;
         s.parse().map_err(D::Error::custom)
@@ -356,7 +420,7 @@ where
 
 fn deserialize_ed25519_base64<'de, D>(deserializer: D) -> Result<Ed25519, D::Error>
 where
-    D: de::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
     use de::Error;
     let encoded = String::deserialize(deserializer)?;
@@ -367,7 +431,7 @@ where
 #[cfg(feature = "secp256k1")]
 fn deserialize_secp256k1_base64<'de, D>(deserializer: D) -> Result<Secp256k1, D::Error>
 where
-    D: de::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
     use de::Error;
     let encoded = String::deserialize(deserializer)?;


### PR DESCRIPTION
Backports just the `block_results` RPC endpoint-related changes from #1061.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
