### PR TITLE
Tendermint: Added `unix_timestamp` and `unix_timestamp_nanos` method in Time struct.

### DIFF
--- a/.changelog/unreleased/improvements/1175-unix-timestamp-conversion.md
+++ b/.changelog/unreleased/improvements/1175-unix-timestamp-conversion.md
@@ -1,2 +1,2 @@
-- Added `Time` methods `unix_timestamp` and `unix_timestamp_nanos`.
+- `[tendermint]` Added `Time` methods `unix_timestamp` and `unix_timestamp_nanos`.
   ([#1175](https://github.com/informalsystems/tendermint-rs/issues/1175))

--- a/.changelog/unreleased/improvements/1175-unix-timestamp-conversion.md
+++ b/.changelog/unreleased/improvements/1175-unix-timestamp-conversion.md
@@ -1,0 +1,2 @@
+- Added `Time` methods `unix_timestamp` and `unix_timestamp_nanos`.
+  ([#1175](https://github.com/informalsystems/tendermint-rs/issues/1175))


### PR DESCRIPTION
close #1175 

I thought it would be easier to write code with other time libraries such as `chrono` if it porivided a `unix timestamp`

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
