### PR TITLE
Add support for `tendermint::chain::Id` constants

### DIFF
--- a/.changelog/unreleased/features/1105-chain-id-constants.md
+++ b/.changelog/unreleased/features/1105-chain-id-constants.md
@@ -1,0 +1,2 @@
+- `[tendermint]` Add `tendermint::chain::Id::new` with support for chain ID constants
+  ([#1105](https://github.com/informalsystems/tendermint-rs/issues/1105)).


### PR DESCRIPTION
In PeggyJv/ocular#18 we are trying to create a registry of "well-known" chain IDs. I proposed using `tendermint::chain::Id` for this, but to do so we'd need to have a const initializer support.

This commit changes the internal representation of `chain::Id` to `Cow<'static, str>`. This permits a `const fn` initializer, but avoids adding a lifetime to `chain::Id` itself.

It also adds `chain::Id::new` which is defined as a `const fn`, which can be used to define chain ID constants.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
