### PR TITLE
Remove async-trait from dependencies

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -30,7 +30,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-trait = { version = "0.1", default-features = false }
 bytes = { version = "1.0", default-features = false, features = ["serde"] }
 ed25519 = { version = "1.3", default-features = false }
 ed25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }


### PR DESCRIPTION
The macro is not used anywhere by tendermint,
let's speed up compile times by removing it from the build.