### PR TITLE
Updated spec url

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Crates are released on [crates.io](https://crates.io).
 
 ## Contributing
 
-The Tendermint protocols are specified in English in the [tendermint/spec
-repo](https://github.com/tendermint/spec).  Any protocol changes or
-clarifications should be contributed there.
+The Tendermint protocols are specified in English in the [tendermint/tendermint
+repo](https://github.com/tendermint/tendermint/tree/master/spec). Any protocol
+changes or clarifications should be contributed there.
 
 This repo contains the TLA+ specifications and Rust implementations for various
 components of Tendermint. See the [CONTRIBUTING.md][contributing] to start


### PR DESCRIPTION
The tendermint/spec repo is archived and directs people to the URL in this patch.
