### PR TITLE
deps: Remove `ansi_term` dependency

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -33,4 +33,4 @@ toml = { version = "0.5" }
 url = { version = "2.2" }
 
 [dev-dependencies]
-pretty_assertions = "0.7.2"
+pretty_assertions = "1.3.0"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -61,6 +61,6 @@ clock = ["time/std"]
 secp256k1 = ["k256", "ripemd160"]
 
 [dev-dependencies]
-pretty_assertions = { version = "1.3.0", default-features = false }
+pretty_assertions = "1.3.0"
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 tendermint-pbt-gen = { path = "../pbt-gen", default-features = false, features = ["time"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -61,6 +61,6 @@ clock = ["time/std"]
 secp256k1 = ["k256", "ripemd160"]
 
 [dev-dependencies]
-pretty_assertions = { version = "0.7.2", default-features = false }
+pretty_assertions = { version = "1.3.0", default-features = false }
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 tendermint-pbt-gen = { path = "../pbt-gen", default-features = false, features = ["time"] }


### PR DESCRIPTION
Closes #1186.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
