### PR TITLE
Fix clippy lints in v0.23.x

### DIFF
--- a/tools/proto-compiler/src/functions.rs
+++ b/tools/proto-compiler/src/functions.rs
@@ -2,7 +2,7 @@ use git2::build::{CheckoutBuilder, RepoBuilder};
 use git2::{AutotagOption, Commit, FetchOptions, Oid, Reference, Repository};
 use std::fs::{copy, create_dir_all, remove_dir_all, File};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use subtle_encoding::hex;
 use walkdir::WalkDir;
 
@@ -17,7 +17,7 @@ pub fn get_commitish(dir: &PathBuf, url: &str, commitish: &str) {
     checkout_commitish(&repo, commitish)
 }
 
-fn clone_new(dir: &PathBuf, url: &str) -> Repository {
+fn clone_new(dir: &Path, url: &str) -> Repository {
     println!(
         "  [info] => Cloning {} into {} folder",
         url,
@@ -115,7 +115,7 @@ fn find_reference_or_commit<'a>(
 ) -> (Option<Reference<'a>>, Commit<'a>) {
     let mut tried_origin = false; // we tried adding 'origin/' to the commitish
 
-    let mut try_reference = repo.resolve_reference_from_short_name(&commitish);
+    let mut try_reference = repo.resolve_reference_from_short_name(commitish);
     if try_reference.is_err() {
         // Local branch might be missing, try the remote branch
         try_reference = repo.resolve_reference_from_short_name(&format!("origin/{}", commitish));
@@ -238,7 +238,7 @@ pub fn generate_tendermint_lib(prost_dir: &PathBuf, tendermint_lib_target: &Path
         );
 
         for part in parts {
-            tab_count = tab_count - 1;
+            tab_count -= 1;
             let tabs = tab.repeat(tab_count);
             //{tabs} pub mod {part} {
             //{inner_content}

--- a/tools/rpc-probe/src/client.rs
+++ b/tools/rpc-probe/src/client.rs
@@ -39,9 +39,10 @@ impl Client {
             response_tx,
         })
         .await?;
-        response_rx.recv().await.ok_or_else(|| {
-            Error::InternalError("internal channel communication problem".to_string())
-        })?
+        response_rx
+            .recv()
+            .await
+            .ok_or_else(|| Error::Internal("internal channel communication problem".to_string()))?
     }
 
     pub async fn subscribe(
@@ -59,7 +60,7 @@ impl Client {
         })
         .await?;
         let response = response_rx.recv().await.ok_or_else(|| {
-            Error::InternalError("internal channel communication problem".to_string())
+            Error::Internal("internal channel communication problem".to_string())
         })??;
         Ok((subscription_rx, response))
     }
@@ -94,7 +95,7 @@ impl Client {
                 return Ok(());
             }
         }
-        Err(Error::InternalError(format!(
+        Err(Error::Internal(format!(
             "subscription terminated before we could reach target height of {}",
             h
         )))
@@ -106,9 +107,9 @@ impl Client {
 
     async fn send_cmd(&mut self, cmd: DriverCommand) -> Result<()> {
         self.cmd_tx.send(cmd).map_err(|e| {
-            Error::InternalError(format!(
+            Error::Internal(format!(
                 "WebSocket driver channel receiving end closed unexpectedly: {}",
-                e.to_string()
+                e,
             ))
         })
     }
@@ -156,7 +157,7 @@ impl ClientDriver {
                 Some(res) = self.stream.next() => match res {
                     Ok(msg) => self.handle_incoming_msg(msg).await?,
                     Err(e) => return Err(
-                        Error::WebSocketError(
+                        Error::WebSocket(
                             format!("failed to read from WebSocket connection: {}", e),
                         ),
                     ),
@@ -180,7 +181,7 @@ impl ClientDriver {
 
     async fn send_msg(&mut self, msg: Message) -> Result<()> {
         self.stream.send(msg).await.map_err(|e| {
-            Error::WebSocketError(format!("failed to write to WebSocket connection: {}", e))
+            Error::WebSocket(format!("failed to write to WebSocket connection: {}", e))
         })
     }
 

--- a/tools/rpc-probe/src/error.rs
+++ b/tools/rpc-probe/src/error.rs
@@ -7,10 +7,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Clone, Error)]
 pub enum Error {
     #[error("an internal error occurred: {0}")]
-    InternalError(String),
+    Internal(String),
 
     #[error("WebSocket connection error: {0}")]
-    WebSocketError(String),
+    WebSocket(String),
 
     #[error("timed out: {0}")]
     Timeout(String),
@@ -36,7 +36,7 @@ pub enum Error {
 
 impl From<async_tungstenite::tungstenite::Error> for Error {
     fn from(e: async_tungstenite::tungstenite::Error) -> Self {
-        Self::WebSocketError(e.to_string())
+        Self::WebSocket(e.to_string())
     }
 }
 
@@ -54,13 +54,13 @@ impl From<serde_json::Error> for Error {
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
     fn from(e: tokio::sync::mpsc::error::SendError<T>) -> Self {
-        Self::InternalError(format!("failed to send to channel: {}", e))
+        Self::Internal(format!("failed to send to channel: {}", e))
     }
 }
 
 impl From<tokio::task::JoinError> for Error {
     fn from(e: tokio::task::JoinError) -> Self {
-        Self::InternalError(format!(
+        Self::Internal(format!(
             "failed while waiting for async task to join: {}",
             e
         ))


### PR DESCRIPTION
Just some minor lints picked up by Rust 1.61 in the `tools` directory.
