### PR TITLE
Update cargo audit config file format to v0.17.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -19,9 +19,6 @@ show_tree = true
 arch = "x86_64"
 os = "linux"
 
-[packages]
-source = "all"
-
 [yanked]
 enabled = true
 update_index = true


### PR DESCRIPTION
Running `cargo audit` locally fails due to a breaking change in the configuration file format.