### PR TITLE
Fix changelog for v0.28.0 release

### DIFF
--- a/.changelog/v0.28.0/breaking/0000-light-client-verification-preds.md
+++ b/.changelog/v0.28.0/breaking/0000-light-client-verification-preds.md
@@ -1,3 +1,2 @@
 - `[tendermint-light-client-verifier]` Add `is_matching_chain_id`
   method to the `VerificationPredicates` trait
-  ([#1249](https://github.com/informalsystems/tendermint-rs/pull/1249))

--- a/.changelog/v0.28.0/breaking/0000-light-client-verifier.md
+++ b/.changelog/v0.28.0/breaking/0000-light-client-verifier.md
@@ -1,3 +1,2 @@
 - `[tendermint-light-client-verifier]` Add a
   `chain_id` field to the `TrustedBlockState` struct
-  ([#1249](https://github.com/informalsystems/tendermint-rs/pull/1249))

--- a/.changelog/v0.28.0/security/0000-light-client-security.md
+++ b/.changelog/v0.28.0/security/0000-light-client-security.md
@@ -1,3 +1,2 @@
 - `[tendermint-light-client]` Fix an issue where the light client was not
   checking that the chain ID of the trusted and untrusted headers match
-  ([#1249](https://github.com/informalsystems/tendermint-rs/pull/1249))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,10 @@ this version immediately.
 
 ### BREAKING
 
-- `[tendermint-light-client-verifier]` Add a
-  `chain_id` field to the `TrustedBlockState` struct
-  ([#1249](https://github.com/informalsystems/tendermint-rs/pull/1249))
 - `[tendermint-light-client-verifier]` Add `is_matching_chain_id`
   method to the `VerificationPredicates` trait
-  ([#1249](https://github.com/informalsystems/tendermint-rs/pull/1249))
+- `[tendermint-light-client-verifier]` Add a
+  `chain_id` field to the `TrustedBlockState` struct
 
 ### IMPROVEMENTS
 
@@ -28,7 +26,6 @@ this version immediately.
 
 - `[tendermint-light-client]` Fix an issue where the light client was not
   checking that the chain ID of the trusted and untrusted headers match
-  ([#1249](https://github.com/informalsystems/tendermint-rs/pull/1249))
 
 ## v0.27.0
 


### PR DESCRIPTION
Removes the incorrect PR references from the v0.28.0 changelog.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
