### PR TITLE
Bump `sha2` to v0.10; replace `ripemd160` with `ripemd` v0.1

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 signature = { version = "1.2", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
@@ -52,13 +52,13 @@ time = { version = "0.3.5", default-features = false, features = ["macros", "par
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.10", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
-ripemd160 = { version = "0.9", default-features = false, optional = true }
+ripemd = { version = "0.1", default-features = false, optional = true }
 
 [features]
 default = ["std"]
 std = ["flex-error/std", "flex-error/eyre_tracer", "clock"]
 clock = ["time/std"]
-secp256k1 = ["k256", "ripemd160"]
+secp256k1 = ["k256", "ripemd"]
 
 [dev-dependencies]
 pretty_assertions = { version = "0.7.2", default-features = false }

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(feature = "secp256k1")]
-use ripemd160::Ripemd160;
+use ripemd::Ripemd160;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use subtle::{self, ConstantTimeEq};


### PR DESCRIPTION
These crates are both based on `digest` v0.10, which is also the same version used by `k256` v0.11 (#1129).

Note that the `ripemd160` crate is now deprecated:

https://docs.rs/ripemd160/latest/ripemd160/

The `ripemd` crate is the replacement. It has the same maintainers (@RustCrypto), but now combines the former `ripemd160` and `ripemd320` crates into a single crate.