### PR TITLE
feat(tendermint): add `TryFrom` implementations for `node::Info`

### DIFF
--- a/tendermint/src/channel.rs
+++ b/tendermint/src/channel.rs
@@ -2,12 +2,15 @@
 
 mod id;
 
-use core::fmt::{self, Display};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Display},
+};
 
 use serde::{Deserialize, Serialize};
 
 pub use self::id::Id;
-use crate::{prelude::*, serializers};
+use crate::{error::Error, prelude::*, serializers};
 
 /// Channels
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -40,5 +43,16 @@ pub struct Channels(String);
 impl Display for Channels {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Channels {
+    type Error = Error;
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        // TODO(erwan): what validation does a `Channels` need?
+        // possibly: length should be 20 bytes?
+        let value = String::from_utf8(value)
+            .map_err(|_| Error::parse("failed parsing channels".to_string()))?;
+        Ok(Channels(value))
     }
 }

--- a/tendermint/src/node/info.rs
+++ b/tendermint/src/node/info.rs
@@ -1,10 +1,20 @@
 //! Node information (used in RPC responses)
 
-use core::fmt::{self, Display};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
+use tendermint_proto::p2p::{
+    DefaultNodeInfo as RawInfo, DefaultNodeInfoOther as RawOtherInfo,
+    ProtocolVersion as RawProtocolVersion,
+};
 
-use crate::{chain, channel::Channels, node, prelude::*, serializers, Moniker, Version};
+use crate::{
+    chain, channel::Channels, error::Error, node, prelude::*, serializers, Moniker, Version,
+};
 
 /// Node information
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -34,6 +44,40 @@ pub struct Info {
     pub other: OtherInfo,
 }
 
+impl TryFrom<RawInfo> for Info {
+    type Error = Error;
+    fn try_from(raw: RawInfo) -> Result<Self, Self::Error> {
+        // TODO(erwan): my understand is that a `Channels` is 20 bytes wide
+        // let's get this to compile and ask for feedback on how to do validation properly
+        let channels = Channels::try_from(raw.channels)?;
+
+        let protocol_version = if let Some(version) = raw.protocol_version {
+            ProtocolVersionInfo::try_from(version)?
+        } else {
+            return Err(Error::missing_data()); // TODO(erwan): could do better than this error?
+        };
+
+        let other_info = if let Some(raw_info) = raw.other {
+            OtherInfo::try_from(raw_info)?
+        } else {
+            return Err(Error::missing_data()); // TODO(erwan): could do better than this error?
+        };
+
+        Ok(Info {
+            protocol_version: protocol_version,
+            id: node::Id::from_str(raw.default_node_id.as_str())?,
+            listen_addr: ListenAddress::new(raw.listen_addr),
+            // TODO(erwan): improve trait bound on that method
+            network: chain::Id::try_from(raw.network)?,
+            version: Version::try_from(raw.version)?,
+            channels: channels,
+            // TODO(erwan): what validation does a moniker need
+            moniker: Moniker::from_str(&raw.moniker)?,
+            other: other_info,
+        })
+    }
+}
+
 /// Protocol version information
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProtocolVersionInfo {
@@ -48,6 +92,17 @@ pub struct ProtocolVersionInfo {
     /// App version
     #[serde(with = "serializers::from_str")]
     pub app: u64,
+}
+
+impl TryFrom<RawProtocolVersion> for ProtocolVersionInfo {
+    type Error = Error;
+    fn try_from(raw: RawProtocolVersion) -> Result<Self, Self::Error> {
+        Ok(ProtocolVersionInfo {
+            p2p: raw.p2p,
+            block: raw.block,
+            app: raw.app,
+        })
+    }
 }
 
 /// Listen address information
@@ -81,6 +136,16 @@ pub struct OtherInfo {
     pub rpc_address: String,
 }
 
+impl TryFrom<RawOtherInfo> for OtherInfo {
+    type Error = Error;
+    fn try_from(raw: RawOtherInfo) -> Result<Self, Self::Error> {
+        Ok(OtherInfo {
+            tx_index: TxIndexStatus::try_from(raw.tx_index)?,
+            rpc_address: raw.rpc_address,
+        })
+    }
+}
+
 /// Transaction index status
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum TxIndexStatus {
@@ -91,6 +156,18 @@ pub enum TxIndexStatus {
     /// Index is off
     #[serde(rename = "off")]
     Off,
+}
+
+impl TryFrom<String> for TxIndexStatus {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "on" => Ok(TxIndexStatus::On),
+            "off" => Ok(TxIndexStatus::Off),
+            _ => Err(Error::missing_data()), // TODO(erwan): use more appropriate error
+        }
+    }
 }
 
 impl Default for TxIndexStatus {

--- a/tendermint/src/version.rs
+++ b/tendermint/src/version.rs
@@ -1,4 +1,7 @@
-use core::fmt::{self, Debug, Display};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Debug, Display},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +9,15 @@ use crate::prelude::*;
 
 /// Tendermint version
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct Version(String);
+pub struct Version(pub String);
+
+impl TryFrom<String> for Version {
+    type Error = crate::error::Error;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        // TODO(erwan): what validation does `Version` needs?
+        Ok(Version(value))
+    }
+}
 
 impl Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This draft PR is part of the #1181 story:

### PR items:
* [x] implement `TryFrom<pb::p2p::NodeInfo>` for `node::Info`
* [ ] implements `From<node::Info> for pb::p2p::NodeInfo`
* [ ] implements  `Protobuf<pb::p2p::NodeInfo> for node::Info`

In particular, I need help/feedback with regard to how validation is done. You can grep the PR for `TODO(erwan)` for the specific relevant parts that need extra scrutiny imo. 

### other items:

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
