### PR TITLE
light-client: Fix verification of blocks between two trusted heights

### DIFF
--- a/.changelog/unreleased/bug-fixes/1246-verify-between-trusted.md
+++ b/.changelog/unreleased/bug-fixes/1246-verify-between-trusted.md
@@ -1,0 +1,3 @@
+- `[tendermint-light-client]` Fix verification of blocks between two trusted
+  heights
+  ([#1246](https://github.com/informalsystems/tendermint-rs/issues/1246))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,14 @@ jobs:
         with:
           toolchain: stable
           override: true
+      # NOTE: We test with default features to make sure things work without "unstable".
       - uses: actions-rs/cargo@v1
+        name: Test with default features
+        with:
+          command: test
+          args: -p tendermint-light-client
+      - uses: actions-rs/cargo@v1
+        name: Test with all features
         with:
           command: test-all-features
           args: -p tendermint-light-client

--- a/light-client/src/components/scheduler.rs
+++ b/light-client/src/components/scheduler.rs
@@ -20,7 +20,7 @@ pub trait Scheduler: Send + Sync {
     ///
     /// ## Postcondition
     /// - The resulting height must be valid according to `valid_schedule`. [LCV-SCHEDULE-POST.1]
-    #[requires(light_store.highest_trusted_or_verified().is_some())]
+    #[requires(light_store.highest_trusted_or_verified_before(target_height).is_some())]
     #[ensures(valid_schedule(ret, target_height, current_height, light_store))]
     fn schedule(
         &self,
@@ -61,7 +61,7 @@ pub fn basic_bisecting_schedule(
     target_height: Height,
 ) -> Height {
     let trusted_height = light_store
-        .highest_trusted_or_verified()
+        .highest_trusted_or_verified_before(target_height)
         .map(|lb| lb.height())
         .unwrap();
 
@@ -105,7 +105,7 @@ pub fn valid_schedule(
     light_store: &dyn LightStore,
 ) -> bool {
     let latest_trusted_height = light_store
-        .highest_trusted_or_verified()
+        .highest_trusted_or_verified_before(target_height)
         .map(|lb| lb.height())
         .unwrap();
 

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -161,7 +161,8 @@ impl LightClient {
         // Get the highest trusted state
         let highest = state
             .light_store
-            .highest_trusted_or_verified()
+            .highest_trusted_or_verified_before(target_height)
+            .or_else(|| state.light_store.lowest_trusted_or_verified())
             .ok_or_else(Error::no_initial_trusted_state)?;
 
         if target_height >= highest.height() {
@@ -187,7 +188,7 @@ impl LightClient {
             // Get the latest trusted state
             let trusted_block = state
                 .light_store
-                .highest_trusted_or_verified()
+                .highest_trusted_or_verified_before(target_height)
                 .ok_or_else(Error::no_initial_trusted_state)?;
 
             if target_height < trusted_block.height() {
@@ -267,7 +268,8 @@ impl LightClient {
     ) -> Result<LightBlock, Error> {
         let trusted_state = state
             .light_store
-            .highest_trusted_or_verified()
+            .highest_trusted_or_verified_before(target_height)
+            .or_else(|| state.light_store.lowest_trusted_or_verified())
             .ok_or_else(Error::no_initial_trusted_state)?;
 
         Err(Error::target_lower_than_trusted_state(
@@ -304,7 +306,8 @@ impl LightClient {
 
         let root = state
             .light_store
-            .highest_trusted_or_verified()
+            .highest_trusted_or_verified_before(target_height)
+            .or_else(|| state.light_store.lowest_trusted_or_verified())
             .ok_or_else(Error::no_initial_trusted_state)?;
 
         assert!(root.height() >= target_height);

--- a/light-client/src/store.rs
+++ b/light-client/src/store.rs
@@ -43,6 +43,9 @@ pub trait LightStore: Debug + Send + Sync {
     /// Get the light block of greatest height with the given status.
     fn highest(&self, status: Status) -> Option<LightBlock>;
 
+    /// Get the light block of greatest hight before the given height with the given status.
+    fn highest_before(&self, height: Height, status: Status) -> Option<LightBlock>;
+
     /// Get the light block of lowest height with the given status.
     fn lowest(&self, status: Status) -> Option<LightBlock>;
 
@@ -72,6 +75,16 @@ pub trait LightStore: Debug + Send + Sync {
         let latest_verified = self.highest(Status::Verified);
 
         std_ext::option::select(latest_trusted, latest_verified, |t, v| {
+            std_ext::cmp::max_by_key(t, v, |lb| lb.height())
+        })
+    }
+
+    /// Get the first light block before the given height with the trusted or verified status.
+    fn highest_trusted_or_verified_before(&self, height: Height) -> Option<LightBlock> {
+        let highest_trusted = self.highest_before(height, Status::Trusted);
+        let highest_verified = self.highest_before(height, Status::Verified);
+
+        std_ext::option::select(highest_trusted, highest_verified, |t, v| {
             std_ext::cmp::max_by_key(t, v, |lb| lb.height())
         })
     }

--- a/light-client/src/store/memory.rs
+++ b/light-client/src/store/memory.rs
@@ -72,6 +72,15 @@ impl LightStore for MemoryStore {
             .map(|(_, e)| e.light_block.clone())
     }
 
+    fn highest_before(&self, height: Height, status: Status) -> Option<LightBlock> {
+        self.store
+            .iter()
+            .filter(|(_, e)| e.status == status)
+            .filter(|(h, _)| h <= &&height)
+            .max_by_key(|(&height, _)| height)
+            .map(|(_, e)| e.light_block.clone())
+    }
+
     fn lowest(&self, status: Status) -> Option<LightBlock> {
         self.store
             .iter()

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -483,6 +483,14 @@ mod tests {
         let mut light_store = MemoryStore::new();
         light_store.insert(trusted_state, Status::Trusted);
 
+        for extra_trusted_height in trust_options.extra_heights {
+            let trusted_state = io
+                .fetch_light_block(AtHeight::At(extra_trusted_height))
+                .expect("could not 'request' light block");
+
+            light_store.insert(trusted_state, Status::Trusted);
+        }
+
         let state = State {
             light_store: Box::new(light_store),
             verification_trace: HashMap::new(),
@@ -526,17 +534,12 @@ mod tests {
         )
     }
 
-    fn make_peer_list(
+    fn make_peer_list_opts(
         primary: Option<Vec<LightBlock>>,
         witnesses: Option<Vec<Vec<LightBlock>>>,
         now: Time,
+        trust_options: TrustOptions,
     ) -> PeerList<Instance> {
-        let trust_options = TrustOptions {
-            period: DurationStr(Duration::new(604800, 0)),
-            height: Height::try_from(1_u64).expect("Error while making height"),
-            trust_level: TrustThresholdFraction::TWO_THIRDS,
-        };
-
         let mut peer_list = PeerList::builder();
 
         if let Some(primary) = primary {
@@ -557,6 +560,24 @@ mod tests {
             }
         }
         peer_list.build()
+    }
+
+    fn make_peer_list(
+        primary: Option<Vec<LightBlock>>,
+        witnesses: Option<Vec<Vec<LightBlock>>>,
+        now: Time,
+    ) -> PeerList<Instance> {
+        make_peer_list_opts(
+            primary,
+            witnesses,
+            now,
+            TrustOptions {
+                period: DurationStr(Duration::new(604800, 0)),
+                height: Height::try_from(1_u64).expect("Error while making height"),
+                extra_heights: vec![],
+                trust_level: TrustThresholdFraction::TWO_THIRDS,
+            },
+        )
     }
 
     fn change_provider(
@@ -858,5 +879,39 @@ mod tests {
             .connected_nodes
             .iter()
             .any(|&peer| peer == primary[0].provider));
+    }
+
+    #[test]
+    fn test_bisection_between_trusted_heights() {
+        let chain = LightChain::default_with_length(10);
+        let primary = chain
+            .light_blocks
+            .into_iter()
+            .map(|lb| lb.generate().unwrap().into_light_block())
+            .collect::<Vec<LightBlock>>();
+
+        let witness = change_provider(primary.clone(), None);
+
+        // Specify two trusted heights (1 and 8), then attempt to verify target height 4 which
+        // falls between the two. Verification should use regular bisection.
+
+        let peer_list = make_peer_list_opts(
+            Some(primary.clone()),
+            Some(vec![witness]),
+            get_time(11).unwrap(),
+            TrustOptions {
+                period: DurationStr(Duration::new(604800, 0)),
+                height: Height::try_from(1_u64).expect("Error while making height"),
+                extra_heights: vec![Height::try_from(8_u64).expect("Error while making height")],
+                trust_level: TrustThresholdFraction::TWO_THIRDS,
+            },
+        );
+
+        let (result, _) = run_bisection_test(peer_list, 4);
+
+        let expected_state = primary[3].clone();
+        let new_state = result.unwrap();
+
+        assert_eq!(expected_state, new_state);
     }
 }

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -77,6 +77,8 @@ pub struct Provider<LB> {
 pub struct TrustOptions {
     pub period: DurationStr,
     pub height: HeightStr,
+    #[serde(default)]
+    pub extra_heights: Vec<HeightStr>,
     pub trust_level: TrustThreshold,
 }
 


### PR DESCRIPTION
Fixes #1246 

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
