### PR TITLE
chore: Fix clippy lints for Rust 1.65

### DIFF
--- a/light-client-verifier/src/operations/commit_validator.rs
+++ b/light-client-verifier/src/operations/commit_validator.rs
@@ -93,7 +93,7 @@ impl CommitValidator for ProdCommitValidator {
                 } => validator_address,
             };
 
-            if validator_set.validator(*validator_address) == None {
+            if validator_set.validator(*validator_address).is_none() {
                 return Err(VerificationError::faulty_signer(
                     *validator_address,
                     self.hasher.hash_validator_set(validator_set),

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -83,7 +83,7 @@ impl Handshake<AwaitingEphKey> {
         protocol_version: Version,
     ) -> (Self, EphemeralPublic) {
         // Generate an ephemeral key for perfect forward secrecy.
-        let local_eph_privkey = EphemeralSecret::new(&mut OsRng);
+        let local_eph_privkey = EphemeralSecret::new(OsRng);
         let local_eph_pubkey = EphemeralPublic::from(&local_eph_privkey);
 
         (

--- a/proto/tests/unit.rs
+++ b/proto/tests/unit.rs
@@ -22,7 +22,7 @@ impl TryFrom<RawBlockId> for BlockId {
         Ok(BlockId {
             hash: String::from_utf8(value.hash)
                 .map_err(|_| "Could not convert vector to string")?,
-            part_set_header_exists: value.part_set_header != None,
+            part_set_header_exists: value.part_set_header.is_some(),
         })
     }
 }

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -256,7 +256,7 @@ mod tests {
             // If `from_value` is the inverse of `to_value`, then it will always
             // map the JSON `encoded_time` to back to the inital `time`.
             let time: Time = datetime.try_into().unwrap();
-            let json_encoded_time = serde_json::to_value(&time).unwrap();
+            let json_encoded_time = serde_json::to_value(time).unwrap();
             let decoded_time: Time = serde_json::from_value(json_encoded_time).unwrap();
             prop_assert_eq!(time, decoded_time);
         }
@@ -273,7 +273,7 @@ mod tests {
             // arbitrarily generated textual timestamps, rather than times in a
             // range. Tho we do incidentally test the inversion as well.
             let time: Time = stamp.parse().unwrap();
-            let json_encoded_time = serde_json::to_value(&time).unwrap();
+            let json_encoded_time = serde_json::to_value(time).unwrap();
             let decoded_time: Time = serde_json::from_value(json_encoded_time).unwrap();
             prop_assert_eq!(time, decoded_time);
         }

--- a/testgen/src/commit.rs
+++ b/testgen/src/commit.rs
@@ -126,7 +126,7 @@ impl Generator<block::Commit> for Commit {
 
         let vote_to_sig = |v: &Vote| -> Result<block::CommitSig, SimpleError> {
             let vote = v.generate()?;
-            if vote.block_id == None {
+            if vote.block_id.is_none() {
                 Ok(block::CommitSig::BlockIdFlagNil {
                     validator_address: vote.validator_address,
                     timestamp: vote.timestamp.unwrap(),

--- a/testgen/src/tester.rs
+++ b/testgen/src/tester.rs
@@ -300,7 +300,7 @@ impl Tester {
                 let output_dir = output_env.full_path(path);
                 let output_env = TestEnv::new(output_dir.to_str().unwrap()).unwrap();
                 test(test_case, &env, &test_env, &output_env);
-                fs::remove_dir_all(&env.current_dir()).unwrap();
+                fs::remove_dir_all(env.current_dir()).unwrap();
             }),
             Err(e) => ParseError(e),
         };


### PR DESCRIPTION
A few minor clippy nits.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
