### PR TITLE
rpc: Sanitize slice data accessors for ABCI types

### DIFF
--- a/.changelog/unreleased/breaking-changes/1140-sanitize-abci-slice-accessors.md
+++ b/.changelog/unreleased/breaking-changes/1140-sanitize-abci-slice-accessors.md
@@ -1,0 +1,4 @@
+- `[rpc]` Change data accessor methods `abci::Data::value` and
+  `abci::Log::value` to `Data::as_bytes` and `Log::as_str`,
+  returning a byte array slice and a string slice respectively.
+  ([#1140](https://github.com/informalsystems/tendermint-rs/pull/1140))

--- a/rpc/src/abci/data.rs
+++ b/rpc/src/abci/data.rs
@@ -23,8 +23,8 @@ impl From<Data> for Vec<u8> {
 }
 
 impl Data {
-    /// Get value
-    pub fn value(&self) -> &Vec<u8> {
+    /// Get the data as a byte array
+    pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 }

--- a/rpc/src/abci/log.rs
+++ b/rpc/src/abci/log.rs
@@ -10,8 +10,8 @@ use crate::prelude::*;
 pub struct Log(String);
 
 impl Log {
-    /// Convenience function: get value
-    pub fn value(&self) -> &String {
+    /// Access to the log message as a string.
+    pub fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -352,7 +352,7 @@ fn incoming_fixtures() {
                 assert_eq!(result.response.index, 0);
                 assert!(result.response.info.is_empty());
                 assert_eq!(result.response.key, base64::decode("dHgw").unwrap());
-                assert_eq!(result.response.log.value(), "exists");
+                assert_eq!(result.response.log.as_str(), "exists");
                 assert!(result.response.proof.is_none());
                 assert_eq!(result.response.value, base64::decode("dmFsdWU=").unwrap());
             },
@@ -366,7 +366,7 @@ fn incoming_fixtures() {
                     result.response.key,
                     base64::decode("bm9uX2V4aXN0ZW50X2tleQ==").unwrap()
                 );
-                assert_eq!(result.response.log.value(), "does not exist");
+                assert_eq!(result.response.log.as_str(), "does not exist");
                 assert!(result.response.proof.is_none());
                 assert!(result.response.value.is_empty());
             },
@@ -547,12 +547,12 @@ fn incoming_fixtures() {
             "broadcast_tx_async" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "broadcast_tx_commit" => {
                 let result =
@@ -568,7 +568,7 @@ fn incoming_fixtures() {
                 // Todo: https://github.com/informalsystems/tendermint-rs/issues/761
                 // assert_eq!(result.check_tx.gas_wanted.value(), 1);
                 assert!(result.check_tx.info.to_string().is_empty());
-                assert!(result.check_tx.log.value().is_empty());
+                assert!(result.check_tx.log.as_str().is_empty());
                 assert_eq!(result.deliver_tx.code, tendermint_rpc::abci::Code::Ok);
                 assert_eq!(
                     result.deliver_tx.codespace,
@@ -637,7 +637,7 @@ fn incoming_fixtures() {
                 assert_eq!(result.deliver_tx.gas_used.value(), 0);
                 assert_eq!(result.deliver_tx.gas_wanted.value(), 0);
                 assert!(result.deliver_tx.info.to_string().is_empty());
-                assert!(result.deliver_tx.log.value().is_empty());
+                assert!(result.deliver_tx.log.as_str().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
@@ -646,12 +646,12 @@ fn incoming_fixtures() {
             "broadcast_tx_sync" => {
                 let result = endpoint::broadcast::tx_sync::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "commit_at_height_10" => {
                 let result = endpoint::commit::Response::from_string(content).unwrap();
@@ -1294,62 +1294,62 @@ fn incoming_fixtures() {
             "subscribe_txs_broadcast_tx_0" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "subscribe_txs_broadcast_tx_1" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "subscribe_txs_broadcast_tx_2" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "subscribe_txs_broadcast_tx_3" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "subscribe_txs_broadcast_tx_4" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "subscribe_txs_broadcast_tx_5" => {
                 let result = endpoint::broadcast::tx_async::Response::from_string(content).unwrap();
                 assert_eq!(result.code, tendermint_rpc::abci::Code::Ok);
-                assert!(result.data.value().is_empty());
+                assert!(result.data.as_bytes().is_empty());
                 assert_ne!(
                     result.hash,
                     tendermint_rpc::abci::transaction::Hash::new([0; 32])
                 );
-                assert!(result.log.value().is_empty());
+                assert!(result.log.as_str().is_empty());
             },
             "tx_prove" => {
                 let result = endpoint::tx::Response::from_string(content).unwrap();
@@ -1396,7 +1396,7 @@ fn incoming_fixtures() {
                     assert_eq!(tx.tx_result.gas_used.value(), 0);
                     assert_eq!(tx.tx_result.gas_wanted.value(), 0);
                     assert!(tx.tx_result.info.to_string().is_empty());
-                    assert!(tx.tx_result.log.value().is_empty());
+                    assert!(tx.tx_result.log.as_str().is_empty());
                     assert!(tx.proof.is_none());
                 }
             },
@@ -1412,7 +1412,7 @@ fn incoming_fixtures() {
                     assert_eq!(tx.tx_result.gas_used.value(), 0);
                     assert_eq!(tx.tx_result.gas_wanted.value(), 0);
                     assert!(tx.tx_result.info.to_string().is_empty());
-                    assert!(tx.tx_result.log.value().is_empty());
+                    assert!(tx.tx_result.log.as_str().is_empty());
                     let proof = tx.proof.unwrap();
                     assert_eq!(proof.data, tx.tx.as_bytes());
                     assert!(proof.proof.is_some());


### PR DESCRIPTION
It does not make sense to access wrapped data as references to container types `&Vec<u8>` and `&String`. Expose the data as slice references instead.

* [ ] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
