### PR TITLE
deps: Remove `wee_alloc` optional dependency

### DIFF
--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -34,12 +34,5 @@ wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "ser
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", default-features = false, optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", default-features = false, optional = true }
-
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3.13", default-features = false }

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -22,12 +22,6 @@ use tendermint_light_client_verifier::{
 };
 use wasm_bindgen::{prelude::*, JsValue};
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc<'_> = wee_alloc::WeeAlloc::INIT;
-
 /// Check whether a given untrusted block can be trusted.
 #[wasm_bindgen]
 pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &JsValue) -> JsValue {


### PR DESCRIPTION
Closes #1192.

`wee_alloc` was an optional dependency and an optimization anyways.

---

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
