### PR TITLE
Add crypto provider

### DIFF
--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -33,5 +33,9 @@ serde = { version = "1.0.106", default-features = false }
 time = { version = "0.3", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
+k256 = { version = "0.11", default-features = false, features = ["ecdsa", "sha256"] }
+digest = { version = "0.10", default-features = false }
+ed25519 = { version = "1.3", default-features = false }
+
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen", default-features = false }

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -36,6 +36,7 @@ flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "sha256"] }
 digest = { version = "0.10", default-features = false }
 ed25519 = { version = "1.3", default-features = false }
+signature = { version = "1", default-features = false }
 
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen", default-features = false }

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -39,3 +39,5 @@ ed25519 = { version = "1.3", default-features = false }
 
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen", default-features = false }
+sha2 = { version = "0.9", default-features = false }
+

--- a/light-client-verifier/src/host_functions.rs
+++ b/light-client-verifier/src/host_functions.rs
@@ -42,6 +42,16 @@ mod tests {
 
     impl<D: Digest, S: signature::Signature> DigestVerifier<D, S> for SubstrateSignatureVerifier<D> {
         fn verify_digest(&self, digest: D, signature: &S) -> Result<(), ed25519::Error> {
+            // TODO; having issues here
+            /*
+                        error[E0277]: the trait bound `VerifyingKey: DigestVerifier<D, _>` is not satisfied
+              --> light-client-verifier/src/host_functions.rs:46:38
+               |
+            46 |             self.inner.verify_digest(digest, signature)
+               |                        ------------- ^^^^^^ the trait `DigestVerifier<D, _>` is not implemented for `VerifyingKey`
+               |                        |
+               |                        required by a bound introduced by this call
+                         */
             self.inner.verify_digest(digest, signature)
         }
     }
@@ -102,7 +112,6 @@ mod tests {
             // Self::secp256k1_verify(sig, message, public)
             let verifier =
                 <<Self as CryptoProvider>::EcdsaSecp256k1Verifier>::from_bytes(public).unwrap();
-            // TODO: probably should name the verifier properly - not sure how to do it better
             let signature = k256::ecdsa::Signature::from_der(sig).unwrap();
             Ok(verifier.verify(message, &signature).unwrap())
         }

--- a/light-client-verifier/src/host_functions.rs
+++ b/light-client-verifier/src/host_functions.rs
@@ -6,9 +6,65 @@ use tendermint::signature::Verifier;
 pub trait CryptoProvider {
     type Sha256: Digest + FixedOutput<OutputSize = U32>;
 
-    type EcdsaSecp256k1Signer: Signer<k256::ecdsa::Signature>;
-    type EcdsaSecp256k1Verifier: Verifier<k256::ecdsa::Signature>;
+    // type EcdsaSecp256k1Signer: Signer<k256::ecdsa::Signature>;
+    // type EcdsaSecp256k1Verifier: Verifier<k256::ecdsa::Signature>;
 
-    type Ed25519Signer: Signer<ed25519::Signature>;
-    type Ed25519Verifier: Verifier<ed25519::Signature>;
+    // type Ed25519Signer: Signer<ed25519::Signature>;
+    // type Ed25519Verifier: Verifier<ed25519::Signature>;
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    struct SubstrateHostFunctionsManager;
+
+    trait SubstrateHostFunctions: CryptoProvider {
+        fn sha2_256(preimage: &[u8]) -> [u8; 32];
+        fn ed25519_verify(sig: &[u8], msg: &[u8], pub_key: &[u8]) -> Result<(), ()>;
+        fn secp256k1_verify(sig: &[u8], message: &[u8], public: &[u8]) -> Result<(), ()>;
+    }
+
+    impl SubstrateHostFunctionsManager for SubstrateHostFunctions {
+        type Sha256 = sha2::Sha256;
+
+        fn sha2_256(preimage: &[u8]) -> [u8; 32] {
+            unimplemented!()
+        }
+        fn ed25519_verify(sig: &[u8], msg: &[u8], pub_key: &[u8]) -> Result<(), ()> {
+            unimplemented!()
+        }
+        fn secp256k1_verify(sig: &[u8], message: &[u8], public: &[u8]) -> Result<(), ()> {
+            unimplemented!()
+        }
+    }
+
+    // impl CryptoProvider for CryptoManager {
+    //     fn sha2_256(preimage: &[u8]) -> [u8; 32] {
+    //         sp_core::hashing::sha2_256(preimage)
+    //     }
+
+    //     fn ed25519_verify(sig: &[u8], msg: &[u8], pub_key: &[u8]) -> Result<(), ()> {
+    //         use sp_core::{ed25519, ByteArray, Pair};
+
+    //         let signature = ed25519::Signature::from_slice(sig).ok_or(())?;
+
+    //         let public_key = ed25519::Public::from_slice(pub_key).map_err(|_| ())?;
+    //         if ed25519::Pair::verify(&signature, msg, &public_key) {
+    //             return Ok(());
+    //         }
+    //         Err(())
+    //     }
+
+    //     fn secp256k1_verify(sig: &[u8], message: &[u8], public: &[u8]) -> Result<(), ()> {
+    //         use sp_core::{ecdsa, ByteArray, Pair};
+
+    //         let public = ecdsa::Public::from_slice(public).map_err(|_| ())?;
+    //         if ecdsa::Pair::verify_weak(&sig, message, &public) {
+    //             return Ok(());
+    //         }
+
+    //         Err(())
+    //     }
+    // }
 }

--- a/light-client-verifier/src/host_functions.rs
+++ b/light-client-verifier/src/host_functions.rs
@@ -1,0 +1,14 @@
+use digest::FixedOutput;
+use digest::{consts::U32, Digest};
+use tendermint::signature::Signer;
+use tendermint::signature::Verifier;
+
+pub trait CryptoProvider {
+    type Sha256: Digest + FixedOutput<OutputSize = U32>;
+
+    type EcdsaSecp256k1Signer: Signer<k256::ecdsa::Signature>;
+    type EcdsaSecp256k1Verifier: Verifier<k256::ecdsa::Signature>;
+
+    type Ed25519Signer: Signer<ed25519::Signature>;
+    type Ed25519Verifier: Verifier<ed25519::Signature>;
+}

--- a/light-client-verifier/src/host_functions.rs
+++ b/light-client-verifier/src/host_functions.rs
@@ -16,8 +16,9 @@ pub trait CryptoProvider {
 #[cfg(test)]
 mod tests {
 
+    /// A draft for an imlpementation of the HostFunctionManager for a specific chain (i.e. Polkadot/Substrate)
+    /// that uses the [`CryptoProvider`] trait
     use core::marker::PhantomData;
-
     use signature::{DigestSigner, DigestVerifier};
 
     use super::*;

--- a/light-client-verifier/src/lib.rs
+++ b/light-client-verifier/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 mod prelude;
 
 pub mod errors;
+pub mod host_functions;
 pub mod operations;
 pub mod options;
 pub mod predicates;


### PR DESCRIPTION
Draft definition of the `CryptoProvider` trait defined in #1213 + an actual instance of the trait
for a `HostFunction*` implementation