### PR TITLE
Fix JSON deserialization of abci::ResponseInfo (backport to v0.23.x)

### DIFF
--- a/.changelog/unreleased/bug-fixes/1132-allow-omitted-fields-in-abci_info.md
+++ b/.changelog/unreleased/bug-fixes/1132-allow-omitted-fields-in-abci_info.md
@@ -1,0 +1,4 @@
+- `[tools/proto-compiler]` Annotate serde to fall back to `Default` for the
+  omitted fields when deserializing `tendermint_proto::abci::ResponseInfo` struct,
+  also providing deserialization for the response at the `/abci_info` RPC endpoint.
+  ([#1132](https://github.com/informalsystems/tendermint-rs/issues/1132))

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -226,6 +226,7 @@ pub struct ResponseFlush {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseInfo {
     #[prost(string, tag="1")]
+    #[serde(default)]
     pub data: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     #[serde(default)]
@@ -234,9 +235,10 @@ pub struct ResponseInfo {
     #[serde(with = "crate::serializers::from_str", default)]
     pub app_version: u64,
     #[prost(int64, tag="4")]
-    #[serde(with = "crate::serializers::from_str")]
+    #[serde(with = "crate::serializers::from_str", default)]
     pub last_block_height: i64,
     #[prost(bytes="vec", tag="5")]
+    #[serde(default)]
     #[serde(skip_serializing_if = "::prost::alloc::vec::Vec::is_empty", with = "serde_bytes")]
     pub last_block_app_hash: ::prost::alloc::vec::Vec<u8>,
 }

--- a/testgen/src/apalache.rs
+++ b/testgen/src/apalache.rs
@@ -1,7 +1,7 @@
 use crate::{command::*, tester::TestEnv};
 use serde::{Deserialize, Serialize};
-use std::io;
 use std::fmt::Write;
+use std::io;
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct ApalacheTestBatch {

--- a/testgen/src/apalache.rs
+++ b/testgen/src/apalache.rs
@@ -1,6 +1,7 @@
 use crate::{command::*, tester::TestEnv};
 use serde::{Deserialize, Serialize};
 use std::io;
+use std::fmt::Write;
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct ApalacheTestBatch {
@@ -67,7 +68,7 @@ pub fn run_apalache_test(dir: &str, test: ApalacheTestCase) -> io::Result<Apalac
             break;
         }
         if line.starts_with("======") {
-            new_model += &format!("{} == ~{}\n", inv, test.test);
+            let _ = write!(&mut new_model, "{} == ~{}\n", inv, test.test);
         }
         new_model += line;
         new_model += "\n";

--- a/testgen/src/apalache.rs
+++ b/testgen/src/apalache.rs
@@ -68,7 +68,7 @@ pub fn run_apalache_test(dir: &str, test: ApalacheTestCase) -> io::Result<Apalac
             break;
         }
         if line.starts_with("======") {
-            let _ = write!(&mut new_model, "{} == ~{}\n", inv, test.test);
+            let _ = writeln!(&mut new_model, "{} == ~{}", inv, test.test);
         }
         new_model += line;
         new_model += "\n";

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -86,17 +86,22 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         ".tendermint.types.EvidenceParams.max_bytes",
         QUOTED_WITH_DEFAULT,
     ),
-    (".tendermint.abci.ResponseInfo.last_block_height", QUOTED),
-    (".tendermint.abci.ResponseInfo.version", DEFAULT),
     (".tendermint.version.Consensus.block", QUOTED),
     (".tendermint.version.Consensus.app", QUOTED_WITH_DEFAULT),
-    (
-        ".tendermint.abci.ResponseInfo.last_block_app_hash",
-        VEC_SKIP_IF_EMPTY,
-    ),
+    (".tendermint.abci.ResponseInfo.data", DEFAULT),
+    (".tendermint.abci.ResponseInfo.version", DEFAULT),
     (
         ".tendermint.abci.ResponseInfo.app_version",
         QUOTED_WITH_DEFAULT,
+    ),
+    (
+        ".tendermint.abci.ResponseInfo.last_block_height",
+        QUOTED_WITH_DEFAULT,
+    ),
+    (".tendermint.abci.ResponseInfo.last_block_app_hash", DEFAULT),
+    (
+        ".tendermint.abci.ResponseInfo.last_block_app_hash",
+        VEC_SKIP_IF_EMPTY,
     ),
     (".tendermint.types.BlockID.hash", HEXSTRING),
     (".tendermint.types.BlockID.part_set_header", ALIAS_PARTS),


### PR DESCRIPTION
Backport of #1131 to v0.23.x

Should fix https://github.com/informalsystems/ibc-rs/issues/2444

The fields are annotated with `json:"omitempty"` in the Go source, so give them default values for `Deserialize`. The `/abci_info` endpoint is known to omit some of the fields depending on what the node software supplies.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
