### PR TITLE
Update `k256` to v0.11 (fixes #1153) on v0.23.x

### DIFF
--- a/.changelog/unreleased/dependencies/1153-k256-0.11.md
+++ b/.changelog/unreleased/dependencies/1153-k256-0.11.md
@@ -1,0 +1,2 @@
+- Update `k256` to v0.11 ([#1153](https://github.com/informalsystems/tendermint-
+  rs/issues/1153))

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2", default-features = false }
 x25519-dalek = { version = "1.1", default-features = false }
 zeroize = { version = "1", default-features = false }
-signature = { version = "1.3.0", default-features = false }
+signature = { version = "1", default-features = false }
 aead = { version = "0.4.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -44,14 +44,14 @@ serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
 sha2 = { version = "0.9", default-features = false }
-signature = { version = "1.2", default-features = false }
+signature = { version = "1", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.23.8-pre.1", default-features = false, path = "../proto" }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
-k256 = { version = "0.10", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
+k256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
 ripemd160 = { version = "0.9", default-features = false, optional = true }
 
 [features]


### PR DESCRIPTION
and relaxed the crate version bounds

* [x] Referenced an issue explaining the need for the change
* [N/A] Updated all relevant documentation in docs
* [N/A] Updated all code comments where relevant
* [N/A] Wrote tests
* [x] Added entry in `.changelog/`
