### PR TITLE
light-client-js: remove the syn version pin

### DIFF
--- a/.changelog/unreleased/improvements/1242-serde-wasm-bindgen.md
+++ b/.changelog/unreleased/improvements/1242-serde-wasm-bindgen.md
@@ -1,0 +1,2 @@
+- `[tendermint-light-client-js]` Switch to serde-wasm-bindgen for marshalling
+  JS values ([#1242](https://github.com/informalsystems/tendermint-rs/pull/1242))

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -22,8 +22,6 @@ default = ["console_error_panic_hook"]
 [dependencies]
 serde = { version = "1.0", default-features = false, features = [ "derive" ] }
 serde_json = { version = "1.0", default-features = false }
-# TODO(thane): Remove once https://github.com/rustwasm/wasm-bindgen/issues/2508 is resolved
-syn = { version = "=1.0.65", default-features = false }
 tendermint = { version = "0.27.0", default-features = false, path = "../tendermint" }
 tendermint-light-client-verifier = { version = "0.27.0", default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { version = "1.0", default-features = false }
 tendermint = { version = "0.27.0", default-features = false, path = "../tendermint" }
 tendermint-light-client-verifier = { version = "0.27.0", default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }
+serde-wasm-bindgen = { version = "0.4.5", default-features = false }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -24,22 +24,18 @@ use wasm_bindgen::{prelude::*, JsValue};
 
 /// Check whether a given untrusted block can be trusted.
 #[wasm_bindgen]
-pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &JsValue) -> JsValue {
-    let result = deserialize_params(
-        untrusted.clone(),
-        trusted.clone(),
-        options.clone(),
-        now.clone(),
-    )
-    .map(|(untrusted, trusted, options, now)| {
-        let verifier = ProdVerifier::default();
-        verifier.verify(
-            untrusted.as_untrusted_state(),
-            trusted.as_trusted_state(),
-            &options,
-            now,
-        )
-    });
+pub fn verify(untrusted: JsValue, trusted: JsValue, options: JsValue, now: JsValue) -> JsValue {
+    let result = deserialize_params(untrusted, trusted, options, now).map(
+        |(untrusted, trusted, options, now)| {
+            let verifier = ProdVerifier::default();
+            verifier.verify(
+                untrusted.as_untrusted_state(),
+                trusted.as_trusted_state(),
+                &options,
+                now,
+            )
+        },
+    );
     serde_wasm_bindgen::to_value(&result).unwrap()
 }
 

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -25,46 +25,50 @@ use wasm_bindgen::{prelude::*, JsValue};
 /// Check whether a given untrusted block can be trusted.
 #[wasm_bindgen]
 pub fn verify(untrusted: &JsValue, trusted: &JsValue, options: &JsValue, now: &JsValue) -> JsValue {
-    let result = deserialize_params(untrusted, trusted, options, now).map(
-        |(untrusted, trusted, options, now)| {
-            let verifier = ProdVerifier::default();
-            verifier.verify(
-                untrusted.as_untrusted_state(),
-                trusted.as_trusted_state(),
-                &options,
-                now,
-            )
-        },
-    );
-    JsValue::from_serde(&result).unwrap()
+    let result = deserialize_params(
+        untrusted.clone(),
+        trusted.clone(),
+        options.clone(),
+        now.clone(),
+    )
+    .map(|(untrusted, trusted, options, now)| {
+        let verifier = ProdVerifier::default();
+        verifier.verify(
+            untrusted.as_untrusted_state(),
+            trusted.as_trusted_state(),
+            &options,
+            now,
+        )
+    });
+    serde_wasm_bindgen::to_value(&result).unwrap()
 }
 
 fn deserialize_params(
-    untrusted: &JsValue,
-    trusted: &JsValue,
-    options: &JsValue,
-    now: &JsValue,
+    untrusted: JsValue,
+    trusted: JsValue,
+    options: JsValue,
+    now: JsValue,
 ) -> Result<(LightBlock, LightBlock, Options, Time), Error> {
-    let untrusted = untrusted.into_serde().map_err(|e| Error::Serialization {
-        param: "untrusted".to_string(),
-        msg: e.to_string(),
-    })?;
-
-    let trusted = trusted.into_serde().map_err(|e| Error::Serialization {
-        param: "trusted".to_string(),
-        msg: e.to_string(),
-    })?;
-
-    let options = options
-        .into_serde::<JsOptions>()
-        .map(Into::into)
-        .map_err(|e| Error::Serialization {
-            param: "options".to_string(),
+    let untrusted =
+        serde_wasm_bindgen::from_value(untrusted).map_err(|e| Error::Serialization {
+            param: "untrusted".into(),
             msg: e.to_string(),
         })?;
 
-    let now = now.into_serde().map_err(|e| Error::Serialization {
-        param: "now".to_string(),
+    let trusted = serde_wasm_bindgen::from_value(trusted).map_err(|e| Error::Serialization {
+        param: "trusted".into(),
+        msg: e.to_string(),
+    })?;
+
+    let options = serde_wasm_bindgen::from_value::<JsOptions>(options)
+        .map(Into::into)
+        .map_err(|e| Error::Serialization {
+            param: "options".into(),
+            msg: e.to_string(),
+        })?;
+
+    let now = serde_wasm_bindgen::from_value(now).map_err(|e| Error::Serialization {
+        param: "now".into(),
         msg: e.to_string(),
     })?;
 

--- a/light-client-js/tests/web.rs
+++ b/light-client-js/tests/web.rs
@@ -163,7 +163,7 @@ fn successful_verification() {
     let now =
         serde_wasm_bindgen::to_value(&Time::parse_from_rfc3339("1970-01-07T00:00:00Z").unwrap())
             .unwrap();
-    let js_result = verify(&untrusted_block, &trusted_block, &options, &now);
+    let js_result = verify(untrusted_block, trusted_block, options, now);
     console_log!("js_result = {:?}", js_result);
     let verdict = serde_wasm_bindgen::from_value::<Result<Verdict, Error>>(js_result)
         .unwrap()
@@ -179,7 +179,7 @@ fn failed_verification_outside_trusting_period() {
     let now =
         serde_wasm_bindgen::to_value(&Time::parse_from_rfc3339("1970-01-16T00:00:00Z").unwrap())
             .unwrap();
-    let js_result = verify(&untrusted_block, &trusted_block, &options, &now);
+    let js_result = verify(untrusted_block, trusted_block, options, now);
     console_log!("js_result = {:?}", js_result);
     // The result is Ok because we successfully obtained a verdict, even if the
     // verdict isn't Verdict::Success.

--- a/light-client-js/tests/web.rs
+++ b/light-client-js/tests/web.rs
@@ -161,10 +161,11 @@ fn successful_verification() {
     let options = test_options();
     // Choose a "now" value within the trusting period
     let now =
-        JsValue::from_serde(&Time::parse_from_rfc3339("1970-01-07T00:00:00Z").unwrap()).unwrap();
+        serde_wasm_bindgen::to_value(&Time::parse_from_rfc3339("1970-01-07T00:00:00Z").unwrap())
+            .unwrap();
     let js_result = verify(&untrusted_block, &trusted_block, &options, &now);
     console_log!("js_result = {:?}", js_result);
-    let verdict = JsValue::into_serde::<Result<Verdict, Error>>(&js_result)
+    let verdict = serde_wasm_bindgen::from_value::<Result<Verdict, Error>>(js_result)
         .unwrap()
         .unwrap();
     assert_eq!(verdict, Verdict::Success);
@@ -176,12 +177,13 @@ fn failed_verification_outside_trusting_period() {
     let options = test_options();
     // Choose a "now" value outside the trusting period
     let now =
-        JsValue::from_serde(&Time::parse_from_rfc3339("1970-01-16T00:00:00Z").unwrap()).unwrap();
+        serde_wasm_bindgen::to_value(&Time::parse_from_rfc3339("1970-01-16T00:00:00Z").unwrap())
+            .unwrap();
     let js_result = verify(&untrusted_block, &trusted_block, &options, &now);
     console_log!("js_result = {:?}", js_result);
     // The result is Ok because we successfully obtained a verdict, even if the
     // verdict isn't Verdict::Success.
-    let verdict = JsValue::into_serde::<Result<Verdict, Error>>(&js_result)
+    let verdict = serde_wasm_bindgen::from_value::<Result<Verdict, Error>>(js_result)
         .unwrap()
         .unwrap();
     match verdict {
@@ -192,14 +194,16 @@ fn failed_verification_outside_trusting_period() {
 
 fn test_blocks() -> (JsValue, JsValue) {
     let untrusted_block =
-        JsValue::from_serde(&serde_json::from_str::<LightBlock>(UNTRUSTED_BLOCK).unwrap()).unwrap();
+        serde_wasm_bindgen::to_value(&serde_json::from_str::<LightBlock>(UNTRUSTED_BLOCK).unwrap())
+            .unwrap();
     let trusted_block =
-        JsValue::from_serde(&serde_json::from_str::<LightBlock>(TRUSTED_BLOCK).unwrap()).unwrap();
+        serde_wasm_bindgen::to_value(&serde_json::from_str::<LightBlock>(TRUSTED_BLOCK).unwrap())
+            .unwrap();
     (untrusted_block, trusted_block)
 }
 
 fn test_options() -> JsValue {
-    JsValue::from_serde(&JsOptions {
+    serde_wasm_bindgen::to_value(&JsOptions {
         trust_threshold: (1, 3),
         trusting_period: 1209600, // 2 weeks
         clock_drift: 5,           // 5 seconds

--- a/proto/src/serializers/part_set_header_total.rs
+++ b/proto/src/serializers/part_set_header_total.rs
@@ -36,10 +36,17 @@ impl<'de> Visitor<'de> for PartSetHeaderTotalStringOrU32 {
     type Value = u32;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> core::fmt::Result {
-        formatter.write_str("an u32 integer or string between 0 and 2^32")
+        formatter.write_str("an integer or string between 0 and 2^32")
     }
 
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        u32::try_from(v).map_err(|e| E::custom(format!("part_set_header.total {}", e)))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
     where
         E: Error,
     {


### PR DESCRIPTION
The bug this used to work around is closed and the problem
no longer seems to persist.