### PR TITLE
deps: Unpin time dependency

### DIFF
--- a/.changelog/unreleased/dependencies/1199-unpin-time-dep.md
+++ b/.changelog/unreleased/dependencies/1199-unpin-time-dep.md
@@ -1,0 +1,2 @@
+- Unpin `time` dependency
+  ([#1199](https://github.com/informalsystems/tendermint-rs/pull/1199))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Install grcov
         run: |
           rustup component add llvm-tools-preview
-          curl -L https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+          curl -L https://github.com/mozilla/grcov/releases/download/v0.8.11/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: Run grcov
         run: |
           ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --branch --ignore-not-existing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-11-10
+          toolchain: nightly-2022-09-18
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -30,7 +30,7 @@ tendermint = { version = "0.23.9", path = "../tendermint", default-features = fa
 
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }
 serde = { version = "1.0.106", default-features = false }
-time = { version = "0.3.5", default-features = false }
+time = { version = "0.3", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -47,8 +47,7 @@ serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"
 serde_derive = { version = "1.0.106", default-features = false }
 sled = { version = "0.34.3", optional = true, default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
-# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
-time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
+time = { version = "0.3", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = ["rt"], optional = true }
 flex-error = { version = "0.4.4", default-features = false }
 

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -19,10 +19,8 @@ description = """
 default = ["time"]
 
 [dependencies]
-# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
-time = { version = ">=0.3, <0.3.12", default-features = false, optional = true }
+time = { version = "0.3", default-features = false, optional = true }
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
-time = { version = ">=0.3, <0.3.12", features = ["macros"] }
+time = { version = "0.3", features = ["macros"] }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -25,8 +25,7 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 subtle-encoding = { version = "0.5", default-features = false, features = ["hex", "base64", "alloc"] }
 num-traits = { version = "0.2", default-features = false }
 num-derive = { version = "0.3", default-features = false }
-# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
-time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -48,8 +48,7 @@ signature = { version = "1", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.23.9", default-features = false, path = "../proto" }
-# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
-time = { version = ">=0.3, <0.3.12", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa", "sha256"] }

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -235,7 +235,6 @@ mod tests {
         let dts = vec![
             datetime!(0000-12-31 23:59:59.999999999 UTC),
             datetime!(0001-01-01 00:00:00.999999999 +00:00:01),
-            datetime!(9999-12-31 23:59:59 -00:00:01),
             Date::from_calendar_date(-1, October, 9)
                 .unwrap()
                 .midnight()

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -23,8 +23,7 @@ ed25519-dalek = { version = "1", default-features = false }
 gumdrop = { version = "0.8.0", default-features = false }
 simple-error = { version = "0.2.1", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }
-# TODO(thane): Remove restrictions once js-sys issue is resolved (causes the Substrate no_std check to fail)
-time = { package = "time", version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
+time = { package = "time", version = "0.3", default-features = false, features = ["std"] }
 
 [[bin]]
 name = "tendermint-testgen"


### PR DESCRIPTION
It appears as though we no longer need the `time` dependency pinned for the no_std check to pass.

---

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
