### PR TITLE
Generic `AppState` for `genesis()`

### DIFF
--- a/.changelog/unreleased/improvements/1106-genesis-app-state.md
+++ b/.changelog/unreleased/improvements/1106-genesis-app-state.md
@@ -1,0 +1,2 @@
+- `[tendermint-rpc]` Allow users to specify the `AppState` type in the `Client::genesis()` function.
+  ([#1106](https://github.com/informalsystems/tendermint-rs/issues/1106))

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -21,7 +21,10 @@ use crate::prelude::*;
 use crate::query::Query;
 use crate::{Error, Order, SimpleRequest};
 use async_trait::async_trait;
+use core::fmt;
 use core::time::Duration;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tendermint::abci::{self, Transaction};
 use tendermint::block::Height;
 use tendermint::evidence::Evidence;
@@ -229,8 +232,11 @@ pub trait Client {
     }
 
     /// `/genesis`: get genesis file.
-    async fn genesis(&self) -> Result<Genesis, Error> {
-        Ok(self.perform(genesis::Request).await?.genesis)
+    async fn genesis<AppState>(&self) -> Result<Genesis<AppState>, Error>
+    where
+        AppState: fmt::Debug + Serialize + DeserializeOwned + Send,
+    {
+        Ok(self.perform(genesis::Request::default()).await?.genesis)
     }
 
     /// `/net_info`: obtain information about P2P and other network connections.

--- a/rpc/src/client/bin/main.rs
+++ b/rpc/src/client/bin/main.rs
@@ -377,7 +377,8 @@ where
             serde_json::to_string_pretty(&client.consensus_state().await?).map_err(Error::serde)?
         }
         ClientRequest::Genesis => {
-            serde_json::to_string_pretty(&client.genesis().await?).map_err(Error::serde)?
+            serde_json::to_string_pretty(&client.genesis::<serde_json::Value>().await?)
+                .map_err(Error::serde)?
         }
         ClientRequest::Health => {
             serde_json::to_string_pretty(&client.health().await?).map_err(Error::serde)?

--- a/rpc/src/endpoint/genesis.rs
+++ b/rpc/src/endpoint/genesis.rs
@@ -1,28 +1,45 @@
 //! `/genesis` endpoint JSON-RPC wrapper
 
-use serde::{Deserialize, Serialize};
+use core::{fmt, marker::PhantomData};
 
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tendermint::Genesis;
 
 /// Get the genesis state for the current chain
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Request;
+pub struct Request<AppState> {
+    marker: PhantomData<AppState>,
+}
 
-impl crate::Request for Request {
-    type Response = Response;
+impl<AppState> Default for Request<AppState> {
+    fn default() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<AppState> crate::Request for Request<AppState>
+where
+    AppState: fmt::Debug + Serialize + DeserializeOwned + Send,
+{
+    type Response = Response<AppState>;
 
     fn method(&self) -> crate::Method {
         crate::Method::Genesis
     }
 }
 
-impl crate::SimpleRequest for Request {}
+impl<AppState> crate::SimpleRequest for Request<AppState> where
+    AppState: fmt::Debug + Serialize + DeserializeOwned + Send
+{
+}
 
 /// Block responses
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Response {
+pub struct Response<AppState> {
     /// Genesis data
-    pub genesis: Genesis,
+    pub genesis: Genesis<AppState>,
 }
 
-impl crate::Response for Response {}
+impl<AppState> crate::Response for Response<AppState> where AppState: Serialize + DeserializeOwned {}

--- a/rpc/src/endpoint/genesis.rs
+++ b/rpc/src/endpoint/genesis.rs
@@ -7,15 +7,11 @@ use tendermint::Genesis;
 
 /// Get the genesis state for the current chain
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Request<AppState> {
-    marker: PhantomData<AppState>,
-}
+pub struct Request<AppState>(#[serde(skip)] PhantomData<AppState>);
 
 impl<AppState> Default for Request<AppState> {
     fn default() -> Self {
-        Self {
-            marker: PhantomData,
-        }
+        Self(PhantomData)
     }
 }
 

--- a/rpc/tests/gaia_fixtures.rs
+++ b/rpc/tests/gaia_fixtures.rs
@@ -72,7 +72,9 @@ fn incoming_fixtures() {
                 assert!(endpoint::consensus_state::Response::from_string(content).is_ok())
             }
             "genesis" => {
-                assert!(endpoint::genesis::Response::from_string(content).is_ok())
+                assert!(
+                    endpoint::genesis::Response::<serde_json::Value>::from_string(content).is_ok()
+                )
             }
             "net_info" => {
                 assert!(endpoint::net_info::Response::from_string(content).is_ok())
@@ -145,7 +147,9 @@ fn outgoing_fixtures() {
                 assert!(endpoint::consensus_state::Request::from_string(content).is_ok())
             }
             "genesis" => {
-                assert!(endpoint::genesis::Request::from_string(content).is_ok())
+                assert!(
+                    endpoint::genesis::Request::<serde_json::Value>::from_string(content).is_ok()
+                )
             }
             "net_info" => {
                 assert!(endpoint::net_info::Request::from_string(content).is_ok())

--- a/rpc/tests/gaia_fixtures.rs
+++ b/rpc/tests/gaia_fixtures.rs
@@ -148,7 +148,8 @@ fn outgoing_fixtures() {
             }
             "genesis" => {
                 assert!(
-                    endpoint::genesis::Request::<serde_json::Value>::from_string(content).is_ok()
+                    endpoint::genesis::Request::<Option<serde_json::Value>>::from_string(content)
+                        .is_ok()
                 )
             }
             "net_info" => {

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -163,10 +163,10 @@ fn outgoing_fixtures() {
                 RequestWrapper<endpoint::consensus_state::Request>,
             >(&content)
             .is_ok()),
-            "genesis" => assert!(
-                serde_json::from_str::<RequestWrapper<endpoint::genesis::Request>>(&content)
-                    .is_ok()
-            ),
+            "genesis" => assert!(serde_json::from_str::<
+                RequestWrapper<endpoint::genesis::Request::<serde_json::Value>>,
+            >(&content)
+            .is_ok()),
             "net_info" => assert!(serde_json::from_str::<
                 RequestWrapper<endpoint::net_info::Request>,
             >(&content)
@@ -727,7 +727,8 @@ fn incoming_fixtures() {
                 assert!(endpoint::consensus_state::Response::from_string(content).is_ok());
             }
             "genesis" => {
-                let result = endpoint::genesis::Response::from_string(content).unwrap();
+                let result =
+                    endpoint::genesis::Response::<serde_json::Value>::from_string(content).unwrap();
                 assert!(result.genesis.app_hash.is_empty());
                 assert_eq!(result.genesis.chain_id.as_str(), CHAIN_ID);
                 assert_eq!(result.genesis.consensus_params.block.max_bytes, 22020096);

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -728,7 +728,8 @@ fn incoming_fixtures() {
             }
             "genesis" => {
                 let result =
-                    endpoint::genesis::Response::<serde_json::Value>::from_string(content).unwrap();
+                    endpoint::genesis::Response::<Option<serde_json::Value>>::from_string(content)
+                        .unwrap();
                 assert!(result.genesis.app_hash.is_empty());
                 assert_eq!(result.genesis.chain_id.as_str(), CHAIN_ID);
                 assert_eq!(result.genesis.consensus_params.block.max_bytes, 22020096);

--- a/tendermint/src/genesis.rs
+++ b/tendermint/src/genesis.rs
@@ -30,6 +30,5 @@ pub struct Genesis<AppState = serde_json::Value> {
     pub app_hash: Vec<u8>,
 
     /// App state
-    #[serde(default)]
     pub app_state: AppState,
 }

--- a/tools/kvstore-test/Cargo.toml
+++ b/tools/kvstore-test/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1.0", features = [ "rt-multi-thread", "macros" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 contracts = "0.4.0"
+serde_json = "1"

--- a/tools/kvstore-test/tests/tendermint.rs
+++ b/tools/kvstore-test/tests/tendermint.rs
@@ -200,7 +200,7 @@ mod rpc {
     /// `/genesis` endpoint
     #[tokio::test]
     async fn genesis() {
-        let genesis = localhost_http_client().genesis().await.unwrap(); // https://github.com/tendermint/tendermint/issues/5549
+        let genesis = localhost_http_client().genesis::<Option<serde_json::Value>>().await.unwrap(); // https://github.com/tendermint/tendermint/issues/5549
 
         assert_eq!(
             genesis.consensus_params.validator.pub_key_types[0].to_string(),


### PR DESCRIPTION
Resolves: #1106 

This PR basically modifies the `genesis()` RPC function like so ->
```patch
-    async fn genesis(&self) -> Result<Genesis, Error> 
+    async fn genesis<AppState>(&self) -> Result<Genesis<AppState>, Error>
```
(Many thanks to @romac for writing the code 🙏)

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
