### PR TITLE
Decouple tendermint-rpc from tendermint-proto

### DIFF
--- a/.changelog/unreleased/breaking-changes/1234-decouple-rpc-from-proto.md
+++ b/.changelog/unreleased/breaking-changes/1234-decouple-rpc-from-proto.md
@@ -1,0 +1,5 @@
+- `[tendermint]` Rename `merkle::proof::Proof` to `ProofOps`
+  ([#1234](https://github.com/informalsystems/tendermint-rs/pull/1234))
+- `[tendermint-rpc]` Change the type of `/tx` response field `proof`
+  to `tendermint::tx::Proof`
+  ([#1233](https://github.com/informalsystems/tendermint-rs/issues/1233))

--- a/.changelog/unreleased/improvements/1234-decouple-rpc-from-proto.md
+++ b/.changelog/unreleased/improvements/1234-decouple-rpc-from-proto.md
@@ -1,0 +1,3 @@
+- `[tendermint]` Add domain types `merkle::Proof` and `tx::Proof`,
+  to represent protobuf messages `crypto.Proof` and `types.TxProof` respectively
+  ([#1234](https://github.com/informalsystems/tendermint-rs/pull/1234))

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -71,7 +71,6 @@ serde_bytes = { version = "0.11", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 tendermint-config = { version = "0.26.0", path = "../config", default-features = false }
 tendermint = { version = "0.26.0", default-features = false, path = "../tendermint" }
-tendermint-proto = { version = "0.26.0", default-features = false, path = "../proto" }
 thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 uuid = { version = "0.8", default-features = false }

--- a/rpc/src/endpoint/abci_query.rs
+++ b/rpc/src/endpoint/abci_query.rs
@@ -1,7 +1,7 @@
 //! `/abci_query` endpoint JSON-RPC wrapper
 
 use serde::{Deserialize, Serialize};
-use tendermint::{abci::Code, block, merkle::proof::Proof, serializers};
+use tendermint::{abci::Code, block, merkle::proof::ProofOps, serializers};
 
 use crate::prelude::*;
 
@@ -87,7 +87,7 @@ pub struct AbciQuery {
 
     /// Proof (might be explicit null)
     #[serde(alias = "proofOps")]
-    pub proof: Option<Proof>,
+    pub proof: Option<ProofOps>,
 
     /// Block height
     pub height: block::Height,

--- a/rpc/src/endpoint/block_search.rs
+++ b/rpc/src/endpoint/block_search.rs
@@ -3,15 +3,15 @@
 use serde::{Deserialize, Serialize};
 
 pub use super::{block, block_results};
-use crate::{prelude::*, Method, Order};
+use crate::{prelude::*, serializers, Method, Order};
 
 /// Request for searching for blocks by their BeginBlock and EndBlock events.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Request {
     pub query: String,
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub page: u32,
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub per_page: u8,
     pub order_by: Order,
 }
@@ -41,7 +41,7 @@ impl crate::SimpleRequest for Request {}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Response {
     pub blocks: Vec<block::Response>,
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub total_count: u32,
 }
 

--- a/rpc/src/endpoint/tx.rs
+++ b/rpc/src/endpoint/tx.rs
@@ -1,8 +1,7 @@
 //! `/tx` endpoint JSON-RPC wrapper
 
 use serde::{Deserialize, Serialize};
-use tendermint::{abci, block, Hash};
-use tendermint_proto::types::TxProof;
+use tendermint::{abci, block, tx, Hash};
 
 use crate::{prelude::*, serializers, Method};
 
@@ -51,7 +50,7 @@ pub struct Response {
     #[serde(with = "serializers::bytes::base64string")]
     pub tx: Vec<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proof: Option<TxProof>,
+    pub proof: Option<tx::Proof>,
 }
 
 impl crate::Response for Response {}

--- a/rpc/src/endpoint/tx_search.rs
+++ b/rpc/src/endpoint/tx_search.rs
@@ -3,16 +3,16 @@
 use serde::{Deserialize, Serialize};
 
 pub use super::tx;
-use crate::{prelude::*, Method, Order};
+use crate::{prelude::*, serializers, Method, Order};
 
 /// Request for searching for transactions with their results.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Request {
     pub query: String,
     pub prove: bool,
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub page: u32,
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub per_page: u8,
     pub order_by: Order,
 }
@@ -49,7 +49,7 @@ impl crate::SimpleRequest for Request {}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Response {
     pub txs: Vec<tx::Response>,
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub total_count: u32,
 }
 

--- a/rpc/src/endpoint/validators.rs
+++ b/rpc/src/endpoint/validators.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use tendermint::{block, validator};
 
-use crate::{prelude::*, PageNumber, PerPage};
+use crate::{prelude::*, serializers, PageNumber, PerPage};
 
 /// The default number of validators to return per page.
 pub const DEFAULT_VALIDATORS_PER_PAGE: u8 = 30;
@@ -16,10 +16,10 @@ pub struct Request {
     /// defaults to the latest height.
     pub height: Option<block::Height>,
     /// The number of the page to fetch.
-    #[serde(with = "tendermint_proto::serializers::optional_from_str")]
+    #[serde(with = "serializers::optional_from_str")]
     pub page: Option<PageNumber>,
     /// The number of validators to fetch per page.
-    #[serde(with = "tendermint_proto::serializers::optional_from_str")]
+    #[serde(with = "serializers::optional_from_str")]
     pub per_page: Option<PerPage>,
 }
 
@@ -64,7 +64,7 @@ pub struct Response {
     pub validators: Vec<validator::Info>,
 
     /// Total number of validators for this block height.
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub total: i32,
 }
 

--- a/rpc/src/event.rs
+++ b/rpc/src/event.rs
@@ -5,7 +5,7 @@ use alloc::collections::BTreeMap as HashMap;
 use serde::{Deserialize, Serialize};
 use tendermint::{abci, Block};
 
-use crate::{prelude::*, query::EventType, response::Wrapper, Response};
+use crate::{prelude::*, query::EventType, response::Wrapper, serializers, Response};
 
 /// An incoming event produced by a [`Subscription`].
 ///
@@ -59,10 +59,10 @@ pub enum EventData {
 /// Transaction result info.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct TxInfo {
-    #[serde(with = "tendermint_proto::serializers::from_str")]
+    #[serde(with = "serializers::from_str")]
     pub height: i64,
     pub index: Option<i64>,
-    #[serde(with = "tendermint_proto::serializers::bytes::base64string")]
+    #[serde(with = "serializers::bytes::base64string")]
     pub tx: Vec<u8>,
     pub result: TxResult,
 }

--- a/rpc/src/query.rs
+++ b/rpc/src/query.rs
@@ -6,14 +6,13 @@
 
 use core::{fmt, str::FromStr};
 
-use tendermint_proto::serializers::timestamp;
 use time::{
     format_description::well_known::Rfc3339,
     macros::{format_description, offset},
     Date, OffsetDateTime,
 };
 
-use crate::{prelude::*, Error};
+use crate::{prelude::*, serializers::timestamp, Error};
 
 /// A structured query for use in interacting with the Tendermint RPC event
 /// subscription system.

--- a/rpc/src/serializers.rs
+++ b/rpc/src/serializers.rs
@@ -5,7 +5,7 @@
 //! CAUTION: There are no guarantees for backwards compatibility, this module should be considered
 //! an internal implementation detail which can vanish without further warning. Use at your own
 //! risk.
-pub use tendermint_proto::serializers::*;
+pub use tendermint::serializers::*;
 
 pub mod opt_tm_hash_base64;
 pub mod tm_hash_base64;

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -1393,8 +1393,9 @@ fn incoming_fixtures() {
                     assert!(tx.tx_result.log.is_empty());
                     let proof = tx.proof.unwrap();
                     assert_eq!(proof.data, tx.tx);
-                    assert!(proof.proof.is_some());
-                    assert_ne!(proof.root_hash, [0; 32]);
+                    assert_eq!(proof.proof.total, 1);
+                    assert_eq!(proof.proof.index, 0);
+                    assert_ne!(proof.root_hash.as_bytes(), [0; 32]);
                 }
             },
             _ => {

--- a/tendermint/src/abci/response/query.rs
+++ b/tendermint/src/abci/response/query.rs
@@ -25,7 +25,7 @@ pub struct Query {
     pub value: Bytes,
     /// Serialized proof for the value data, if requested, to be verified against
     /// the app hash for the given `height`.
-    pub proof: Option<merkle::Proof>,
+    pub proof: Option<merkle::ProofOps>,
     /// The block height from which data was derived.
     ///
     /// Note that this is the height of the block containing the application's

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -220,6 +220,14 @@ define_error! {
 
         TrustThresholdTooSmall
             |_| { "trust threshold too small (must be >= 1/3)" },
+
+        NegativeProofTotal
+            [ DisplayOnly<TryFromIntError> ]
+            |_| { "negative number of items in proof" },
+
+        NegativeProofIndex
+            [ DisplayOnly<TryFromIntError> ]
+            |_| { "negative item index in proof" },
     }
 }
 

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -48,6 +48,7 @@ pub mod signature;
 pub mod time;
 mod timeout;
 pub mod trust_threshold;
+pub mod tx;
 pub mod validator;
 mod version;
 pub mod vote;

--- a/tendermint/src/merkle.rs
+++ b/tendermint/src/merkle.rs
@@ -2,6 +2,8 @@
 
 pub mod proof;
 
+pub use proof::Proof;
+
 use sha2::{Digest, Sha256};
 
 use crate::prelude::*;

--- a/tendermint/src/merkle/proof.rs
+++ b/tendermint/src/merkle/proof.rs
@@ -9,10 +9,10 @@ use tendermint_proto::{
 
 use crate::{prelude::*, serializers, Error};
 
-/// Proof is Merkle proof defined by the list of ProofOps
+/// Merkle proof defined by the list of ProofOps
 /// <https://github.com/tendermint/tendermint/blob/c8483531d8e756f7fbb812db1dd16d841cdf298a/crypto/merkle/merkle.proto#L26>
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
-pub struct Proof {
+pub struct ProofOps {
     /// The list of ProofOps
     pub ops: Vec<ProofOp>,
 }
@@ -58,9 +58,9 @@ impl From<ProofOp> for RawProofOp {
     }
 }
 
-impl Protobuf<RawProofOps> for Proof {}
+impl Protobuf<RawProofOps> for ProofOps {}
 
-impl TryFrom<RawProofOps> for Proof {
+impl TryFrom<RawProofOps> for ProofOps {
     type Error = Error;
 
     fn try_from(value: RawProofOps) -> Result<Self, Self::Error> {
@@ -70,8 +70,8 @@ impl TryFrom<RawProofOps> for Proof {
     }
 }
 
-impl From<Proof> for RawProofOps {
-    fn from(value: Proof) -> Self {
+impl From<ProofOps> for RawProofOps {
+    fn from(value: ProofOps) -> Self {
         let ops: Vec<RawProofOp> = value.ops.into_iter().map(RawProofOp::from).collect();
 
         RawProofOps { ops }
@@ -80,7 +80,7 @@ impl From<Proof> for RawProofOps {
 
 #[cfg(test)]
 mod test {
-    use super::Proof;
+    use super::ProofOps;
     use crate::test::test_serialization_roundtrip;
 
     #[test]
@@ -100,6 +100,6 @@ mod test {
                 }
             ]
         }"#;
-        test_serialization_roundtrip::<Proof>(payload);
+        test_serialization_roundtrip::<ProofOps>(payload);
     }
 }

--- a/tendermint/src/tx.rs
+++ b/tendermint/src/tx.rs
@@ -1,0 +1,3 @@
+mod proof;
+
+pub use proof::Proof;

--- a/tendermint/src/tx/proof.rs
+++ b/tendermint/src/tx/proof.rs
@@ -4,6 +4,7 @@ use tendermint_proto::Protobuf;
 
 use crate::{merkle, prelude::*, Error, Hash};
 
+/// Merkle proof of the presence of a transaction in the Merkle tree.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "RawTxProof", into = "RawTxProof")]
 pub struct Proof {

--- a/tendermint/src/tx/proof.rs
+++ b/tendermint/src/tx/proof.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+use tendermint_proto::types::TxProof as RawTxProof;
+use tendermint_proto::Protobuf;
+
+use crate::{merkle, prelude::*, Error, Hash};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "RawTxProof", into = "RawTxProof")]
+pub struct Proof {
+    pub root_hash: Hash,
+    pub data: Vec<u8>,
+    pub proof: merkle::Proof,
+}
+
+impl Protobuf<RawTxProof> for Proof {}
+
+impl TryFrom<RawTxProof> for Proof {
+    type Error = Error;
+
+    fn try_from(message: RawTxProof) -> Result<Self, Self::Error> {
+        Ok(Self {
+            root_hash: message.root_hash.try_into()?,
+            data: message.data,
+            proof: message.proof.ok_or_else(Error::missing_data)?.try_into()?,
+        })
+    }
+}
+
+impl From<Proof> for RawTxProof {
+    fn from(value: Proof) -> Self {
+        Self {
+            root_hash: value.root_hash.into(),
+            data: value.data,
+            proof: Some(value.proof.into()),
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #1233

Replace remaining use of `prost-build`-generated structs in `tendermint-rpc` with domain types newly defined in `tendermint`.

In `tendermint`, `merkle::proof::Proof` was named inconsistently with regard to protobuf, which has it as `crypto.ProofOps`, yet also the `crypto.Proof` message is defined, which we make use of now. Renamed that domain type to `ProofOps` to make way for the newly added `Proof`. 

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
