### PR TITLE
tendermint: fix minimal-versions correctness for `bytes`

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bytes = { version = "1.0", default-features = false, features = ["serde"] }
+bytes = { version = "1.2", default-features = false, features = ["serde"] }
 ed25519 = { version = "1.3", default-features = false }
 ed25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }
 futures = { version = "0.3", default-features = false }


### PR DESCRIPTION
The `tendermint` crate uses features of `bytes` introduced in version 1.2, namely a `From<Vec<u8>>` impl for `Bytes`.

See https://github.com/cosmos/cosmos-rust/pull/314 for additional context