### PR TITLE
`TrustThresholdFraction`: allow to be initialized with value 1

### DIFF
--- a/.changelog/unreleased/bug-fixes/1208-trustthresholdfraction-check.md
+++ b/.changelog/unreleased/bug-fixes/1208-trustthresholdfraction-check.md
@@ -1,0 +1,2 @@
+- Allow a `TrustThresholdFraction` of 1  
+  ([#1208](https://github.com/informalsystems/tendermint-rs/issues/1208))

--- a/tendermint/proptest-regressions/trust_threshold.txt
+++ b/tendermint/proptest-regressions/trust_threshold.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5f12a01ebfd5d2efb4e16c1267e4d876465cfa3294d159abf2051d5aba03f74c # shrinks to num = 1

--- a/tendermint/src/trust_threshold.rs
+++ b/tendermint/src/trust_threshold.rs
@@ -54,7 +54,7 @@ impl TrustThresholdFraction {
     /// The parameters are valid iff `1/3 <= numerator/denominator < 1`.
     /// In any other case we return an error.
     pub fn new(numerator: u64, denominator: u64) -> Result<Self, Error> {
-        if numerator >= denominator {
+        if numerator > denominator {
             return Err(Error::trust_threshold_too_large());
         }
         if denominator == 0 {

--- a/tendermint/src/trust_threshold.rs
+++ b/tendermint/src/trust_threshold.rs
@@ -51,7 +51,7 @@ impl TrustThresholdFraction {
     /// Instantiate a TrustThresholdFraction if the given denominator and
     /// numerator are valid.
     ///
-    /// The parameters are valid iff `1/3 <= numerator/denominator < 1`.
+    /// The parameters are valid iff `1/3 <= numerator/denominator <= 1`.
     /// In any other case we return an error.
     pub fn new(numerator: u64, denominator: u64) -> Result<Self, Error> {
         if numerator > denominator {

--- a/tendermint/src/trust_threshold.rs
+++ b/tendermint/src/trust_threshold.rs
@@ -160,12 +160,6 @@ mod test {
         }
 
         #[test]
-        fn cannot_be_one(num in 1..1000u64) {
-            assert!(TrustThresholdFraction::new(num, num).is_err());
-            assert!(from_json(num, num).is_err());
-        }
-
-        #[test]
         fn undefined(num in 1..1000u64) {
             // Numerator should be irrelevant
             let denom = 0u64;
@@ -190,6 +184,12 @@ mod test {
             let frac = from_json(num, denom).unwrap();
             assert_eq!(frac.numerator(), num);
             assert_eq!(frac.denominator(), denom);
+        }
+
+        #[test]
+        fn can_be_one(num in 1..1000u64) {
+            assert!(TrustThresholdFraction::new(num, num).is_ok());
+            assert!(from_json(num, num).is_ok());
         }
     }
 }


### PR DESCRIPTION
Closes: #1208 

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
