### PR TITLE
Serialization of optional values without Clone

### DIFF
--- a/proto/src/serializers/optional.rs
+++ b/proto/src/serializers/optional.rs
@@ -16,7 +16,10 @@ where
 pub fn serialize<S, T>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
-    T: Clone + Default + Serialize,
+    T: Default + Serialize,
 {
-    value.clone().unwrap_or_default().serialize(serializer)
+    match value {
+        Some(v) => v.serialize(serializer),
+        None => T::default().serialize(serializer),
+    }
 }


### PR DESCRIPTION
With a bit less spiffy syntax, an `Option<T>` can be serialized without cloning the whole value.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
