### PR TITLE
Remove direct ed25519 crate dependency

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -32,7 +32,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
 bytes = { version = "1.0", default-features = false, features = ["serde"] }
-ed25519 = { version = "1.3", default-features = false }
 ed25519-consensus = { version = "1.2", default-features = false }
 futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }


### PR DESCRIPTION
Mild dependency cleanup that I noticed in a crate that imported tendermintrs

The ed25519 crate dependency is unused as far as I can tell, and this is just used within ed25519_consensus. The point is a bit moot, since ed25519_consensus imports ed25519 as well, but one less version bump that needs to be maintained later.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
