### PR TITLE
clippy: Fix lints for Rust 1.62 (v0.23.x)

### DIFF
--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -396,7 +396,7 @@ mod sealed {
                 response_tx,
             }))?;
             // Make sure our subscription request went through successfully.
-            let _ = response_rx.recv().await.ok_or_else(|| {
+            response_rx.recv().await.ok_or_else(|| {
                 Error::client_internal("failed to hear back from WebSocket driver".to_string())
             })??;
             Ok(Subscription::new(id, query, subscription_rx))
@@ -408,7 +408,7 @@ mod sealed {
                 query: query.to_string(),
                 response_tx,
             }))?;
-            let _ = response_rx.recv().await.ok_or_else(|| {
+            response_rx.recv().await.ok_or_else(|| {
                 Error::client_internal("failed to hear back from WebSocket driver".to_string())
             })??;
             Ok(())
@@ -993,7 +993,7 @@ mod test {
                 Some(id) => id.clone(),
                 None => return,
             };
-            let _ = self.send(Id::Str(subs_id), ev).await;
+            self.send(Id::Str(subs_id), ev).await;
         }
 
         async fn handle_incoming_msg(&mut self, msg: Message) -> Option<Result<(), Error>> {

--- a/testgen/src/apalache.rs
+++ b/testgen/src/apalache.rs
@@ -1,5 +1,6 @@
 use crate::{command::*, tester::TestEnv};
 use serde::{Deserialize, Serialize};
+use std::fmt::Write as _;
 use std::io;
 
 #[derive(Deserialize, Clone, Debug)]
@@ -67,7 +68,7 @@ pub fn run_apalache_test(dir: &str, test: ApalacheTestCase) -> io::Result<Apalac
             break;
         }
         if line.starts_with("======") {
-            new_model += &format!("{} == ~{}\n", inv, test.test);
+            let _ = writeln!(new_model, "{} == ~{}", inv, test.test);
         }
         new_model += line;
         new_model += "\n";


### PR DESCRIPTION
Fixes some minor clippy lints.