### PR TITLE
support parsing `unix abstract socket`

### DIFF
--- a/config/src/net.rs
+++ b/config/src/net.rs
@@ -87,6 +87,13 @@ impl FromStr for Address {
     type Err = Error;
 
     fn from_str(addr: &str) -> Result<Self, Error> {
+        // unix abstract socket address, `man 7 unix` for system descriptions
+        if addr.starts_with("unix://@") {
+            return Ok(Self::Unix {
+                path: addr.trim_start_matches("unix://").to_owned(),
+            });
+        }
+
         let prefixed_addr = if addr.contains("://") {
             addr.to_owned()
         } else {


### PR DESCRIPTION
tendermint core can accept `unix abstract socket`, but this crate can NOT parse it.

this pr fix this issue.

ref: https://golang-examples.tumblr.com/post/92025745979/pitfall-of-abstract-unix-domain-socket-address-in-go