### PR TITLE
tendermint: Bump `sha2` and `ripemd` crates to their latest versions

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -27,20 +27,20 @@ default = ["flex-error/std", "flex-error/eyre_tracer"]
 amino = ["prost-derive"]
 
 [dependencies]
-chacha20poly1305 = { version = "0.8", default-features = false, features = ["reduced-round"] }
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["reduced-round"] }
 ed25519-dalek = { version = "1", default-features = false }
 eyre = { version = "0.6", default-features = false }
 flume = { version = "0.10.7", default-features = false }
-hkdf = { version = "0.10.0", default-features = false }
-merlin = { version = "2", default-features = false }
+hkdf = { version = "0.12.3", default-features = false }
+merlin = { version = "3.0", default-features = false }
 prost = { version = "0.11", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["std"] }
-sha2 = { version = "0.9", default-features = false }
+rand_core = { version = "0.6", default-features = false, features = ["std"] }
+sha2 = { version = "0.10.2", default-features = false }
 subtle = { version = "2", default-features = false }
-x25519-dalek = { version = "1.1", default-features = false }
+x25519-dalek = { version = "=2.0.0-pre.1", default-features = false }
 zeroize = { version = "1", default-features = false }
 signature = { version = "1", default-features = false }
-aead = { version = "0.4.1", default-features = false }
+aead = { version = "0.5.0", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 # path dependencies

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use chacha20poly1305::{
-    aead::{generic_array::GenericArray, AeadInPlace, NewAead},
+    aead::{generic_array::GenericArray, AeadInPlace, KeyInit},
     ChaCha20Poly1305,
 };
 use ed25519_dalek::{self as ed25519, Signer, Verifier};

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.23.9" # Also update `html_root_url` in lib.rs and
-                               # depending crates (rpc, light-node, ..) when bumping this
+version    = "0.23.9" # Also update `html_root_url` in lib.rs and depending crates (rpc, light-node, ..) when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/master/tendermint"
@@ -43,7 +42,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10.2", default-features = false }
 signature = { version = "1", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
@@ -53,13 +52,13 @@ time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macr
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
-ripemd160 = { version = "0.9", default-features = false, optional = true }
+ripemd = { version = "0.1.1", default-features = false, optional = true }
 
 [features]
 default = ["std"]
 std = ["flex-error/std", "flex-error/eyre_tracer", "clock"]
 clock = ["time/std"]
-secp256k1 = ["k256", "ripemd160"]
+secp256k1 = ["k256", "ripemd"]
 
 [dev-dependencies]
 pretty_assertions = { version = "0.7.2", default-features = false }

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(feature = "secp256k1")]
-use ripemd160::Ripemd160;
+use ripemd::Ripemd160;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use subtle::{self, ConstantTimeEq};

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -20,7 +20,7 @@ flume = { version = "0.10", default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["std"] }
 readwrite = { version = "^0.1.1", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
-x25519-dalek = { version = "1.1", default-features = false }
+x25519-dalek = { version = "=2.0.0-pre.1", default-features = false }
 
 tendermint = { path = "../tendermint", default-features = false }
 tendermint-p2p = { path = "../p2p", default-features = false }


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
