### PR TITLE
Fix JSON deserialization of abci::ResponseInfo

### DIFF
--- a/.changelog/unreleased/bug-fixes/1132-allow-omitted-fields-in-abci_info.md
+++ b/.changelog/unreleased/bug-fixes/1132-allow-omitted-fields-in-abci_info.md
@@ -1,0 +1,4 @@
+- `[tools/proto-compiler]` Annotate serde to fall back to `Default` for the
+  omitted fields when deserializing `tendermint_proto::abci::ResponseInfo` struct,
+  also providing deserialization for the response at the `/abci_info` RPC endpoint.
+  ([#1132](https://github.com/informalsystems/tendermint-rs/issues/1132))

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -216,15 +216,17 @@ pub struct ResponseFlush {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseInfo {
     #[prost(string, tag="1")]
+    #[serde(default)]
     pub data: ::prost::alloc::string::String,
     /// this is the software version of the application. TODO: remove?
     #[prost(string, tag="2")]
+    #[serde(default)]
     pub version: ::prost::alloc::string::String,
     #[prost(uint64, tag="3")]
-    #[serde(with = "crate::serializers::from_str")]
+    #[serde(with = "crate::serializers::from_str", default)]
     pub app_version: u64,
     #[prost(int64, tag="4")]
-    #[serde(with = "crate::serializers::from_str")]
+    #[serde(with = "crate::serializers::from_str", default)]
     pub last_block_height: i64,
     #[prost(bytes="bytes", tag="5")]
     #[serde(skip_serializing_if = "bytes::Bytes::is_empty")]

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -229,6 +229,7 @@ pub struct ResponseInfo {
     #[serde(with = "crate::serializers::from_str", default)]
     pub last_block_height: i64,
     #[prost(bytes="bytes", tag="5")]
+    #[serde(default)]
     #[serde(skip_serializing_if = "bytes::Bytes::is_empty")]
     pub last_block_app_hash: ::prost::bytes::Bytes,
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -67,7 +67,7 @@ peg = { version = "0.7.0", default-features = false }
 pin-project = { version = "1.0.1", default-features = false }
 serde = { version = "1", default-features = false, features = [ "derive" ] }
 serde_bytes = { version = "0.11", default-features = false }
-serde_json = { version = "1", default-features = false, features = ["std"] }
+serde_json = { version = "1", default-features = false }
 tendermint-config = { version = "0.24.0-pre.2", path = "../config", default-features = false }
 tendermint = { version = "0.24.0-pre.2", default-features = false, path = "../tendermint" }
 tendermint-proto = { version = "0.24.0-pre.2", default-features = false, path = "../proto" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -67,7 +67,7 @@ peg = { version = "0.7.0", default-features = false }
 pin-project = { version = "1.0.1", default-features = false }
 serde = { version = "1", default-features = false, features = [ "derive" ] }
 serde_bytes = { version = "0.11", default-features = false }
-serde_json = { version = "1", default-features = false }
+serde_json = { version = "1", default-features = false, features = ["std"] }
 tendermint-config = { version = "0.24.0-pre.2", path = "../config", default-features = false }
 tendermint = { version = "0.24.0-pre.2", default-features = false, path = "../tendermint" }
 tendermint-proto = { version = "0.24.0-pre.2", default-features = false, path = "../proto" }

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -98,6 +98,7 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         ".tendermint.abci.ResponseInfo.last_block_height",
         QUOTED_WITH_DEFAULT,
     ),
+    (".tendermint.abci.ResponseInfo.last_block_app_hash", DEFAULT),
     (
         ".tendermint.abci.ResponseInfo.last_block_app_hash",
         BYTES_SKIP_IF_EMPTY,

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -14,6 +14,7 @@ const SERIALIZED: &str = r#"#[derive(::serde::Deserialize, ::serde::Serialize)]"
 const TYPE_TAG: &str = r#"#[serde(tag = "type", content = "value")]"#;
 
 /// Predefined custom attributes for field annotations
+const DEFAULT: &str = r#"#[serde(default)]"#;
 const QUOTED: &str = r#"#[serde(with = "crate::serializers::from_str")]"#;
 const QUOTED_WITH_DEFAULT: &str = r#"#[serde(with = "crate::serializers::from_str", default)]"#;
 const HEXSTRING: &str = r#"#[serde(with = "crate::serializers::bytes::hexstring")]"#;
@@ -85,14 +86,22 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         ".tendermint.types.EvidenceParams.max_bytes",
         QUOTED_WITH_DEFAULT,
     ),
-    (".tendermint.abci.ResponseInfo.last_block_height", QUOTED),
     (".tendermint.version.Consensus.block", QUOTED),
     (".tendermint.version.Consensus.app", QUOTED_WITH_DEFAULT),
+    (".tendermint.abci.ResponseInfo.data", DEFAULT),
+    (".tendermint.abci.ResponseInfo.version", DEFAULT),
+    (
+        ".tendermint.abci.ResponseInfo.app_version",
+        QUOTED_WITH_DEFAULT,
+    ),
+    (
+        ".tendermint.abci.ResponseInfo.last_block_height",
+        QUOTED_WITH_DEFAULT,
+    ),
     (
         ".tendermint.abci.ResponseInfo.last_block_app_hash",
         BYTES_SKIP_IF_EMPTY,
     ),
-    (".tendermint.abci.ResponseInfo.app_version", QUOTED),
     (".tendermint.types.BlockID.hash", HEXSTRING),
     (".tendermint.types.BlockID.part_set_header", ALIAS_PARTS),
     (


### PR DESCRIPTION
Fixes: #1132

The fields of the tendermint-go struct equivalent to `abci::ResponseInfo` are annotated with `json:"omitempty"`, so give them default values for `Deserialize`. The `/abci_info` endpoint is known to omit the `app_version` field in some recent revisions of Gaia.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
