### PR TITLE
Pin `time` to <0.3.12 to ensure we stay no-std compatible

### DIFF
--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -47,7 +47,7 @@ serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"
 serde_derive = { version = "1.0.106", default-features = false }
 sled = { version = "0.34.3", optional = true, default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
-time = { version = "0.3", default-features = false, features = ["std"] }
+time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = ["rt"], optional = true }
 flex-error = { version = "0.4.4", default-features = false }
 

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -47,6 +47,7 @@ serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"
 serde_derive = { version = "1.0.106", default-features = false }
 sled = { version = "0.34.3", optional = true, default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
+# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
 time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = ["rt"], optional = true }
 flex-error = { version = "0.4.4", default-features = false }

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -19,8 +19,8 @@ description = """
 default = ["time"]
 
 [dependencies]
-time = { version = "0.3", default-features = false, optional = true }
+time = { version = ">=0.3, <0.3.12", default-features = false, optional = true }
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-time = { version = "0.3", features = ["macros"] }
+time = { version = ">=0.3, <0.3.12", features = ["macros"] }

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -19,8 +19,10 @@ description = """
 default = ["time"]
 
 [dependencies]
+# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
 time = { version = ">=0.3, <0.3.12", default-features = false, optional = true }
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
+# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
 time = { version = ">=0.3, <0.3.12", features = ["macros"] }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -25,6 +25,7 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 subtle-encoding = { version = "0.5", default-features = false, features = ["hex", "base64", "alloc"] }
 num-traits = { version = "0.2", default-features = false }
 num-derive = { version = "0.3", default-features = false }
+# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
 time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macros", "parsing"] }
 flex-error = { version = "0.4.4", default-features = false }
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -25,7 +25,7 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 subtle-encoding = { version = "0.5", default-features = false, features = ["hex", "base64", "alloc"] }
 num-traits = { version = "0.2", default-features = false }
 num-derive = { version = "0.3", default-features = false }
-time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
+time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macros", "parsing"] }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -48,7 +48,7 @@ signature = { version = "1", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.23.8", default-features = false, path = "../proto" }
-time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
+time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa", "sha256"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -48,6 +48,7 @@ signature = { version = "1", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.23.8", default-features = false, path = "../proto" }
+# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
 time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -23,6 +23,7 @@ ed25519-dalek = { version = "1", default-features = false }
 gumdrop = { version = "0.8.0", default-features = false }
 simple-error = { version = "0.2.1", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }
+# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
 time = { package = "time", version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 
 [[bin]]

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -23,7 +23,7 @@ ed25519-dalek = { version = "1", default-features = false }
 gumdrop = { version = "0.8.0", default-features = false }
 simple-error = { version = "0.2.1", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }
-time = { package = "time", version = "0.3", default-features = false, features = ["std"] }
+time = { package = "time", version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 
 [[bin]]
 name = "tendermint-testgen"


### PR DESCRIPTION

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
