### PR TITLE
ci: Update CI coverage check to use llvm-cov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,28 +144,20 @@ jobs:
         env:
           RUST_LOG: debug
 
-  nightly-coverage:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
-          toolchain: nightly-2022-01-11
-          override: true
-      - uses: actions-rs/cargo@v1
+          toolchain: stable
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
         with:
-          command: test-all-features
-        env:
-          RUSTFLAGS: '-Zinstrument-coverage'
-          LLVM_PROFILE_FILE: '%p-%m.profraw'
-      - name: Install grcov
-        run: |
-          rustup component add llvm-tools-preview
-          curl -L https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
-      - name: Run grcov
-        run: |
-          ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --branch --ignore-not-existing
-      - name: Upload to Codecov
-        run: |
-          bash <(curl -s https://codecov.io/bash) -f ./lcov.info
+          files: lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
Follows from https://github.com/informalsystems/tendermint-rs/pull/995#issuecomment-1094168166

This updates our coverage check in CI to use https://github.com/taiki-e/cargo-llvm-cov and Rust stable.