### PR TITLE
chore: Bump protos to those provided by Tendermint v0.35.4

### DIFF
--- a/proto/src/prost/tendermint.crypto.rs
+++ b/proto/src/prost/tendermint.crypto.rs
@@ -1,3 +1,27 @@
+/// PublicKey defines the keys available for use with Tendermint Validators
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublicKey {
+    #[prost(oneof="public_key::Sum", tags="1, 2, 3")]
+    pub sum: ::core::option::Option<public_key::Sum>,
+}
+/// Nested message and enum types in `PublicKey`.
+pub mod public_key {
+    #[derive(::serde::Deserialize, ::serde::Serialize)]
+    #[serde(tag = "type", content = "value")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(bytes, tag="1")]
+        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
+        Ed25519(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag="2")]
+        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
+        Secp256k1(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag="3")]
+        #[serde(rename = "tendermint/PubKeySr25519", with = "crate::serializers::bytes::base64string")]
+        Sr25519(::prost::alloc::vec::Vec<u8>),
+    }
+}
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
@@ -49,28 +73,4 @@ pub struct ProofOp {
 pub struct ProofOps {
     #[prost(message, repeated, tag="1")]
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
-}
-/// PublicKey defines the keys available for use with Tendermint Validators
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PublicKey {
-    #[prost(oneof="public_key::Sum", tags="1, 2, 3")]
-    pub sum: ::core::option::Option<public_key::Sum>,
-}
-/// Nested message and enum types in `PublicKey`.
-pub mod public_key {
-    #[derive(::serde::Deserialize, ::serde::Serialize)]
-    #[serde(tag = "type", content = "value")]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(bytes, tag="1")]
-        #[serde(rename = "tendermint/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]
-        Ed25519(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag="2")]
-        #[serde(rename = "tendermint/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]
-        Secp256k1(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag="3")]
-        #[serde(rename = "tendermint/PubKeySr25519", with = "crate::serializers::bytes::base64string")]
-        Sr25519(::prost::alloc::vec::Vec<u8>),
-    }
 }

--- a/proto/src/prost/tendermint.p2p.rs
+++ b/proto/src/prost/tendermint.p2p.rs
@@ -1,4 +1,53 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexAddress {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub ip: ::prost::alloc::string::String,
+    #[prost(uint32, tag="3")]
+    pub port: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexRequest {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexResponse {
+    #[prost(message, repeated, tag="1")]
+    pub addresses: ::prost::alloc::vec::Vec<PexAddress>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexAddressV2 {
+    #[prost(string, tag="1")]
+    pub url: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexRequestV2 {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexResponseV2 {
+    #[prost(message, repeated, tag="1")]
+    pub addresses: ::prost::alloc::vec::Vec<PexAddressV2>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PexMessage {
+    #[prost(oneof="pex_message::Sum", tags="1, 2, 3, 4")]
+    pub sum: ::core::option::Option<pex_message::Sum>,
+}
+/// Nested message and enum types in `PexMessage`.
+pub mod pex_message {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(message, tag="1")]
+        PexRequest(super::PexRequest),
+        #[prost(message, tag="2")]
+        PexResponse(super::PexResponse),
+        #[prost(message, tag="3")]
+        PexRequestV2(super::PexRequestV2),
+        #[prost(message, tag="4")]
+        PexResponseV2(super::PexResponseV2),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProtocolVersion {
     #[prost(uint64, tag="1")]
     pub p2p: u64,
@@ -91,53 +140,4 @@ pub struct AuthSigMessage {
     pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
     #[prost(bytes="vec", tag="2")]
     pub sig: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexAddress {
-    #[prost(string, tag="1")]
-    pub id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub ip: ::prost::alloc::string::String,
-    #[prost(uint32, tag="3")]
-    pub port: u32,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexRequest {
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexResponse {
-    #[prost(message, repeated, tag="1")]
-    pub addresses: ::prost::alloc::vec::Vec<PexAddress>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexAddressV2 {
-    #[prost(string, tag="1")]
-    pub url: ::prost::alloc::string::String,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexRequestV2 {
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexResponseV2 {
-    #[prost(message, repeated, tag="1")]
-    pub addresses: ::prost::alloc::vec::Vec<PexAddressV2>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PexMessage {
-    #[prost(oneof="pex_message::Sum", tags="1, 2, 3, 4")]
-    pub sum: ::core::option::Option<pex_message::Sum>,
-}
-/// Nested message and enum types in `PexMessage`.
-pub mod pex_message {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(message, tag="1")]
-        PexRequest(super::PexRequest),
-        #[prost(message, tag="2")]
-        PexResponse(super::PexResponse),
-        #[prost(message, tag="3")]
-        PexRequestV2(super::PexRequestV2),
-        #[prost(message, tag="4")]
-        PexResponseV2(super::PexResponseV2),
-    }
 }

--- a/proto/src/prost/tendermint.types.rs
+++ b/proto/src/prost/tendermint.types.rs
@@ -276,77 +276,6 @@ pub enum SignedMsgType {
     /// Proposals
     Proposal = 32,
 }
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Evidence {
-    #[prost(oneof="evidence::Sum", tags="1, 2")]
-    pub sum: ::core::option::Option<evidence::Sum>,
-}
-/// Nested message and enum types in `Evidence`.
-pub mod evidence {
-    #[derive(::serde::Deserialize, ::serde::Serialize)]
-    #[serde(tag = "type", content = "value")]
-    #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(message, tag="1")]
-        #[serde(rename = "tendermint/DuplicateVoteEvidence")]
-        DuplicateVoteEvidence(super::DuplicateVoteEvidence),
-        #[prost(message, tag="2")]
-        #[serde(rename = "tendermint/LightClientAttackEvidence")]
-        LightClientAttackEvidence(super::LightClientAttackEvidence),
-    }
-}
-/// DuplicateVoteEvidence contains evidence of a validator signed two conflicting votes.
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DuplicateVoteEvidence {
-    #[prost(message, optional, tag="1")]
-    pub vote_a: ::core::option::Option<Vote>,
-    #[prost(message, optional, tag="2")]
-    pub vote_b: ::core::option::Option<Vote>,
-    #[prost(int64, tag="3")]
-    pub total_voting_power: i64,
-    #[prost(int64, tag="4")]
-    pub validator_power: i64,
-    #[prost(message, optional, tag="5")]
-    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
-}
-/// LightClientAttackEvidence contains evidence of a set of validators attempting to mislead a light client.
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LightClientAttackEvidence {
-    #[prost(message, optional, tag="1")]
-    pub conflicting_block: ::core::option::Option<LightBlock>,
-    #[prost(int64, tag="2")]
-    pub common_height: i64,
-    #[prost(message, repeated, tag="3")]
-    pub byzantine_validators: ::prost::alloc::vec::Vec<Validator>,
-    #[prost(int64, tag="4")]
-    pub total_voting_power: i64,
-    #[prost(message, optional, tag="5")]
-    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EvidenceList {
-    #[prost(message, repeated, tag="1")]
-    #[serde(with = "crate::serializers::nullable")]
-    pub evidence: ::prost::alloc::vec::Vec<Evidence>,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Block {
-    #[prost(message, optional, tag="1")]
-    pub header: ::core::option::Option<Header>,
-    #[prost(message, optional, tag="2")]
-    pub data: ::core::option::Option<Data>,
-    #[prost(message, optional, tag="3")]
-    pub evidence: ::core::option::Option<EvidenceList>,
-    #[prost(message, optional, tag="4")]
-    pub last_commit: ::core::option::Option<Commit>,
-}
 /// ConsensusParams contains consensus critical parameters that determine the
 /// validity of blocks.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -419,15 +348,6 @@ pub struct HashedParams {
     #[prost(int64, tag="2")]
     pub block_max_gas: i64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EventDataRoundState {
-    #[prost(int64, tag="1")]
-    pub height: i64,
-    #[prost(int32, tag="2")]
-    pub round: i32,
-    #[prost(string, tag="3")]
-    pub step: ::prost::alloc::string::String,
-}
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanonicalBlockId {
@@ -483,4 +403,84 @@ pub struct CanonicalVote {
     pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="6")]
     pub chain_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EventDataRoundState {
+    #[prost(int64, tag="1")]
+    pub height: i64,
+    #[prost(int32, tag="2")]
+    pub round: i32,
+    #[prost(string, tag="3")]
+    pub step: ::prost::alloc::string::String,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Evidence {
+    #[prost(oneof="evidence::Sum", tags="1, 2")]
+    pub sum: ::core::option::Option<evidence::Sum>,
+}
+/// Nested message and enum types in `Evidence`.
+pub mod evidence {
+    #[derive(::serde::Deserialize, ::serde::Serialize)]
+    #[serde(tag = "type", content = "value")]
+    #[serde(from = "crate::serializers::evidence::EvidenceVariant", into = "crate::serializers::evidence::EvidenceVariant")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(message, tag="1")]
+        #[serde(rename = "tendermint/DuplicateVoteEvidence")]
+        DuplicateVoteEvidence(super::DuplicateVoteEvidence),
+        #[prost(message, tag="2")]
+        #[serde(rename = "tendermint/LightClientAttackEvidence")]
+        LightClientAttackEvidence(super::LightClientAttackEvidence),
+    }
+}
+/// DuplicateVoteEvidence contains evidence of a validator signed two conflicting votes.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DuplicateVoteEvidence {
+    #[prost(message, optional, tag="1")]
+    pub vote_a: ::core::option::Option<Vote>,
+    #[prost(message, optional, tag="2")]
+    pub vote_b: ::core::option::Option<Vote>,
+    #[prost(int64, tag="3")]
+    pub total_voting_power: i64,
+    #[prost(int64, tag="4")]
+    pub validator_power: i64,
+    #[prost(message, optional, tag="5")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+}
+/// LightClientAttackEvidence contains evidence of a set of validators attempting to mislead a light client.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LightClientAttackEvidence {
+    #[prost(message, optional, tag="1")]
+    pub conflicting_block: ::core::option::Option<LightBlock>,
+    #[prost(int64, tag="2")]
+    pub common_height: i64,
+    #[prost(message, repeated, tag="3")]
+    pub byzantine_validators: ::prost::alloc::vec::Vec<Validator>,
+    #[prost(int64, tag="4")]
+    pub total_voting_power: i64,
+    #[prost(message, optional, tag="5")]
+    pub timestamp: ::core::option::Option<super::super::google::protobuf::Timestamp>,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EvidenceList {
+    #[prost(message, repeated, tag="1")]
+    #[serde(with = "crate::serializers::nullable")]
+    pub evidence: ::prost::alloc::vec::Vec<Evidence>,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Block {
+    #[prost(message, optional, tag="1")]
+    pub header: ::core::option::Option<Header>,
+    #[prost(message, optional, tag="2")]
+    pub data: ::core::option::Option<Data>,
+    #[prost(message, optional, tag="3")]
+    pub evidence: ::core::option::Option<EvidenceList>,
+    #[prost(message, optional, tag="4")]
+    pub last_commit: ::core::option::Option<Commit>,
 }

--- a/proto/src/tendermint.rs
+++ b/proto/src/tendermint.rs
@@ -1,53 +1,15 @@
 //! Tendermint-proto auto-generated sub-modules for Tendermint
 
-pub mod statesync {
-    include!("prost/tendermint.statesync.rs");
-}
-
-pub mod abci {
-    include!("prost/tendermint.abci.rs");
-}
-
-pub mod version {
-    include!("prost/tendermint.version.rs");
+pub mod consensus {
+    include!("prost/tendermint.consensus.rs");
 }
 
 pub mod types {
     include!("prost/tendermint.types.rs");
 }
 
-pub mod consensus {
-    include!("prost/tendermint.consensus.rs");
-}
-
-pub mod p2p {
-    include!("prost/tendermint.p2p.rs");
-}
-
-pub mod privval {
-    include!("prost/tendermint.privval.rs");
-}
-
-pub mod crypto {
-    include!("prost/tendermint.crypto.rs");
-}
-
 pub mod mempool {
     include!("prost/tendermint.mempool.rs");
-}
-
-pub mod blocksync {
-    include!("prost/tendermint.blocksync.rs");
-}
-
-pub mod state {
-    include!("prost/tendermint.state.rs");
-}
-
-pub mod libs {
-    pub mod bits {
-        include!("prost/tendermint.libs.bits.rs");
-    }
 }
 
 pub mod rpc {
@@ -56,7 +18,45 @@ pub mod rpc {
     }
 }
 
+pub mod libs {
+    pub mod bits {
+        include!("prost/tendermint.libs.bits.rs");
+    }
+}
+
+pub mod state {
+    include!("prost/tendermint.state.rs");
+}
+
+pub mod version {
+    include!("prost/tendermint.version.rs");
+}
+
+pub mod blocksync {
+    include!("prost/tendermint.blocksync.rs");
+}
+
+pub mod privval {
+    include!("prost/tendermint.privval.rs");
+}
+
+pub mod statesync {
+    include!("prost/tendermint.statesync.rs");
+}
+
+pub mod p2p {
+    include!("prost/tendermint.p2p.rs");
+}
+
+pub mod abci {
+    include!("prost/tendermint.abci.rs");
+}
+
+pub mod crypto {
+    include!("prost/tendermint.crypto.rs");
+}
+
 pub mod meta {
     pub const REPOSITORY: &str = "https://github.com/tendermint/tendermint";
-    pub const COMMITISH: &str = "v0.35.0";
+    pub const COMMITISH: &str = "v0.35.4";
 }

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -6,7 +6,7 @@ pub const TENDERMINT_REPO: &str = "https://github.com/tendermint/tendermint";
 // Tag: v0.34.0-rc4
 // Branch: master
 // Commit ID (full length): d7d0ffea13c60c98b812d243ba5a2c375f341c15
-pub const TENDERMINT_COMMITISH: &str = "v0.35.0";
+pub const TENDERMINT_COMMITISH: &str = "v0.35.4";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;


### PR DESCRIPTION
Doesn't seem like anything substantial changed - prost's code generation is just nondeterministic unfortunately.