### PR TITLE
Re-add `block_by_hash` Tendermint endpoint

### DIFF
--- a/.changelog/unreleased/bug-fixes/832-block-by-hash-encoding.md
+++ b/.changelog/unreleased/bug-fixes/832-block-by-hash-encoding.md
@@ -1,0 +1,4 @@
+- `[tendermint-rpc]` The encoding of the `hash` field for requests to the `/block_by_hash`
+  endpoint has been changed to base64 (from hex) to accommodate discrepancies in
+  how the Tendermint RPC encodes this field for different RPC interfaces
+  ([#942](https://github.com/informalsystems/tendermint-rs/issues/942))

--- a/.changelog/unreleased/features/832-block-by-hash.md
+++ b/.changelog/unreleased/features/832-block-by-hash.md
@@ -1,1 +1,1 @@
-- `[tendermint-rpc]` Add support for the `/block_by_hash` RPC endpoint. See <https://docs.tendermint.com/master/rpc/#/Info/block_by_hash> for details. Links to  ([#832](https://github.com/informalsystems/tendermint-rs/issues/832)).
+- `[tendermint-rpc]` Add support for the `/block_by_hash` RPC endpoint. See <https://docs.tendermint.com/master/rpc/#/Info/block_by_hash> for details ([#832](https://github.com/informalsystems/tendermint-rs/issues/832)).

--- a/.changelog/unreleased/features/832-block-by-hash.md
+++ b/.changelog/unreleased/features/832-block-by-hash.md
@@ -1,0 +1,1 @@
+- `[tendermint-rpc]` Add support for the `/block_by_hash` RPC endpoint. See <https://docs.tendermint.com/master/rpc/#/Info/block_by_hash> for details. Links to  ([#832](https://github.com/informalsystems/tendermint-rs/issues/832)).

--- a/rpc/src/abci/tag.rs
+++ b/rpc/src/abci/tag.rs
@@ -5,8 +5,7 @@ use core::{fmt, str::FromStr};
 use serde::{Deserialize, Serialize};
 use tendermint::error::Error;
 
-use crate::prelude::*;
-use crate::serializers::bytes::base64string;
+use crate::{prelude::*, serializers::bytes::base64string};
 
 /// Tags
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -67,6 +67,14 @@ pub trait Client {
         self.perform(block::Request::new(height.into())).await
     }
 
+    /// `/block_by_hash`: get block by hash.
+    async fn block_by_hash(
+        &self,
+        hash: tendermint::Hash,
+    ) -> Result<block_by_hash::Response, Error> {
+        self.perform(block_by_hash::Request::new(hash)).await
+    }
+
     /// `/block`: get the latest block.
     async fn latest_block(&self) -> Result<block::Response, Error> {
         self.perform(block::Request::default()).await

--- a/rpc/src/client/bin/main.rs
+++ b/rpc/src/client/bin/main.rs
@@ -78,6 +78,8 @@ enum ClientRequest {
     },
     /// Get a block at a given height.
     Block { height: u32 },
+    /// Get a block by its hash.
+    BlockByHash { hash: String },
     /// Get block headers between two heights (min <= height <= max).
     Blockchain {
         /// The minimum height
@@ -315,6 +317,13 @@ where
         .map_err(Error::serde)?,
         ClientRequest::Block { height } => {
             serde_json::to_string_pretty(&client.block(height).await?).map_err(Error::serde)?
+        },
+        ClientRequest::BlockByHash { hash } => {
+            serde_json::to_string_pretty(
+                &client.block_by_hash(
+                    tendermint::Hash::from_str(&hash).map_err(|e| Error::parse(e.to_string()))?
+                ).await?
+            ).map_err(Error::serde)?
         },
         ClientRequest::Blockchain { min, max } => {
             serde_json::to_string_pretty(&client.blockchain(min, max).await?)

--- a/rpc/src/client/bin/main.rs
+++ b/rpc/src/client/bin/main.rs
@@ -318,13 +318,14 @@ where
         ClientRequest::Block { height } => {
             serde_json::to_string_pretty(&client.block(height).await?).map_err(Error::serde)?
         },
-        ClientRequest::BlockByHash { hash } => {
-            serde_json::to_string_pretty(
-                &client.block_by_hash(
-                    tendermint::Hash::from_str(&hash).map_err(|e| Error::parse(e.to_string()))?
-                ).await?
-            ).map_err(Error::serde)?
-        },
+        ClientRequest::BlockByHash { hash } => serde_json::to_string_pretty(
+            &client
+                .block_by_hash(
+                    tendermint::Hash::from_str(&hash).map_err(|e| Error::parse(e.to_string()))?,
+                )
+                .await?,
+        )
+        .map_err(Error::serde)?,
         ClientRequest::Blockchain { min, max } => {
             serde_json::to_string_pretty(&client.blockchain(min, max).await?)
                 .map_err(Error::serde)?

--- a/rpc/src/endpoint.rs
+++ b/rpc/src/endpoint.rs
@@ -3,6 +3,7 @@
 pub mod abci_info;
 pub mod abci_query;
 pub mod block;
+pub mod block_by_hash;
 pub mod block_results;
 pub mod block_search;
 pub mod blockchain;

--- a/rpc/src/endpoint/block_by_hash.rs
+++ b/rpc/src/endpoint/block_by_hash.rs
@@ -1,9 +1,10 @@
 //! `/block_by_hash` endpoint JSON-RPC wrapper
 
 use serde::{Deserialize, Serialize};
-
-use tendermint::block::{self, Block};
-use tendermint::Hash;
+use tendermint::{
+    block::{self, Block},
+    Hash,
+};
 
 /// Get information about a specific block by its hash
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/rpc/src/endpoint/block_by_hash.rs
+++ b/rpc/src/endpoint/block_by_hash.rs
@@ -1,24 +1,25 @@
-//! `/block` endpoint JSON-RPC wrapper
+//! `/block_by_hash` endpoint JSON-RPC wrapper
 
 use serde::{Deserialize, Serialize};
 
 use tendermint::Hash;
 use tendermint::block::{self, Block};
 
-/// Get information about a specific block
+/// Get information about a specific block by its hash
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Request {
     /// Hash of the block to request.
     ///
-    /// If no hash is provided, it will fetch results for the latest block.
+    /// If no hash is provided, it will return no block (as if the hash
+    /// did not match any block).
     pub hash: Option<Hash>,
 }
 
 impl Request {
     /// Create a new request for information about a particular block
-    pub fn new(hash: Hash) -> Self {
+    pub fn new<H: Into<Hash>>(hash: H) -> Self {
         Self {
-            hash: Some(hash),
+            hash: Some(hash.into()),
         }
     }
 }

--- a/rpc/src/endpoint/block_by_hash.rs
+++ b/rpc/src/endpoint/block_by_hash.rs
@@ -13,6 +13,11 @@ pub struct Request {
     ///
     /// If no hash is provided, it will return no block (as if the hash
     /// did not match any block).
+    ///
+    /// Serialized internally into a base64-encoded string before sending to
+    /// the RPC server.
+    #[serde(default)]
+    #[serde(with = "crate::serializers::opt_tm_hash_base64")]
     pub hash: Option<Hash>,
 }
 

--- a/rpc/src/endpoint/block_by_hash.rs
+++ b/rpc/src/endpoint/block_by_hash.rs
@@ -2,8 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use tendermint::Hash;
 use tendermint::block::{self, Block};
+use tendermint::Hash;
 
 /// Get information about a specific block by its hash
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/rpc/src/endpoint/block_by_hash.rs
+++ b/rpc/src/endpoint/block_by_hash.rs
@@ -1,0 +1,46 @@
+//! `/block` endpoint JSON-RPC wrapper
+
+use serde::{Deserialize, Serialize};
+
+use tendermint::Hash;
+use tendermint::block::{self, Block};
+
+/// Get information about a specific block
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Request {
+    /// Hash of the block to request.
+    ///
+    /// If no hash is provided, it will fetch results for the latest block.
+    pub hash: Option<Hash>,
+}
+
+impl Request {
+    /// Create a new request for information about a particular block
+    pub fn new(hash: Hash) -> Self {
+        Self {
+            hash: Some(hash),
+        }
+    }
+}
+
+impl crate::Request for Request {
+    type Response = Response;
+
+    fn method(&self) -> crate::Method {
+        crate::Method::BlockByHash
+    }
+}
+
+impl crate::SimpleRequest for Request {}
+
+/// Block responses
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Response {
+    /// Block ID
+    pub block_id: block::Id,
+
+    /// Block data
+    pub block: Option<Block>,
+}
+
+impl crate::Response for Response {}

--- a/rpc/src/endpoint/tx.rs
+++ b/rpc/src/endpoint/tx.rs
@@ -13,7 +13,7 @@ pub struct Request {
     ///
     /// Serialized internally into a base64-encoded string before sending to
     /// the RPC server.
-    #[serde(with = "crate::serializers::hash_base64")]
+    #[serde(with = "crate::serializers::tx_hash_base64")]
     pub hash: abci::transaction::Hash,
     /// Whether or not to include the proofs of the transaction's inclusion in
     /// the block.

--- a/rpc/src/method.rs
+++ b/rpc/src/method.rs
@@ -23,6 +23,9 @@ pub enum Method {
     /// Get block info
     Block,
 
+    /// Get block info by hash
+    BlockByHash,
+
     /// Get ABCI results for a particular block
     BlockResults,
 
@@ -88,6 +91,7 @@ impl Method {
             Method::AbciInfo => "abci_info",
             Method::AbciQuery => "abci_query",
             Method::Block => "block",
+            Method::BlockByHash => "block_by_hash",
             Method::BlockResults => "block_results",
             Method::BlockSearch => "block_search",
             Method::Blockchain => "blockchain",
@@ -119,6 +123,7 @@ impl FromStr for Method {
             "abci_info" => Method::AbciInfo,
             "abci_query" => Method::AbciQuery,
             "block" => Method::Block,
+            "block_by_hash" => Method::BlockByHash,
             "block_results" => Method::BlockResults,
             "block_search" => Method::BlockSearch,
             "blockchain" => Method::Blockchain,

--- a/rpc/src/serializers.rs
+++ b/rpc/src/serializers.rs
@@ -7,4 +7,6 @@
 //! risk.
 pub use tendermint_proto::serializers::*;
 
-pub mod hash_base64;
+pub mod opt_tm_hash_base64;
+pub mod tm_hash_base64;
+pub mod tx_hash_base64;

--- a/rpc/src/serializers/opt_tm_hash_base64.rs
+++ b/rpc/src/serializers/opt_tm_hash_base64.rs
@@ -1,0 +1,25 @@
+//! Encoding/decoding Option Tendermint hashes to/from base64.
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tendermint::hash::Hash;
+
+use crate::prelude::*;
+
+#[derive(Serialize, Deserialize)]
+struct Helper(#[serde(with = "crate::serializers::tm_hash_base64")] Hash);
+
+/// Deserialize base64-encoded string into an Option<tendermint::Hash>
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Hash>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let helper: Option<Helper> = Option::deserialize(deserializer)?;
+    Ok(helper.map(|Helper(hash)| hash))
+}
+
+/// Serialize from an Option<tendermint::Hash> into a base64-encoded string
+pub fn serialize<S>(value: &Option<Hash>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    value.map(Helper).serialize(serializer)
+}

--- a/rpc/src/serializers/tm_hash_base64.rs
+++ b/rpc/src/serializers/tm_hash_base64.rs
@@ -20,7 +20,7 @@ where
     }
     let mut decoded_bytes = [0u8; SHA256_HASH_SIZE];
     decoded_bytes.copy_from_slice(decoded.as_ref());
-    Ok(Hash::from_bytes(Sha256, &decoded_bytes).map_err(serde::de::Error::custom)?)
+    Hash::from_bytes(Sha256, &decoded_bytes).map_err(serde::de::Error::custom)
 }
 
 /// Serialize from a tendermint::Hash into a base64-encoded string

--- a/rpc/src/serializers/tm_hash_base64.rs
+++ b/rpc/src/serializers/tm_hash_base64.rs
@@ -1,31 +1,29 @@
-//! Encoding/decoding ABCI transaction hashes to/from base64.
+//! Encoding/decoding Tendermint hashes to/from base64.
 
 use serde::{Deserialize, Deserializer, Serializer};
 use subtle_encoding::base64;
+use tendermint::hash::{Algorithm::Sha256, Hash, SHA256_HASH_SIZE};
 
-use crate::{
-    abci::transaction::{Hash, HASH_LENGTH},
-    prelude::*,
-};
+use crate::prelude::*;
 
-/// Deserialize a base64-encoded string into a Hash
+/// Deserialize a base64-encoded string into an tendermint::Hash
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
     let decoded = base64::decode(&s).map_err(serde::de::Error::custom)?;
-    if decoded.len() != HASH_LENGTH {
+    if decoded.len() != SHA256_HASH_SIZE {
         return Err(serde::de::Error::custom(
             "unexpected transaction length for hash",
         ));
     }
-    let mut decoded_bytes = [0u8; HASH_LENGTH];
+    let mut decoded_bytes = [0u8; SHA256_HASH_SIZE];
     decoded_bytes.copy_from_slice(decoded.as_ref());
-    Ok(Hash::new(decoded_bytes))
+    Ok(Hash::from_bytes(Sha256, &decoded_bytes).map_err(serde::de::Error::custom)?)
 }
 
-/// Serialize from a Hash into a base64-encoded string
+/// Serialize from a tendermint::Hash into a base64-encoded string
 pub fn serialize<S>(value: &Hash, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/rpc/src/serializers/tx_hash_base64.rs
+++ b/rpc/src/serializers/tx_hash_base64.rs
@@ -1,0 +1,36 @@
+//! Encoding/decoding ABCI transaction hashes to/from base64.
+
+use serde::{Deserialize, Deserializer, Serializer};
+use subtle_encoding::base64;
+
+use crate::{
+    abci::transaction::{Hash, HASH_LENGTH},
+    prelude::*,
+};
+
+/// Deserialize a base64-encoded string into an abci::transaction::Hash
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    let decoded = base64::decode(&s).map_err(serde::de::Error::custom)?;
+    if decoded.len() != HASH_LENGTH {
+        return Err(serde::de::Error::custom(
+            "unexpected transaction length for hash",
+        ));
+    }
+    let mut decoded_bytes = [0u8; HASH_LENGTH];
+    decoded_bytes.copy_from_slice(decoded.as_ref());
+    Ok(Hash::new(decoded_bytes))
+}
+
+/// Serialize from an abci::transaction::Hash into a base64-encoded string
+pub fn serialize<S>(value: &Hash, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let base64_bytes = base64::encode(value.as_bytes());
+    let base64_string = String::from_utf8(base64_bytes).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&base64_string)
+}

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -1,8 +1,7 @@
 //! Tendermint kvstore RPC endpoint testing.
 
 use core::str::FromStr;
-use std::collections::BTreeMap as HashMap;
-use std::{fs, path::PathBuf};
+use std::{collections::BTreeMap as HashMap, fs, path::PathBuf};
 
 use subtle_encoding::{base64, hex};
 use tendermint::{

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -95,6 +95,16 @@ fn outgoing_fixtures() {
                         .unwrap();
                 assert_eq!(wrapped.params().height.unwrap().value(), 10);
             },
+            "block_by_hash" => {
+                // First, get the hash at height 1.
+                let wrapped =
+                    serde_json::from_str::<RequestWrapper<endpoint::block_by_hash::Request>>(&content)
+                        .unwrap();
+                assert_eq!(
+                    wrapped.params().hash.unwrap().to_string(),
+                    "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
+                );
+            },
             "block_results_at_height_10" => {
                 let wrapped = serde_json::from_str::<
                     RequestWrapper<endpoint::block_results::Request>,
@@ -463,6 +473,10 @@ fn incoming_fixtures() {
                 assert_eq!(result.height.value(), 10);
                 assert!(result.txs_results.is_none());
                 assert!(result.validator_updates.is_empty());
+            },
+            "block_by_hash" => {
+                let result = endpoint::block::Response::from_string(content).unwrap();
+                assert_eq!(result.block_id.hash.to_string(), "BCF3DB412E80A396D10BF5B5E6D3E63D3B06DEB25AA958BCB8CE18D023838042");
             },
             "block_search" => {
                 let result = endpoint::block_search::Response::from_string(content).unwrap();

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -97,9 +97,10 @@ fn outgoing_fixtures() {
             },
             "block_by_hash" => {
                 // First, get the hash at height 1.
-                let wrapped =
-                    serde_json::from_str::<RequestWrapper<endpoint::block_by_hash::Request>>(&content)
-                        .unwrap();
+                let wrapped = serde_json::from_str::<
+                    RequestWrapper<endpoint::block_by_hash::Request>,
+                >(&content)
+                .unwrap();
                 assert_eq!(
                     wrapped.params().hash.unwrap().to_string(),
                     "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
@@ -476,7 +477,10 @@ fn incoming_fixtures() {
             },
             "block_by_hash" => {
                 let result = endpoint::block::Response::from_string(content).unwrap();
-                assert_eq!(result.block_id.hash.to_string(), "BCF3DB412E80A396D10BF5B5E6D3E63D3B06DEB25AA958BCB8CE18D023838042");
+                assert_eq!(
+                    result.block_id.hash.to_string(),
+                    "BCF3DB412E80A396D10BF5B5E6D3E63D3B06DEB25AA958BCB8CE18D023838042"
+                );
             },
             "block_search" => {
                 let result = endpoint::block_search::Response::from_string(content).unwrap();

--- a/rpc/tests/kvstore_fixtures/incoming/block_by_hash.json
+++ b/rpc/tests/kvstore_fixtures/incoming/block_by_hash.json
@@ -1,0 +1,65 @@
+{
+  "id": "988f944f-4d85-486f-ad27-2f3574c2a4a3",
+  "jsonrpc": "2.0",
+  "result": {
+    "block": {
+      "data": {
+        "txs": []
+      },
+      "evidence": {
+        "evidence": []
+      },
+      "header": {
+        "app_hash": "0000000000000000",
+        "chain_id": "dockerchain",
+        "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+        "data_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "height": "10",
+        "last_block_id": {
+          "hash": "03979BC4F521D92D137F8A93B64D7D1A8589560F64C4543784DECCBCEDF1D13F",
+          "parts": {
+            "hash": "00DC8C2DE1DE6B66960CB5F15F802286D6423903C06804C35053E0F757B34E47",
+            "total": 1
+          }
+        },
+        "last_commit_hash": "B194E4E363E010ED4F80860FAF452B45D81C77D7C68C753424F44596A229D692",
+        "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "next_validators_hash": "D506A39182DDCC44917A3E7827E784B501B354789F99BAC8D56AE50ABE34972B",
+        "proposer_address": "6B3F66DCF73507BCE7148D6580DAC27074108628",
+        "time": "2021-11-25T17:04:38.160820316Z",
+        "validators_hash": "D506A39182DDCC44917A3E7827E784B501B354789F99BAC8D56AE50ABE34972B",
+        "version": {
+          "app": "1",
+          "block": "11"
+        }
+      },
+      "last_commit": {
+        "block_id": {
+          "hash": "03979BC4F521D92D137F8A93B64D7D1A8589560F64C4543784DECCBCEDF1D13F",
+          "parts": {
+            "hash": "00DC8C2DE1DE6B66960CB5F15F802286D6423903C06804C35053E0F757B34E47",
+            "total": 1
+          }
+        },
+        "height": "9",
+        "round": 0,
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "signature": "5yClL8UlPdvb2tzNguZu3UaTH5X5S8S635u9nBQjZQw3NFhrZklXm6Aw7Mxvhn3y7CL0yKHdRmH0FnPh8cs2Cg==",
+            "timestamp": "2021-11-25T17:04:38.160820316Z",
+            "validator_address": "6B3F66DCF73507BCE7148D6580DAC27074108628"
+          }
+        ]
+      }
+    },
+    "block_id": {
+      "hash": "BCF3DB412E80A396D10BF5B5E6D3E63D3B06DEB25AA958BCB8CE18D023838042",
+      "parts": {
+        "hash": "7F02924A557B6B6AEB9390183F5458C88EAC02956AFDCCAAFC09B59A80D1EEA8",
+        "total": 1
+      }
+    }
+  }
+}

--- a/rpc/tests/kvstore_fixtures/outgoing/block_by_hash.json
+++ b/rpc/tests/kvstore_fixtures/outgoing/block_by_hash.json
@@ -1,0 +1,8 @@
+{
+  "id": "a37bcc8e-6a32-4157-9200-a26be9981bbd",
+  "jsonrpc": "2.0",
+  "method": "block",
+  "params": {
+    "hash": "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
+  }
+}

--- a/rpc/tests/kvstore_fixtures/outgoing/block_by_hash.json
+++ b/rpc/tests/kvstore_fixtures/outgoing/block_by_hash.json
@@ -1,8 +1,8 @@
 {
   "id": "a37bcc8e-6a32-4157-9200-a26be9981bbd",
   "jsonrpc": "2.0",
-  "method": "block",
+  "method": "block_by_hash",
   "params": {
-    "hash": "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
+    "hash": "ABEiM0RVZneImaq7zN3u/wARIjNEVWZ3iJmqu8zd7v8="
   }
 }

--- a/tools/kvstore-test/tests/tendermint.rs
+++ b/tools/kvstore-test/tests/tendermint.rs
@@ -122,6 +122,31 @@ mod rpc {
         );
     }
 
+    /// `/block_search` endpoint
+    #[tokio::test]
+    async fn block_by_hash() {
+        let res = localhost_http_client()
+            .block_by_hash(
+                tendermint::Hash::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap()
+            )
+            .await
+            .unwrap();
+        assert!(res.block.is_none());
+
+        // Reuse block(1) to get an existing hash.
+        let height = 1u64;
+        let block_info = localhost_http_client()
+            .block(Height::try_from(height).unwrap())
+            .await
+            .unwrap();
+        let res = localhost_http_client()
+            .block_by_hash(block_info.block_id.hash)
+            .await
+            .unwrap();
+        assert!(res.block.is_some());
+        assert_eq!(block_info.block.header.height.value(), height);
+    }
+
     /// `/block_results` endpoint
     #[tokio::test]
     async fn block_results() {

--- a/tools/kvstore-test/tests/tendermint.rs
+++ b/tools/kvstore-test/tests/tendermint.rs
@@ -17,6 +17,7 @@ mod rpc {
     use std::{
         cmp::min,
         convert::TryFrom,
+        str::FromStr,
         sync::atomic::{AtomicU8, Ordering},
     };
 

--- a/tools/rpc-probe/src/common.rs
+++ b/tools/rpc-probe/src/common.rs
@@ -33,6 +33,16 @@ pub fn block(height: u64) -> PlannedInteraction {
     .into()
 }
 
+pub fn block_by_hash(hash: &str) -> PlannedInteraction {
+    Request::new(
+        "block_by_hash",
+        json!({
+            "hash": format!("{}", hash),
+        }),
+    )
+    .into()
+}
+
 pub fn block_search(query: &str, page: u32, per_page: u32, order_by: &str) -> PlannedInteraction {
     Request::new(
         "block_search",

--- a/tools/rpc-probe/src/kvstore.rs
+++ b/tools/rpc-probe/src/kvstore.rs
@@ -26,6 +26,7 @@ pub fn quick_probe_plan(output_path: &Path, request_wait: Duration) -> Result<Pl
                     .with_min_height(10)
                     .with_name("block_at_height_10"),
                 block_results(10).with_name("block_results_at_height_10"),
+                block_by_hash("0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF").with_name("block_by_hash"),
                 block_search("block.height > 1", 1, 100, "asc").with_name("block_search"),
                 blockchain(1, 10).with_name("blockchain_from_1_to_10"),
                 commit(10).with_name("commit_at_height_10"),


### PR DESCRIPTION
Links https://github.com/informalsystems/tendermint-rs/issues/832.

Re-implements the `block_by_hash` RPC, which returns an optional block.

I applied the patch from https://github.com/informalsystems/tendermint-rs/pull/1089 and fixed the `tendermint::Hash` encoding/decoding to accommodate discrepancies in how the Tendermint RPC encodes this field for different RPC interfaces.

Relates to #942 

CC @hansl
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
