### PR TITLE
v0.23.x: Add support for HTTP Basic authentication to HTTP and WebSocket RPC clients

### DIFF
--- a/.changelog/unreleased/features/1169-basic-auth.md
+++ b/.changelog/unreleased/features/1169-basic-auth.md
@@ -1,0 +1,2 @@
+- Add support for HTTP Basic authentication to HTTP and WebSocket RPC clients
+  ([#1169](https://github.com/informalsystems/tendermint-rs/issues/1169))

--- a/.changelog/unreleased/features/1169-basic-auth.md
+++ b/.changelog/unreleased/features/1169-basic-auth.md
@@ -1,2 +1,2 @@
-- Add support for HTTP Basic authentication to HTTP and WebSocket RPC clients
+- `[tendermint-rpc]` Add support for HTTP Basic authentication to HTTP and WebSocket RPC clients
   ([#1169](https://github.com/informalsystems/tendermint-rs/issues/1169))

--- a/rpc/src/client/transport.rs
+++ b/rpc/src/client/transport.rs
@@ -1,5 +1,6 @@
 //! Tendermint RPC client implementations for different transports.
 
+mod auth;
 pub mod mock;
 mod router;
 

--- a/rpc/src/client/transport/auth.rs
+++ b/rpc/src/client/transport/auth.rs
@@ -1,0 +1,41 @@
+//! This module defines the `Authorization` type for
+//! authorizing a HTTP or WebSocket RPC client using
+//! HTTP Basic authentication.
+
+use alloc::string::{String, ToString};
+use core::fmt;
+
+use http::Uri;
+use subtle_encoding::base64;
+
+/// An HTTP authorization.
+///
+/// Currenlty only HTTP Basic authentication is supported.
+#[derive(Clone, Debug)]
+pub enum Authorization {
+    Basic(String),
+}
+
+impl fmt::Display for Authorization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Basic(cred) => write!(f, "Basic {}", cred),
+        }
+    }
+}
+
+/// Extract the authorization, if any, from the authority part of the given URI.
+///
+/// This authorization can then be supplied to the RPC server via
+/// the `Authorization` HTTP header.
+pub fn authorize(uri: &Uri) -> Option<Authorization> {
+    let authority = uri.authority()?;
+
+    if let Some((userpass, _)) = authority.as_str().split_once('@') {
+        let bytes = base64::encode(userpass);
+        let credentials = String::from_utf8_lossy(bytes.as_slice());
+        Some(Authorization::Basic(credentials.to_string()))
+    } else {
+        None
+    }
+}

--- a/rpc/src/client/transport/auth.rs
+++ b/rpc/src/client/transport/auth.rs
@@ -10,7 +10,7 @@ use subtle_encoding::base64;
 
 /// An HTTP authorization.
 ///
-/// Currenlty only HTTP Basic authentication is supported.
+/// Currently only HTTP Basic authentication is supported.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Authorization {
     Basic(String),

--- a/rpc/src/client/transport/auth.rs
+++ b/rpc/src/client/transport/auth.rs
@@ -11,7 +11,7 @@ use subtle_encoding::base64;
 /// An HTTP authorization.
 ///
 /// Currenlty only HTTP Basic authentication is supported.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Authorization {
     Basic(String),
 }
@@ -37,5 +37,34 @@ pub fn authorize(uri: &Uri) -> Option<Authorization> {
         Some(Authorization::Basic(credentials.to_string()))
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use http::Uri;
+
+    use super::*;
+
+    #[test]
+    fn extract_auth_absent() {
+        let uri = Uri::from_str("http://example.com").unwrap();
+        assert_eq!(authorize(&uri), None);
+    }
+
+    #[test]
+    fn extract_auth_username_only() {
+        let uri = Uri::from_str("http://toto@example.com").unwrap();
+        let base64 = "dG90bw==".to_string();
+        assert_eq!(authorize(&uri), Some(Authorization::Basic(base64)));
+    }
+
+    #[test]
+    fn extract_auth_username_password() {
+        let uri = Uri::from_str("http://toto:tata@example.com").unwrap();
+        let base64 = "dG90bzp0YXRh".to_string();
+        assert_eq!(authorize(&uri), Some(Authorization::Basic(base64)));
     }
 }

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -154,8 +154,10 @@ impl TryFrom<HttpClientUrl> for hyper::Uri {
 }
 
 mod sealed {
+    use crate::client::transport::auth::authorize;
     use crate::prelude::*;
     use crate::{Error, Response, SimpleRequest};
+    use http::header::AUTHORIZATION;
     use hyper::body::Buf;
     use hyper::client::connect::Connect;
     use hyper::client::HttpConnector;
@@ -216,6 +218,10 @@ mod sealed {
                         .parse()
                         .unwrap(),
                 );
+
+                if let Some(auth) = authorize(&self.uri) {
+                    headers.insert(AUTHORIZATION, auth.to_string().parse().unwrap());
+                }
             }
 
             Ok(request)

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -300,3 +300,41 @@ mod sealed {
         Ok(response_body)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use http::{header::AUTHORIZATION, Request, Uri};
+    use hyper::Body;
+
+    use crate::endpoint::abci_info;
+
+    use super::sealed::HyperClient;
+
+    fn authorization(req: &Request<Body>) -> Option<&str> {
+        req.headers()
+            .get(AUTHORIZATION)
+            .map(|h| h.to_str().unwrap())
+    }
+
+    #[test]
+    fn without_basic_auth() {
+        let uri = Uri::from_str("http://example.com").unwrap();
+        let inner = hyper::Client::new();
+        let client = HyperClient::new(uri, inner);
+        let req = client.build_request(abci_info::Request).unwrap();
+
+        assert_eq!(authorization(&req), None);
+    }
+
+    #[test]
+    fn with_basic_auth() {
+        let uri = Uri::from_str("http://toto:tata@example.com").unwrap();
+        let inner = hyper::Client::new();
+        let client = HyperClient::new(uri, inner);
+        let req = client.build_request(abci_info::Request).unwrap();
+
+        assert_eq!(authorization(&req), Some("Basic dG90bzp0YXRh"));
+    }
+}

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -258,6 +258,7 @@ mod sealed {
     };
 
     use crate::client::sync::{unbounded, ChannelTx};
+    use crate::client::transport::auth::authorize;
     use crate::prelude::*;
     use crate::query::Query;
     use crate::request::Wrapper;
@@ -266,7 +267,7 @@ mod sealed {
 
     use async_tungstenite::{
         tokio::{connect_async_with_config, connect_async_with_tls_connector_and_config},
-        tungstenite::protocol::WebSocketConfig,
+        tungstenite::{client::IntoClientRequest, protocol::WebSocketConfig},
     };
 
     use tracing::debug;
@@ -306,7 +307,6 @@ mod sealed {
             url: Url,
             config: Option<WebSocketConfig>,
         ) -> Result<(Self, WebSocketClientDriver), Error> {
-            let url = url.to_string();
             debug!("Connecting to unsecure WebSocket endpoint: {}", url);
 
             let (stream, _response) = connect_async_with_config(url, config)
@@ -338,7 +338,6 @@ mod sealed {
             url: Url,
             config: Option<WebSocketConfig>,
         ) -> Result<(Self, WebSocketClientDriver), Error> {
-            let url = url.to_string();
             debug!("Connecting to secure WebSocket endpoint: {}", url);
 
             // Not supplying a connector means async_tungstenite will create the
@@ -474,6 +473,38 @@ mod sealed {
                 WebSocketClient::Unsecure(c) => c.close(),
                 WebSocketClient::Secure(c) => c.close(),
             }
+        }
+    }
+
+    use async_tungstenite::tungstenite;
+
+    impl IntoClientRequest for Url {
+        fn into_client_request(
+            self,
+        ) -> tungstenite::Result<tungstenite::handshake::client::Request> {
+            let uri = self.to_string().parse::<http::Uri>().unwrap();
+
+            let builder = tungstenite::handshake::client::Request::builder()
+                .method("GET")
+                .header("Host", self.host())
+                .header("Connection", "Upgrade")
+                .header("Upgrade", "websocket")
+                .header("Sec-WebSocket-Version", "13")
+                .header(
+                    "Sec-WebSocket-Key",
+                    tungstenite::handshake::client::generate_key(),
+                );
+
+            let builder = if let Some(auth) = authorize(&uri) {
+                builder.header("Authorization", auth.to_string())
+            } else {
+                builder
+            };
+
+            builder
+                .uri(uri)
+                .body(())
+                .map_err(tungstenite::error::Error::HttpFormat)
         }
     }
 }

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -836,8 +836,11 @@ mod test {
     use crate::{request, Id, Method};
     use alloc::collections::BTreeMap as HashMap;
     use async_tungstenite::tokio::{accept_async, TokioAdapter};
+    use async_tungstenite::tungstenite::client::IntoClientRequest;
     use core::str::FromStr;
     use futures::StreamExt;
+    use http::header::AUTHORIZATION;
+    use http::Uri;
     use std::path::PathBuf;
     use std::println;
     use tendermint_config::net;
@@ -1187,5 +1190,27 @@ mod test {
                 collected_results[i].as_ref().unwrap().clone()
             );
         }
+    }
+
+    fn authorization(req: &http::Request<()>) -> Option<&str> {
+        req.headers()
+            .get(AUTHORIZATION)
+            .map(|h| h.to_str().unwrap())
+    }
+
+    #[test]
+    fn without_basic_auth() {
+        let uri = Uri::from_str("http://example.com").unwrap();
+        let req = uri.into_client_request().unwrap();
+
+        assert_eq!(authorization(&req), None);
+    }
+
+    #[test]
+    fn with_basic_auth() {
+        let uri = Uri::from_str("http://toto:tata@example.com").unwrap();
+        let req = uri.into_client_request().unwrap();
+
+        assert_eq!(authorization(&req), None);
     }
 }

--- a/rpc/src/rpc_url.rs
+++ b/rpc/src/rpc_url.rs
@@ -51,8 +51,6 @@ impl FromStr for Scheme {
 pub struct Url {
     inner: url::Url,
     scheme: Scheme,
-    username: Option<String>,
-    password: Option<String>,
     host: String,
     port: u16,
 }
@@ -64,12 +62,6 @@ impl FromStr for Url {
         let inner: url::Url = s.parse().map_err(Error::parse_url)?;
 
         let scheme: Scheme = inner.scheme().parse()?;
-
-        let username = Some(inner.username())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_owned());
-
-        let password = inner.password().map(|s| s.to_owned());
 
         let host = inner
             .host_str()
@@ -83,8 +75,6 @@ impl FromStr for Url {
         Ok(Self {
             inner,
             scheme,
-            username,
-            password,
             host,
             port,
         })
@@ -110,12 +100,12 @@ impl Url {
 
     /// Get the username associated with this URL, if any.
     pub fn username(&self) -> Option<&str> {
-        self.username.as_deref()
+        Some(self.inner.username()).filter(|s| !s.is_empty())
     }
 
     /// Get the password associated with this URL, if any.
     pub fn password(&self) -> Option<&str> {
-        self.password.as_deref()
+        self.inner.password()
     }
 
     /// Get the authority associated with this URL, if any.

--- a/rpc/src/rpc_url.rs
+++ b/rpc/src/rpc_url.rs
@@ -192,6 +192,28 @@ mod test {
                 }
             ),
             (
+                "tcp://foo@127.0.0.1:26657".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::Http,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "".to_string(),
+                    username: Some("foo".to_string()),
+                    password: None,
+                }
+            ),
+            (
+                "tcp://foo:bar@127.0.0.1:26657".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::Http,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "".to_string(),
+                    username: Some("foo".to_string()),
+                    password: Some("bar".to_string()),
+                }
+            ),
+            (
                 "http://127.0.0.1:26657".to_owned(),
                 ExpectedUrl {
                     scheme: Scheme::Http,
@@ -200,6 +222,28 @@ mod test {
                     path: "/".to_string(),
                     username: None,
                     password: None,
+                }
+            ),
+            (
+                "http://foo@127.0.0.1:26657".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::Http,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/".to_string(),
+                    username: Some("foo".to_string()),
+                    password: None,
+                }
+            ),
+            (
+                "http://foo:bar@127.0.0.1:26657".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::Http,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/".to_string(),
+                    username: Some("foo".to_string()),
+                    password: Some("bar".to_string()),
                 }
             ),
             (
@@ -214,6 +258,28 @@ mod test {
                 }
             ),
             (
+                "https://foo@127.0.0.1:26657".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::Https,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/".to_string(),
+                    username: Some("foo".to_string()),
+                    password: None,
+                }
+            ),
+            (
+                "https://foo:bar@127.0.0.1:26657".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::Https,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/".to_string(),
+                    username: Some("foo".to_string()),
+                    password: Some("bar".to_string()),
+                }
+            ),
+            (
                 "ws://127.0.0.1:26657/websocket".to_owned(),
                 ExpectedUrl {
                     scheme: Scheme::WebSocket,
@@ -225,6 +291,28 @@ mod test {
                 }
             ),
             (
+                "ws://foo@127.0.0.1:26657/websocket".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::WebSocket,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/websocket".to_string(),
+                    username: Some("foo".to_string()),
+                    password: None,
+                }
+            ),
+            (
+                "ws://foo:bar@127.0.0.1:26657/websocket".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::WebSocket,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/websocket".to_string(),
+                    username: Some("foo".to_string()),
+                    password: Some("bar".to_string()),
+                }
+            ),
+            (
                 "wss://127.0.0.1:26657/websocket".to_owned(),
                 ExpectedUrl {
                     scheme: Scheme::SecureWebSocket,
@@ -233,6 +321,28 @@ mod test {
                     path: "/websocket".to_string(),
                     username: None,
                     password: None,
+                }
+            ),
+            (
+                "wss://foo@127.0.0.1:26657/websocket".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::SecureWebSocket,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/websocket".to_string(),
+                    username: Some("foo".to_string()),
+                    password: None,
+                }
+            ),
+            (
+                "wss://foo:bar@127.0.0.1:26657/websocket".to_owned(),
+                ExpectedUrl {
+                    scheme: Scheme::SecureWebSocket,
+                    host: "127.0.0.1".to_string(),
+                    port: 26657,
+                    path: "/websocket".to_string(),
+                    username: Some("foo".to_string()),
+                    password: Some("bar".to_string()),
                 }
             )
         ];

--- a/rpc/src/rpc_url.rs
+++ b/rpc/src/rpc_url.rs
@@ -112,7 +112,7 @@ impl Url {
     /// The authority is the username and password separated by a colon.
     pub fn authority(&self) -> Option<String> {
         self.username()
-            .map(|user| format!("{user}:{}", self.password().unwrap_or_default()))
+            .map(|user| format!("{}:{}", user, self.password().unwrap_or_default()))
     }
 
     /// Get the host associated with this URL.


### PR DESCRIPTION
Closes: #1169

---

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
