### PR TITLE
tendermint-proto: (re-)add `grpc` feature and server definitions

### DIFF
--- a/.changelog/unreleased/features/1227-proto-grpc.md
+++ b/.changelog/unreleased/features/1227-proto-grpc.md
@@ -1,0 +1,2 @@
+- `[tendermint-proto]` Add `grpc` feature and generate gRPC server definitions
+  ([#1227](https://github.com/informalsystems/tendermint-rs/issues/1227))

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -16,6 +16,10 @@ description = """
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = []
+grpc = ["tonic"]
+
 [dependencies]
 prost = { version = "0.11", default-features = false }
 prost-types = { version = "0.11", default-features = false }
@@ -27,6 +31,7 @@ num-traits = { version = "0.2", default-features = false }
 num-derive = { version = "0.3", default-features = false }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 flex-error = { version = "0.4.4", default-features = false }
+tonic = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,6 +1,6 @@
 //! tendermint-proto library gives the developer access to the Tendermint proto-defined structs.
 
-#![no_std]
+#![cfg_attr(not(feature = "grpc"), no_std)]
 #![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant)]
 #![forbid(unsafe_code)]

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -633,3 +633,691 @@ impl EvidenceType {
         }
     }
 }
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod abci_application_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with AbciApplicationServer.
+    #[async_trait]
+    pub trait AbciApplication: Send + Sync + 'static {
+        async fn echo(
+            &self,
+            request: tonic::Request<super::RequestEcho>,
+        ) -> Result<tonic::Response<super::ResponseEcho>, tonic::Status>;
+        async fn flush(
+            &self,
+            request: tonic::Request<super::RequestFlush>,
+        ) -> Result<tonic::Response<super::ResponseFlush>, tonic::Status>;
+        async fn info(
+            &self,
+            request: tonic::Request<super::RequestInfo>,
+        ) -> Result<tonic::Response<super::ResponseInfo>, tonic::Status>;
+        async fn deliver_tx(
+            &self,
+            request: tonic::Request<super::RequestDeliverTx>,
+        ) -> Result<tonic::Response<super::ResponseDeliverTx>, tonic::Status>;
+        async fn check_tx(
+            &self,
+            request: tonic::Request<super::RequestCheckTx>,
+        ) -> Result<tonic::Response<super::ResponseCheckTx>, tonic::Status>;
+        async fn query(
+            &self,
+            request: tonic::Request<super::RequestQuery>,
+        ) -> Result<tonic::Response<super::ResponseQuery>, tonic::Status>;
+        async fn commit(
+            &self,
+            request: tonic::Request<super::RequestCommit>,
+        ) -> Result<tonic::Response<super::ResponseCommit>, tonic::Status>;
+        async fn init_chain(
+            &self,
+            request: tonic::Request<super::RequestInitChain>,
+        ) -> Result<tonic::Response<super::ResponseInitChain>, tonic::Status>;
+        async fn begin_block(
+            &self,
+            request: tonic::Request<super::RequestBeginBlock>,
+        ) -> Result<tonic::Response<super::ResponseBeginBlock>, tonic::Status>;
+        async fn end_block(
+            &self,
+            request: tonic::Request<super::RequestEndBlock>,
+        ) -> Result<tonic::Response<super::ResponseEndBlock>, tonic::Status>;
+        async fn list_snapshots(
+            &self,
+            request: tonic::Request<super::RequestListSnapshots>,
+        ) -> Result<tonic::Response<super::ResponseListSnapshots>, tonic::Status>;
+        async fn offer_snapshot(
+            &self,
+            request: tonic::Request<super::RequestOfferSnapshot>,
+        ) -> Result<tonic::Response<super::ResponseOfferSnapshot>, tonic::Status>;
+        async fn load_snapshot_chunk(
+            &self,
+            request: tonic::Request<super::RequestLoadSnapshotChunk>,
+        ) -> Result<tonic::Response<super::ResponseLoadSnapshotChunk>, tonic::Status>;
+        async fn apply_snapshot_chunk(
+            &self,
+            request: tonic::Request<super::RequestApplySnapshotChunk>,
+        ) -> Result<tonic::Response<super::ResponseApplySnapshotChunk>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct AbciApplicationServer<T: AbciApplication> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: AbciApplication> AbciApplicationServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for AbciApplicationServer<T>
+    where
+        T: AbciApplication,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/tendermint.abci.ABCIApplication/Echo" => {
+                    #[allow(non_camel_case_types)]
+                    struct EchoSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestEcho> for EchoSvc<T> {
+                        type Response = super::ResponseEcho;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestEcho>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).echo(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = EchoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/Flush" => {
+                    #[allow(non_camel_case_types)]
+                    struct FlushSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestFlush> for FlushSvc<T> {
+                        type Response = super::ResponseFlush;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestFlush>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).flush(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FlushSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/Info" => {
+                    #[allow(non_camel_case_types)]
+                    struct InfoSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestInfo> for InfoSvc<T> {
+                        type Response = super::ResponseInfo;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestInfo>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).info(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = InfoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/DeliverTx" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeliverTxSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestDeliverTx>
+                    for DeliverTxSvc<T> {
+                        type Response = super::ResponseDeliverTx;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestDeliverTx>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).deliver_tx(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeliverTxSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/CheckTx" => {
+                    #[allow(non_camel_case_types)]
+                    struct CheckTxSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestCheckTx>
+                    for CheckTxSvc<T> {
+                        type Response = super::ResponseCheckTx;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestCheckTx>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).check_tx(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CheckTxSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/Query" => {
+                    #[allow(non_camel_case_types)]
+                    struct QuerySvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestQuery> for QuerySvc<T> {
+                        type Response = super::ResponseQuery;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestQuery>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).query(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = QuerySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/Commit" => {
+                    #[allow(non_camel_case_types)]
+                    struct CommitSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestCommit>
+                    for CommitSvc<T> {
+                        type Response = super::ResponseCommit;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestCommit>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).commit(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CommitSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/InitChain" => {
+                    #[allow(non_camel_case_types)]
+                    struct InitChainSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestInitChain>
+                    for InitChainSvc<T> {
+                        type Response = super::ResponseInitChain;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestInitChain>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).init_chain(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = InitChainSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/BeginBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct BeginBlockSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestBeginBlock>
+                    for BeginBlockSvc<T> {
+                        type Response = super::ResponseBeginBlock;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestBeginBlock>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).begin_block(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = BeginBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/EndBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct EndBlockSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestEndBlock>
+                    for EndBlockSvc<T> {
+                        type Response = super::ResponseEndBlock;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestEndBlock>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).end_block(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = EndBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/ListSnapshots" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListSnapshotsSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestListSnapshots>
+                    for ListSnapshotsSvc<T> {
+                        type Response = super::ResponseListSnapshots;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestListSnapshots>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).list_snapshots(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ListSnapshotsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/OfferSnapshot" => {
+                    #[allow(non_camel_case_types)]
+                    struct OfferSnapshotSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestOfferSnapshot>
+                    for OfferSnapshotSvc<T> {
+                        type Response = super::ResponseOfferSnapshot;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestOfferSnapshot>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).offer_snapshot(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = OfferSnapshotSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/LoadSnapshotChunk" => {
+                    #[allow(non_camel_case_types)]
+                    struct LoadSnapshotChunkSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestLoadSnapshotChunk>
+                    for LoadSnapshotChunkSvc<T> {
+                        type Response = super::ResponseLoadSnapshotChunk;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestLoadSnapshotChunk>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).load_snapshot_chunk(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = LoadSnapshotChunkSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.abci.ABCIApplication/ApplySnapshotChunk" => {
+                    #[allow(non_camel_case_types)]
+                    struct ApplySnapshotChunkSvc<T: AbciApplication>(pub Arc<T>);
+                    impl<
+                        T: AbciApplication,
+                    > tonic::server::UnaryService<super::RequestApplySnapshotChunk>
+                    for ApplySnapshotChunkSvc<T> {
+                        type Response = super::ResponseApplySnapshotChunk;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestApplySnapshotChunk>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).apply_snapshot_chunk(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ApplySnapshotChunkSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: AbciApplication> Clone for AbciApplicationServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: AbciApplication> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: AbciApplication> tonic::transport::NamedService
+    for AbciApplicationServer<T> {
+        const NAME: &'static str = "tendermint.abci.ABCIApplication";
+    }
+}

--- a/proto/src/prost/tendermint.privval.rs
+++ b/proto/src/prost/tendermint.privval.rs
@@ -112,3 +112,227 @@ impl Errors {
         }
     }
 }
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod priv_validator_api_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with PrivValidatorApiServer.
+    #[async_trait]
+    pub trait PrivValidatorApi: Send + Sync + 'static {
+        async fn get_pub_key(
+            &self,
+            request: tonic::Request<super::PubKeyRequest>,
+        ) -> Result<tonic::Response<super::PubKeyResponse>, tonic::Status>;
+        async fn sign_vote(
+            &self,
+            request: tonic::Request<super::SignVoteRequest>,
+        ) -> Result<tonic::Response<super::SignedVoteResponse>, tonic::Status>;
+        async fn sign_proposal(
+            &self,
+            request: tonic::Request<super::SignProposalRequest>,
+        ) -> Result<tonic::Response<super::SignedProposalResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct PrivValidatorApiServer<T: PrivValidatorApi> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: PrivValidatorApi> PrivValidatorApiServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for PrivValidatorApiServer<T>
+    where
+        T: PrivValidatorApi,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/tendermint.privval.PrivValidatorAPI/GetPubKey" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetPubKeySvc<T: PrivValidatorApi>(pub Arc<T>);
+                    impl<
+                        T: PrivValidatorApi,
+                    > tonic::server::UnaryService<super::PubKeyRequest>
+                    for GetPubKeySvc<T> {
+                        type Response = super::PubKeyResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::PubKeyRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).get_pub_key(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetPubKeySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.privval.PrivValidatorAPI/SignVote" => {
+                    #[allow(non_camel_case_types)]
+                    struct SignVoteSvc<T: PrivValidatorApi>(pub Arc<T>);
+                    impl<
+                        T: PrivValidatorApi,
+                    > tonic::server::UnaryService<super::SignVoteRequest>
+                    for SignVoteSvc<T> {
+                        type Response = super::SignedVoteResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SignVoteRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).sign_vote(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SignVoteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.privval.PrivValidatorAPI/SignProposal" => {
+                    #[allow(non_camel_case_types)]
+                    struct SignProposalSvc<T: PrivValidatorApi>(pub Arc<T>);
+                    impl<
+                        T: PrivValidatorApi,
+                    > tonic::server::UnaryService<super::SignProposalRequest>
+                    for SignProposalSvc<T> {
+                        type Response = super::SignedProposalResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SignProposalRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).sign_proposal(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SignProposalSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: PrivValidatorApi> Clone for PrivValidatorApiServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: PrivValidatorApi> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: PrivValidatorApi> tonic::transport::NamedService
+    for PrivValidatorApiServer<T> {
+        const NAME: &'static str = "tendermint.privval.PrivValidatorAPI";
+    }
+}

--- a/proto/src/prost/tendermint.rpc.grpc.rs
+++ b/proto/src/prost/tendermint.rpc.grpc.rs
@@ -22,3 +22,182 @@ pub struct ResponseBroadcastTx {
     #[prost(message, optional, tag="2")]
     pub deliver_tx: ::core::option::Option<super::super::abci::ResponseDeliverTx>,
 }
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod broadcast_api_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with BroadcastApiServer.
+    #[async_trait]
+    pub trait BroadcastApi: Send + Sync + 'static {
+        async fn ping(
+            &self,
+            request: tonic::Request<super::RequestPing>,
+        ) -> Result<tonic::Response<super::ResponsePing>, tonic::Status>;
+        async fn broadcast_tx(
+            &self,
+            request: tonic::Request<super::RequestBroadcastTx>,
+        ) -> Result<tonic::Response<super::ResponseBroadcastTx>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct BroadcastApiServer<T: BroadcastApi> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: BroadcastApi> BroadcastApiServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for BroadcastApiServer<T>
+    where
+        T: BroadcastApi,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/tendermint.rpc.grpc.BroadcastAPI/Ping" => {
+                    #[allow(non_camel_case_types)]
+                    struct PingSvc<T: BroadcastApi>(pub Arc<T>);
+                    impl<T: BroadcastApi> tonic::server::UnaryService<super::RequestPing>
+                    for PingSvc<T> {
+                        type Response = super::ResponsePing;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestPing>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).ping(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = PingSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/tendermint.rpc.grpc.BroadcastAPI/BroadcastTx" => {
+                    #[allow(non_camel_case_types)]
+                    struct BroadcastTxSvc<T: BroadcastApi>(pub Arc<T>);
+                    impl<
+                        T: BroadcastApi,
+                    > tonic::server::UnaryService<super::RequestBroadcastTx>
+                    for BroadcastTxSvc<T> {
+                        type Response = super::ResponseBroadcastTx;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestBroadcastTx>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).broadcast_tx(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = BroadcastTxSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: BroadcastApi> Clone for BroadcastApiServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: BroadcastApi> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: BroadcastApi> tonic::transport::NamedService for BroadcastApiServer<T> {
+        const NAME: &'static str = "tendermint.rpc.grpc.BroadcastAPI";
+    }
+}

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -11,3 +11,4 @@ prost-build     = { version = "0.11" }
 git2            = { version = "0.13" }
 tempfile        = { version = "3.2.0" }
 subtle-encoding = { version = "0.5" }
+tonic-build     = { version = "0.8" }

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -80,7 +80,15 @@ fn main() {
         "super::super::google::protobuf::Timestamp",
     );
     println!("[info] => Creating structs.");
-    pb.compile_protos(&protos, &proto_includes_paths).unwrap();
+    tonic_build::configure()
+        .out_dir(&out_dir)
+        .build_client(false)
+        .build_server(true)
+        .server_mod_attribute("tendermint.abci", "#[cfg(feature = \"grpc\")]")
+        .server_mod_attribute("tendermint.privval", "#[cfg(feature = \"grpc\")]")
+        .server_mod_attribute("tendermint.rpc.grpc", "#[cfg(feature = \"grpc\")]")
+        .compile_with_config(pb, &protos, &proto_includes_paths)
+        .unwrap();
 
     println!("[info] => Removing old structs and copying new structs.");
     copy_files(&out_dir, &target_dir); // This panics if it fails.


### PR DESCRIPTION
See #1225.

Adds a "grpc" feature to the crate along with gRPC server definitions for the "privval" interface used by e.g. TMKMS to support remote signing.

These were originally added in #1137 by @tomtau but lost in the shuffle of Tendermint v0.35-related changes.

They have been updated to use `tonic` v0.8, which the `tendermint-proto` crate updated to after the original #1137 PR landed.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
