### PR TITLE
Update all crates to Rust edition 2021 and fix clippy warnings introduced in Rust 1.67

### DIFF
--- a/.changelog/unreleased/improvements/1262-edition-2021.md
+++ b/.changelog/unreleased/improvements/1262-edition-2021.md
@@ -1,0 +1,3 @@
+- Update all crates to the [2021 edition](https://doc.rust-
+  lang.org/edition-guide/rust-2021/index.html) of the Rust language
+  ([#1262](https://github.com/informalsystems/tendermint-rs/issues/1262))

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "tendermint-abci"
 version     = "0.28.0"
 authors     = ["Informal Systems <hello@informal.systems>"]
-edition     = "2018"
+edition     = "2021"
 license     = "Apache-2.0"
 readme      = "README.md"
 categories  = ["cryptography::cryptocurrencies", "network-programming"]

--- a/abci/src/application/kvstore.rs
+++ b/abci/src/application/kvstore.rs
@@ -133,7 +133,7 @@ impl Application for KeyValueStoreApp {
     fn query(&self, request: RequestQuery) -> ResponseQuery {
         let key = match std::str::from_utf8(&request.data) {
             Ok(s) => s,
-            Err(e) => panic!("Failed to intepret key as UTF-8: {}", e),
+            Err(e) => panic!("Failed to intepret key as UTF-8: {e}"),
         };
         debug!("Attempting to get key: {}", key);
         match self.get(key) {
@@ -161,7 +161,7 @@ impl Application for KeyValueStoreApp {
                     codespace: "".to_string(),
                 },
             },
-            Err(e) => panic!("Failed to get key \"{}\": {:?}", key, e),
+            Err(e) => panic!("Failed to get key \"{key}\": {e:?}"),
         }
     }
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name       = "tendermint-config"
 version    = "0.28.0" # Also update `html_root_url` in lib.rs and
-                               # depending crates (rpc, light-node, ..) when bumping this
+                      # depending crates (rpc, light-node, ..) when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/main/tendermint"
 readme     = "../README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
 keywords   = ["blockchain", "bft", "consensus", "cosmos", "tendermint"]
-edition    = "2018"
+edition    = "2021"
 
 description = """
     tendermint-config provides functions for loading and validating Tendermint

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -208,7 +208,7 @@ impl FromStr for LogLevel {
                 global = Some(parts[0].to_owned());
                 continue;
             } else if parts.len() != 2 {
-                return Err(Error::parse(format!("error parsing log level: {}", level)));
+                return Err(Error::parse(format!("error parsing log level: {level}")));
             }
 
             let key = parts[0].to_owned();
@@ -216,8 +216,7 @@ impl FromStr for LogLevel {
 
             if components.insert(key, value).is_some() {
                 return Err(Error::parse(format!(
-                    "duplicate log level setting for: {}",
-                    level
+                    "duplicate log level setting for: {level}"
                 )));
             }
         }
@@ -229,13 +228,13 @@ impl FromStr for LogLevel {
 impl fmt::Display for LogLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(global) = &self.global {
-            write!(f, "{}", global)?;
+            write!(f, "{global}")?;
             if !self.components.is_empty() {
                 write!(f, ",")?;
             }
         }
         for (i, (k, v)) in self.components.iter().enumerate() {
-            write!(f, "{}:{}", k, v)?;
+            write!(f, "{k}:{v}")?;
 
             if i < self.components.len() - 1 {
                 write!(f, ",")?;
@@ -249,7 +248,7 @@ impl fmt::Display for LogLevel {
 impl<'de> Deserialize<'de> for LogLevel {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let levels = String::deserialize(deserializer)?;
-        Self::from_str(&levels).map_err(|e| D::Error::custom(format!("{}", e)))
+        Self::from_str(&levels).map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 
@@ -725,7 +724,7 @@ where
     string
         .parse()
         .map(Some)
-        .map_err(|e| D::Error::custom(format!("{}", e)))
+        .map_err(|e| D::Error::custom(format!("{e}")))
 }
 
 fn serialize_optional_value<S, T>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
@@ -754,10 +753,7 @@ where
     }
 
     for item in string.split(',') {
-        result.push(
-            item.parse()
-                .map_err(|e| D::Error::custom(format!("{}", e)))?,
-        );
+        result.push(item.parse().map_err(|e| D::Error::custom(format!("{e}")))?);
     }
 
     Ok(result)

--- a/config/src/net.rs
+++ b/config/src/net.rs
@@ -166,7 +166,7 @@ mod tests {
                     assert_eq!(host, "35.192.61.41");
                     assert_eq!(port, 26656);
                 },
-                other => panic!("unexpected address type: {:?}", other),
+                other => panic!("unexpected address type: {other:?}"),
             }
         }
     }
@@ -188,7 +188,7 @@ mod tests {
                     assert_eq!(host, "35.192.61.41");
                     assert_eq!(*port, 26656);
                 },
-                other => panic!("unexpected address type: {:?}", other),
+                other => panic!("unexpected address type: {other:?}"),
             }
         }
     }
@@ -200,7 +200,7 @@ mod tests {
             Address::Unix { path } => {
                 assert_eq!(path, "/tmp/node.sock");
             },
-            other => panic!("unexpected address type: {:?}", other),
+            other => panic!("unexpected address type: {other:?}"),
         }
     }
 
@@ -227,7 +227,7 @@ mod tests {
                     assert_eq!(host, "[2001:0:3238:dfe1:63::fefb]");
                     assert_eq!(*port, 26656);
                 },
-                other => panic!("unexpected address type: {:?}", other),
+                other => panic!("unexpected address type: {other:?}"),
             }
         }
     }

--- a/config/src/net.rs
+++ b/config/src/net.rs
@@ -53,7 +53,7 @@ impl Address {
         if raw_address.starts_with("tcp://") {
             raw_address.parse().ok()
         } else {
-            format!("tcp://{}", raw_address).parse().ok()
+            format!("tcp://{raw_address}").parse().ok()
         }
     }
 }
@@ -61,7 +61,7 @@ impl Address {
 impl<'de> Deserialize<'de> for Address {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+            .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 
@@ -72,13 +72,13 @@ impl Display for Address {
                 peer_id: None,
                 host,
                 port,
-            } => write!(f, "{}{}:{}", TCP_PREFIX, host, port),
+            } => write!(f, "{TCP_PREFIX}{host}:{port}"),
             Address::Tcp {
                 peer_id: Some(peer_id),
                 host,
                 port,
-            } => write!(f, "{}{}@{}:{}", TCP_PREFIX, peer_id, host, port),
-            Address::Unix { path } => write!(f, "{}{}", UNIX_PREFIX, path),
+            } => write!(f, "{TCP_PREFIX}{peer_id}@{host}:{port}"),
+            Address::Unix { path } => write!(f, "{UNIX_PREFIX}{path}"),
         }
     }
 }
@@ -98,7 +98,7 @@ impl FromStr for Address {
             addr.to_owned()
         } else {
             // If the address has no scheme, assume it's TCP
-            format!("{}{}", TCP_PREFIX, addr)
+            format!("{TCP_PREFIX}{addr}")
         };
         let url = Url::parse(&prefixed_addr).map_err(Error::parse_url)?;
         match url.scheme() {
@@ -112,17 +112,17 @@ impl FromStr for Address {
                 host: url
                     .host_str()
                     .ok_or_else(|| {
-                        Error::parse(format!("invalid TCP address (missing host): {}", addr))
+                        Error::parse(format!("invalid TCP address (missing host): {addr}"))
                     })?
                     .to_owned(),
                 port: url.port().ok_or_else(|| {
-                    Error::parse(format!("invalid TCP address (missing port): {}", addr))
+                    Error::parse(format!("invalid TCP address (missing port): {addr}"))
                 })?,
             }),
             "unix" => Ok(Self::Unix {
                 path: url.path().to_string(),
             }),
-            _ => Err(Error::parse(format!("invalid address scheme: {:?}", addr))),
+            _ => Err(Error::parse(format!("invalid address scheme: {addr:?}"))),
         }
     }
 }

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "tendermint-light-client-js"
 version     = "0.28.0"
 authors     = ["Informal Systems <hello@informal.systems>"]
-edition     = "2018"
+edition     = "2021"
 license     = "Apache-2.0"
 readme      = "README.md"
 keywords    = ["blockchain", "bft", "consensus", "light-client", "tendermint"]

--- a/light-client-verifier/src/options.rs
+++ b/light-client-verifier/src/options.rs
@@ -11,7 +11,7 @@ use crate::types::TrustThreshold;
 
 /// Verification parameters
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Display, Serialize, Deserialize)]
-#[display(fmt = "{:?}", self)]
+#[display(fmt = "{self:?}")]
 pub struct Options {
     /// Defines what fraction of the total voting power of a known
     /// and trusted validator set is sufficient for a commit to be

--- a/light-client-verifier/src/types.rs
+++ b/light-client-verifier/src/types.rs
@@ -103,7 +103,7 @@ impl<'a> UntrustedBlockState<'a> {
 /// A light block is the core data structure used by the light client.
 /// It records everything the light client needs to know about a block.
 #[derive(Clone, Debug, Display, PartialEq, Eq, Serialize, Deserialize)]
-#[display(fmt = "{:?}", self)]
+#[display(fmt = "{self:?}")]
 pub struct LightBlock {
     /// Header and commit of this block
     pub signed_header: SignedHeader,
@@ -167,7 +167,7 @@ impl LightBlock {
 /// Contains the local status information, like the latest height, latest block and valset hashes,
 /// list of of connected full nodes (primary and witnesses).
 #[derive(Clone, Debug, Display, PartialEq, Eq, Serialize, Deserialize)]
-#[display(fmt = "{:?}", self)]
+#[display(fmt = "{self:?}")]
 pub struct LatestStatus {
     /// The latest height we are trusting.
     pub height: Option<u64>,

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       = "tendermint-light-client"
 version    = "0.28.0"
-edition    = "2018"
+edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
 keywords   = ["blockchain", "bft", "consensus", "cosmos", "tendermint"]

--- a/light-client/examples/light_client.rs
+++ b/light-client/examples/light_client.rs
@@ -69,7 +69,7 @@ fn main() {
             std::process::exit(1);
         },
         Some(Command::Sync(sync_opts)) => sync_cmd(sync_opts).unwrap_or_else(|e| {
-            eprintln!("Command failed: {}", e);
+            eprintln!("Command failed: {e}");
             std::process::exit(1);
         }),
     }
@@ -125,7 +125,7 @@ fn sync_cmd(opts: SyncOpts) -> Result<(), Box<dyn std::error::Error>> {
                 println!("[info] synced to block {}", light_block.height());
             },
             Err(err) => {
-                println!("[error] sync failed: {}", err);
+                println!("[error] sync failed: {err}");
             },
         }
 

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -302,8 +302,6 @@ impl LightClient {
         target_height: Height,
         state: &mut State,
     ) -> Result<LightBlock, Error> {
-        use std::convert::TryFrom;
-
         let root = state
             .light_store
             .highest_trusted_or_verified_before(target_height)

--- a/light-client/src/peer_list.rs
+++ b/light-client/src/peer_list.rs
@@ -309,8 +309,7 @@ mod tests {
         match new_primary {
             Err(Error(ErrorDetail::NoWitnessesLeft(_), _)) => {},
             _ => panic!(
-                "expected NoWitnessesLeft error, instead got {:?}",
-                new_primary
+                "expected NoWitnessesLeft error, instead got {new_primary:?}"
             ),
         }
     }

--- a/light-client/src/peer_list.rs
+++ b/light-client/src/peer_list.rs
@@ -308,9 +308,7 @@ mod tests {
         let new_primary = peer_list.replace_faulty_primary(None);
         match new_primary {
             Err(Error(ErrorDetail::NoWitnessesLeft(_), _)) => {},
-            _ => panic!(
-                "expected NoWitnessesLeft error, instead got {new_primary:?}"
-            ),
+            _ => panic!("expected NoWitnessesLeft error, instead got {new_primary:?}"),
         }
     }
 

--- a/light-client/src/supervisor.rs
+++ b/light-client/src/supervisor.rs
@@ -664,7 +664,7 @@ mod tests {
 
         match result {
             Err(Error(ErrorDetail::NoWitnesses(_), _)) => {},
-            _ => panic!("expected NoWitnesses error, instead got {:?}", result),
+            _ => panic!("expected NoWitnesses error, instead got {result:?}"),
         }
     }
 
@@ -724,14 +724,14 @@ mod tests {
                         assert_eq!(e.source.code(), rpc::Code::InvalidRequest)
                     },
                     _ => {
-                        panic!("expected Response error, instead got {:?}", e)
+                        panic!("expected Response error, instead got {e:?}")
                     },
                 },
                 _ => {
-                    panic!("expected Rpc error, instead got {:?}", e)
+                    panic!("expected Rpc error, instead got {e:?}")
                 },
             },
-            _ => panic!("expected Io error, instead got {:?}", result),
+            _ => panic!("expected Io error, instead got {result:?}"),
         }
     }
 

--- a/light-client/tests/model_based.rs
+++ b/light-client/tests/model_based.rs
@@ -367,7 +367,7 @@ mod mbt {
             }
             input.block.signed_header.commit.round = (round as u16).into();
             (
-                format!("commit round from {} into {}", r, round),
+                format!("commit round from {r} into {round}"),
                 LiteVerdict::Invalid,
             )
         }
@@ -586,7 +586,7 @@ mod mbt {
                         );
                     },
                     Err(e) => {
-                        output_env.logln(&format!("      > lite: {:?}", e));
+                        output_env.logln(&format!("      > lite: {e:?}"));
                         match e {
                             Verdict::Invalid(_) => assert_eq!(input.verdict, LiteVerdict::Invalid),
                             Verdict::NotEnoughTrust(_) => {
@@ -668,7 +668,7 @@ mod mbt {
         // Check for the necessary programs
         let check_program = |program| {
             if !Command::exists_program(program) {
-                output_env.logln(&format!("    > {} not found", program));
+                output_env.logln(&format!("    > {program} not found"));
                 return false;
             }
             true

--- a/light-client/tests/model_based.rs
+++ b/light-client/tests/model_based.rs
@@ -692,7 +692,7 @@ mod mbt {
                 ApalacheRun::Counterexample(_) => (),
                 run => panic!("{}", run.message()),
             },
-            Err(e) => panic!("failed to run Apalache; reason: {}", e),
+            Err(e) => panic!("failed to run Apalache; reason: {e}"),
         }
         output_env.copy_file_from_env_as(env, "counterexample.tla", &tla_test);
 

--- a/light-client/tests/supervisor.rs
+++ b/light-client/tests/supervisor.rs
@@ -74,7 +74,7 @@ fn run_multipeer_test(tc: LightClientTest<LightBlock>) {
 
     for provider in tc.witnesses.into_iter() {
         let peer_id = provider.value.lite_blocks[0].provider;
-        println!("Witness: {}", peer_id);
+        println!("Witness: {peer_id}");
         let io = MockIo::new(provider.value.lite_blocks);
         let instance = make_instance(peer_id, tc.trust_options.clone(), io.clone(), tc.now);
         peer_list.witness(peer_id, instance);

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -108,10 +108,7 @@ impl Handshake<AwaitingEphKey> {
         &mut self,
         remote_eph_pubkey: EphemeralPublic,
     ) -> Result<Handshake<AwaitingAuthSig>, Error> {
-        let local_eph_privkey = match self.state.local_eph_privkey.take() {
-            Some(key) => key,
-            None => return Err(Error::missing_secret()),
-        };
+        let Some(local_eph_privkey) = self.state.local_eph_privkey.take() else { return Err(Error::missing_secret()) };
         let local_eph_pubkey = EphemeralPublic::from(&local_eph_privkey);
 
         // Compute common shared secret.

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "tendermint-pbt-gen"
-version = "0.28.0"
-authors = ["Informal Systems <hello@informal.systems>"]
-edition = "2018"
+name        = "tendermint-pbt-gen"
+version     = "0.28.0"
+authors     = ["Informal Systems <hello@informal.systems>"]
+edition     = "2021"
 license     = "Apache-2.0"
 readme      = "README.md"
 categories  = ["development-tools"]

--- a/pbt-gen/src/time.rs
+++ b/pbt-gen/src/time.rs
@@ -175,7 +175,7 @@ prop_compose! {
         hour in 0..23u8,
         min in 0..59u8,
     ) -> String {
-        format!("{:}{:0>2}:{:0>2}", sign, hour, min)
+        format!("{sign:}{hour:0>2}:{min:0>2}")
     }
 }
 
@@ -192,9 +192,9 @@ prop_compose! {
     ) -> String {
         let frac = match secfrac {
             None => "".to_owned(),
-            Some(frac) => format!(".{:}", frac)
+            Some(frac) => format!(".{frac:}")
         };
-        format!("{:0>2}:{:0>2}:{:0>2}{:}", hour, min, sec, frac)
+        format!("{hour:0>2}:{min:0>2}:{sec:0>2}{frac:}")
     }
 }
 
@@ -203,7 +203,7 @@ prop_compose! {
         time in arb_rfc3339_partial_time(),
         offset in arb_rfc3339_offset()
     ) -> String {
-        format!("{:}{:}", time, offset)
+        format!("{time:}{offset:}")
     }
 }
 
@@ -223,7 +223,7 @@ prop_compose! {
             year in Just(year),
             month in Just(month),
         ) -> String {
-            format!("{:0>4}-{:0>2}-{:0>2}", year, month, day)
+            format!("{year:0>4}-{month:0>2}-{day:0>2}")
         }
 }
 
@@ -238,7 +238,7 @@ prop_compose! {
         date in arb_rfc3339_full_date(),
         time in arb_rfc3339_full_time()
     ) -> String {
-        format!("{:}T{:}", date, time)
+        format!("{date:}T{time:}")
     }
 }
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "tendermint-proto"
-version = "0.28.0"
-authors = ["Informal Systems <hello@informal.systems>"]
-edition = "2018"
-license = "Apache-2.0"
+name       = "tendermint-proto"
+version    = "0.28.0"
+authors    = ["Informal Systems <hello@informal.systems>"]
+edition    = "2021"
+license    = "Apache-2.0"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/main/proto"
 readme     = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -36,6 +36,6 @@ impl Error {
         E: Display,
         T: TryFrom<Raw, Error = E>,
     {
-        Error::try_from_protobuf(format!("{}", e))
+        Error::try_from_protobuf(format!("{e}"))
     }
 }

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -14,7 +14,7 @@ where
 {
     String::deserialize(deserializer)?
         .parse::<T>()
-        .map_err(|e| D::Error::custom(format!("{}", e)))
+        .map_err(|e| D::Error::custom(format!("{e}")))
 }
 
 /// Serialize from T into string
@@ -23,5 +23,5 @@ where
     S: Serializer,
     T: core::fmt::Display,
 {
-    format!("{}", value).serialize(serializer)
+    format!("{value}").serialize(serializer)
 }

--- a/proto/src/serializers/optional_from_str.rs
+++ b/proto/src/serializers/optional_from_str.rs
@@ -28,6 +28,6 @@ where
         None => return Ok(None),
     };
     Ok(Some(s.parse().map_err(|e: <T as FromStr>::Err| {
-        D::Error::custom(format!("{}", e))
+        D::Error::custom(format!("{e}"))
     })?))
 }

--- a/proto/src/serializers/part_set_header_total.rs
+++ b/proto/src/serializers/part_set_header_total.rs
@@ -43,14 +43,14 @@ impl<'de> Visitor<'de> for PartSetHeaderTotalStringOrU32 {
     where
         E: Error,
     {
-        u32::try_from(v).map_err(|e| E::custom(format!("part_set_header.total {}", e)))
+        u32::try_from(v).map_err(|e| E::custom(format!("part_set_header.total {e}")))
     }
 
     fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
     where
         E: Error,
     {
-        u32::try_from(v).map_err(|e| E::custom(format!("part_set_header.total {}", e)))
+        u32::try_from(v).map_err(|e| E::custom(format!("part_set_header.total {e}")))
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -58,6 +58,6 @@ impl<'de> Visitor<'de> for PartSetHeaderTotalStringOrU32 {
         E: Error,
     {
         v.parse::<u32>()
-            .map_err(|e| E::custom(format!("part_set_header.total {}", e)))
+            .map_err(|e| E::custom(format!("part_set_header.total {e}")))
     }
 }

--- a/proto/src/serializers/time_duration.rs
+++ b/proto/src/serializers/time_duration.rs
@@ -12,7 +12,7 @@ where
 {
     let value = String::deserialize(deserializer)?
         .parse::<u64>()
-        .map_err(|e| D::Error::custom(format!("{}", e)))?;
+        .map_err(|e| D::Error::custom(format!("{e}")))?;
 
     Ok(Duration::from_nanos(value))
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       = "tendermint-rpc"
 version    = "0.28.0"
-edition    = "2018"
+edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs"

--- a/rpc/src/client/bin/main.rs
+++ b/rpc/src/client/bin/main.rs
@@ -427,7 +427,7 @@ where
         },
     };
 
-    println!("{}", result);
+    println!("{result}");
     Ok(())
 }
 

--- a/rpc/src/client/transport/auth.rs
+++ b/rpc/src/client/transport/auth.rs
@@ -19,7 +19,7 @@ pub enum Authorization {
 impl fmt::Display for Authorization {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Basic(cred) => write!(f, "Basic {}", cred),
+            Self::Basic(cred) => write!(f, "Basic {cred}"),
         }
     }
 }

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -135,7 +135,7 @@ impl TryFrom<net::Address> for HttpClientUrl {
                 peer_id: _,
                 host,
                 port,
-            } => format!("http://{}:{}", host, port).parse(),
+            } => format!("http://{host}:{port}").parse(),
             net::Address::Unix { .. } => Err(Error::invalid_network_address()),
         }
     }

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -212,8 +212,7 @@ impl TryFrom<Url> for WebSocketClientUrl {
         match value.scheme() {
             Scheme::WebSocket | Scheme::SecureWebSocket => Ok(Self(value)),
             _ => Err(Error::invalid_params(format!(
-                "cannot use URL {} with WebSocket clients",
-                value
+                "cannot use URL {value} with WebSocket clients"
             ))),
         }
     }
@@ -245,7 +244,7 @@ impl TryFrom<net::Address> for WebSocketClientUrl {
                 peer_id: _,
                 host,
                 port,
-            } => format!("ws://{}:{}/websocket", host, port).parse(),
+            } => format!("ws://{host}:{port}/websocket").parse(),
             net::Address::Unix { .. } => Err(Error::invalid_params(
                 "only TCP-based node addresses are supported".to_string(),
             )),
@@ -1097,8 +1096,7 @@ mod test {
                             },
                             Err(e) => {
                                 println!(
-                                    "Unexpected method in incoming request: {} ({})",
-                                    json_method, e
+                                    "Unexpected method in incoming request: {json_method} ({e})"
                                 );
                             },
                         }
@@ -1118,7 +1116,7 @@ mod test {
 
         fn remove_subscription(&mut self, query: String) {
             if let Some(id) = self.subscriptions.remove(&query) {
-                println!("Removed subscription {} for query: {}", id, query);
+                println!("Removed subscription {id} for query: {query}");
             }
         }
 

--- a/rpc/src/endpoint/consensus_state.rs
+++ b/rpc/src/endpoint/consensus_state.rs
@@ -227,20 +227,17 @@ impl FromStr for VoteSummary {
         let validator_address_fingerprint =
             Fingerprint::from_str(validator[1]).map_err(|e| {
                 Error::client_internal(format!(
-                    "failed to parse validator address fingerprint from consensus state vote summary: {}",
-                    e
+                    "failed to parse validator address fingerprint from consensus state vote summary: {e}"
                 ))
             })?;
         let height = Height::from_str(height_round_type[0]).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse height from consensus state vote summary: {}",
-                e
+                "failed to parse height from consensus state vote summary: {e}"
             ))
         })?;
         let round = Round::from_str(height_round_type[1]).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse round from consensus state vote summary: {}",
-                e
+                "failed to parse round from consensus state vote summary: {e}"
             ))
         })?;
         let vote_type_parts: Vec<&str> = height_round_type[2].split('(').collect();
@@ -253,26 +250,22 @@ impl FromStr for VoteSummary {
         let vote_type_str = vote_type_parts[1].trim_end_matches(')');
         let vote_type = vote::Type::from_str(vote_type_str).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse vote type from consensus state vote summary: {} ({})",
-                e, vote_type_str
+                "failed to parse vote type from consensus state vote summary: {e} ({vote_type_str})"
             ))
         })?;
         let block_id_hash_fingerprint = Fingerprint::from_str(parts[2]).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse block ID hash fingerprint from consensus state vote summary: {}",
-                e
+                "failed to parse block ID hash fingerprint from consensus state vote summary: {e}"
             ))
         })?;
         let signature_fingerprint = Fingerprint::from_str(parts[3]).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse signature fingerprint from consensus state vote summary: {}",
-                e
+                "failed to parse signature fingerprint from consensus state vote summary: {e}"
             ))
         })?;
         let timestamp = Time::parse_from_rfc3339(parts[5]).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse timestamp from consensus state vote summary: {}",
-                e
+                "failed to parse timestamp from consensus state vote summary: {e}"
             ))
         })?;
 
@@ -316,8 +309,7 @@ impl FromStr for Fingerprint {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(hex::decode_upper(s).map_err(|e| {
             Error::client_internal(format!(
-                "failed to parse fingerprint as an uppercase hexadecimal string: {}",
-                e
+                "failed to parse fingerprint as an uppercase hexadecimal string: {e}"
             ))
         })?))
     }
@@ -327,7 +319,7 @@ impl fmt::Display for Fingerprint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let hex_bytes = hex::encode_upper(&self.0);
         let hex_string = String::from_utf8(hex_bytes).unwrap();
-        write!(f, "{}", hex_string)
+        write!(f, "{hex_string}")
     }
 }
 

--- a/rpc/src/id.rs
+++ b/rpc/src/id.rs
@@ -28,8 +28,8 @@ impl Id {
 impl fmt::Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Id::Num(i) => write!(f, "{}", i),
-            Id::Str(s) => write!(f, "{}", s),
+            Id::Num(i) => write!(f, "{i}"),
+            Id::Str(s) => write!(f, "{s}"),
             Id::None => write!(f, ""),
         }
     }

--- a/rpc/src/method.rs
+++ b/rpc/src/method.rs
@@ -163,6 +163,6 @@ impl Serialize for Method {
 impl<'de> Deserialize<'de> for Method {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+            .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }

--- a/rpc/src/order.rs
+++ b/rpc/src/order.rs
@@ -26,8 +26,7 @@ impl FromStr for Order {
             "asc" => Ok(Self::Ascending),
             "desc" => Ok(Self::Descending),
             _ => Err(Error::invalid_params(format!(
-                "invalid order type: {} (must be \"asc\" or \"desc\")",
-                s
+                "invalid order type: {s} (must be \"asc\" or \"desc\")"
             ))),
         }
     }

--- a/rpc/src/query.rs
+++ b/rpc/src/query.rs
@@ -195,7 +195,7 @@ impl From<EventType> for Query {
 impl fmt::Display for Query {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(t) = &self.event_type {
-            write!(f, "tm.event = '{}'", t)?;
+            write!(f, "tm.event = '{t}'")?;
 
             if !self.conditions.is_empty() {
                 write!(f, " AND ")?;
@@ -360,7 +360,7 @@ impl FromStr for Query {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (event_types, conditions) = separate_terms(
             query_parser::query(s)
-                .map_err(|e| Error::invalid_params(format!("failed to parse query: {}", e)))?,
+                .map_err(|e| Error::invalid_params(format!("failed to parse query: {e}")))?,
         );
         if event_types.len() > 1 {
             return Err(Error::invalid_params(
@@ -382,11 +382,11 @@ where
 {
     let mut iter = iterable.into_iter();
     if let Some(first) = iter.next() {
-        write!(f, "{}", first)?;
+        write!(f, "{first}")?;
     }
 
     for item in iter {
-        write!(f, "{}{}", separator, item)?;
+        write!(f, "{separator}{item}")?;
     }
 
     Ok(())
@@ -530,9 +530,9 @@ impl fmt::Display for Operand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Operand::String(s) => write!(f, "{}", escape(s)),
-            Operand::Signed(i) => write!(f, "{}", i),
-            Operand::Unsigned(u) => write!(f, "{}", u),
-            Operand::Float(h) => write!(f, "{}", h),
+            Operand::Signed(i) => write!(f, "{i}"),
+            Operand::Unsigned(u) => write!(f, "{u}"),
+            Operand::Float(h) => write!(f, "{h}"),
             Operand::Date(d) => {
                 write!(f, "DATE ")?;
                 fmt_date(*d, f)?;
@@ -656,7 +656,7 @@ fn escape(s: &str) -> String {
         }
         result.push(ch);
     }
-    format!("'{}'", result)
+    format!("'{result}'")
 }
 
 #[cfg(test)]

--- a/rpc/src/rpc_url.rs
+++ b/rpc/src/rpc_url.rs
@@ -63,11 +63,11 @@ impl FromStr for Url {
 
         let host = inner
             .host_str()
-            .ok_or_else(|| Error::invalid_params(format!("URL is missing its host: {}", s)))?
+            .ok_or_else(|| Error::invalid_params(format!("URL is missing its host: {s}")))?
             .to_owned();
 
         let port = inner.port_or_known_default().ok_or_else(|| {
-            Error::invalid_params(format!("cannot determine appropriate port for URL: {}", s))
+            Error::invalid_params(format!("cannot determine appropriate port for URL: {s}"))
         })?;
 
         Ok(Self {
@@ -351,17 +351,17 @@ mod test {
     fn parsing() {
         for (url_str, expected) in SUPPORTED_URLS.iter() {
             let u = Url::from_str(url_str).unwrap();
-            assert_eq!(expected.scheme, u.scheme(), "{}", url_str);
-            assert_eq!(expected.host, u.host(), "{}", url_str);
-            assert_eq!(expected.port, u.port(), "{}", url_str);
-            assert_eq!(expected.path, u.path(), "{}", url_str);
+            assert_eq!(expected.scheme, u.scheme(), "{url_str}");
+            assert_eq!(expected.host, u.host(), "{url_str}");
+            assert_eq!(expected.port, u.port(), "{url_str}");
+            assert_eq!(expected.path, u.path(), "{url_str}");
             if let Some(n) = u.username() {
-                assert_eq!(expected.username.as_ref().unwrap(), n, "{}", url_str);
+                assert_eq!(expected.username.as_ref().unwrap(), n, "{url_str}");
             } else {
                 assert!(expected.username.is_none(), "{}", url_str);
             }
             if let Some(pw) = u.password() {
-                assert_eq!(expected.password.as_ref().unwrap(), pw, "{}", url_str);
+                assert_eq!(expected.password.as_ref().unwrap(), pw, "{url_str}");
             } else {
                 assert!(expected.password.is_none(), "{}", url_str);
             }

--- a/rpc/tests/gaia_fixtures.rs
+++ b/rpc/tests/gaia_fixtures.rs
@@ -90,7 +90,7 @@ fn incoming_fixtures() {
                     let r = Event::from_string(content);
                     assert!(r.is_ok(), "failed to parse event {file_name}: {r:?}");
                 } else {
-                    panic!("unhandled incoming fixture: {}", file_name);
+                    panic!("unhandled incoming fixture: {file_name}");
                 }
             },
         }
@@ -161,7 +161,7 @@ fn outgoing_fixtures() {
                 let r = endpoint::subscribe::Request::from_string(content);
                 assert!(r.is_ok(), "{r:?}");
             },
-            _ => panic!("unhandled outgoing fixture: {}", file_name),
+            _ => panic!("unhandled outgoing fixture: {file_name}"),
         }
     }
 }

--- a/rpc/tests/gaia_fixtures.rs
+++ b/rpc/tests/gaia_fixtures.rs
@@ -35,7 +35,7 @@ fn incoming_fixtures() {
         match file_name {
             "abci_info_0" | "abci_info_1" | "abci_info_2" => {
                 let r = endpoint::abci_info::Response::from_string(content);
-                assert!(r.is_ok(), "{:?}", r)
+                assert!(r.is_ok(), "{r:?}")
             },
             "block_at_height_0" => {
                 assert!(endpoint::block::Response::from_string(content).is_err())
@@ -48,15 +48,15 @@ fn incoming_fixtures() {
             },
             "block_at_height_4555980" => {
                 let r = endpoint::block::Response::from_string(content);
-                assert!(r.is_ok(), "{:?}", r);
+                assert!(r.is_ok(), "{r:?}");
             },
             "block_results_at_height_10" => {
                 let r = endpoint::block_results::Response::from_string(content);
-                assert!(r.is_ok(), "block_results_at_height_10: {:?}", r);
+                assert!(r.is_ok(), "block_results_at_height_10: {r:?}");
             },
             "block_results_at_height_4555980" => {
                 let r = endpoint::block_results::Response::from_string(content);
-                assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
+                assert!(r.is_ok(), "block_results_at_height_4555980: {r:?}");
             },
             "blockchain_from_1_to_10" => {
                 assert!(endpoint::blockchain::Response::from_string(content).is_ok())
@@ -83,12 +83,12 @@ fn incoming_fixtures() {
             },
             "subscribe_newblock" => {
                 let r = endpoint::subscribe::Response::from_string(content);
-                assert!(r.is_err(), "{:?}", r);
+                assert!(r.is_err(), "{r:?}");
             },
             _ => {
                 if file_name.starts_with("subscribe_newblock_") {
                     let r = Event::from_string(content);
-                    assert!(r.is_ok(), "failed to parse event {}: {:?}", file_name, r);
+                    assert!(r.is_ok(), "failed to parse event {file_name}: {r:?}");
                 } else {
                     panic!("unhandled incoming fixture: {}", file_name);
                 }
@@ -111,7 +111,7 @@ fn outgoing_fixtures() {
         match file_name {
             "abci_info" => {
                 let r = endpoint::abci_info::Request::from_string(content);
-                assert!(r.is_ok(), "{:?}", r)
+                assert!(r.is_ok(), "{r:?}")
             },
             "block_at_height_0" => {
                 assert!(endpoint::block::Request::from_string(content).is_ok())
@@ -127,11 +127,11 @@ fn outgoing_fixtures() {
             },
             "block_results_at_height_10" => {
                 let r = endpoint::block_results::Request::from_string(content);
-                assert!(r.is_ok(), "block_results_at_height_10: {:?}", r);
+                assert!(r.is_ok(), "block_results_at_height_10: {r:?}");
             },
             "block_results_at_height_4555980" => {
                 let r = endpoint::block_results::Request::from_string(content);
-                assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
+                assert!(r.is_ok(), "block_results_at_height_4555980: {r:?}");
             },
             "blockchain_from_1_to_10" => {
                 assert!(endpoint::blockchain::Request::from_string(content).is_ok())
@@ -159,7 +159,7 @@ fn outgoing_fixtures() {
             },
             "subscribe_newblock" => {
                 let r = endpoint::subscribe::Request::from_string(content);
-                assert!(r.is_ok(), "{:?}", r);
+                assert!(r.is_ok(), "{r:?}");
             },
             _ => panic!("unhandled outgoing fixture: {}", file_name),
         }

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -290,7 +290,7 @@ fn outgoing_fixtures() {
                 assert_eq!(wrapped.params().order_by, Order::Ascending);
             },
             _ => {
-                panic!("cannot parse file name: {}", file_name);
+                panic!("cannot parse file name: {file_name}");
             },
         }
     }
@@ -512,7 +512,7 @@ fn incoming_fixtures() {
                         check_vote(&dup.vote_a);
                         check_vote(&dup.vote_b);
                     } else {
-                        panic!("not a duplicate vote: {:?}", evidence);
+                        panic!("not a duplicate vote: {evidence:?}");
                     }
                 }
             },
@@ -825,7 +825,7 @@ fn incoming_fixtures() {
 
                 match result {
                     Err(Error(ErrorDetail::Serde(_), _)) => {},
-                    _ => panic!("expected Serde parse error, instead got {:?}", result),
+                    _ => panic!("expected Serde parse error, instead got {result:?}"),
                 }
             },
             "subscribe_newblock_0" => {
@@ -1402,7 +1402,7 @@ fn incoming_fixtures() {
                 }
             },
             _ => {
-                panic!("cannot parse file name: {}", file_name);
+                panic!("cannot parse file name: {file_name}");
             },
         }
     }
@@ -1419,7 +1419,7 @@ fn check_event_attrs(events: &HashMap<String, Vec<String>>, app_key: &str, heigh
             "tm.event" => assert_eq!(v[0], "Tx"),
             "tx.hash" => assert_eq!(v[0].len(), 64),
             "tx.height" => assert_eq!(v[0], height.to_string()),
-            _ => panic!("unknown event found {}", k),
+            _ => panic!("unknown event found {k}"),
         }
     }
 }

--- a/std-ext/Cargo.toml
+++ b/std-ext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       = "tendermint-std-ext"
 version    = "0.28.0"
-edition    = "2018"
+edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs"

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -74,7 +74,7 @@ impl ConstantTimeEq for Id {
 impl Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in &self.0 {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }
@@ -82,7 +82,7 @@ impl Display for Id {
 
 impl Debug for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "account::Id({})", self)
+        write!(f, "account::Id({self})")
     }
 }
 

--- a/tendermint/src/block/height.rs
+++ b/tendermint/src/block/height.rs
@@ -111,7 +111,7 @@ impl FromStr for Height {
 impl<'de> Deserialize<'de> for Height {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+            .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 

--- a/tendermint/src/block/round.rs
+++ b/tendermint/src/block/round.rs
@@ -92,7 +92,7 @@ impl FromStr for Round {
 impl<'de> Deserialize<'de> for Round {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+            .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 

--- a/tendermint/src/chain/id.rs
+++ b/tendermint/src/chain/id.rs
@@ -130,7 +130,7 @@ impl Serialize for Id {
 impl<'de> Deserialize<'de> for Id {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+            .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -16,7 +16,7 @@ define_error! {
 
         InvalidKey
             { detail: String }
-            |e| { format_args!("invalid key: {}", e) },
+            |e| { format_args!("invalid key: {e}") },
 
         Length
             |_| { format_args!("length error") },

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -138,7 +138,7 @@ impl Hash {
 impl Debug for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Hash::Sha256(_) => write!(f, "Hash::Sha256({})", self),
+            Hash::Sha256(_) => write!(f, "Hash::Sha256({self})"),
             Hash::None => write!(f, "Hash::None"),
         }
     }
@@ -157,7 +157,7 @@ impl Display for Hash {
             Hash::None => String::new(),
         };
 
-        write!(f, "{}", hex)
+        write!(f, "{hex}")
     }
 }
 
@@ -177,7 +177,7 @@ impl<'de> Deserialize<'de> for Hash {
         if hex.is_empty() {
             Err(D::Error::custom("empty hash"))
         } else {
-            Ok(Self::from_str(hex).map_err(|e| D::Error::custom(format!("{}", e)))?)
+            Ok(Self::from_str(hex).map_err(|e| D::Error::custom(format!("{e}")))?)
         }
     }
 }

--- a/tendermint/src/node/id.rs
+++ b/tendermint/src/node/id.rs
@@ -52,7 +52,7 @@ impl ConstantTimeEq for Id {
 impl Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in &self.0 {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -60,7 +60,7 @@ impl Display for Id {
 
 impl Debug for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "node::Id({})", self)
+        write!(f, "node::Id({self})")
     }
 }
 

--- a/tendermint/src/proposal/msg_type.rs
+++ b/tendermint/src/proposal/msg_type.rs
@@ -41,7 +41,6 @@ impl Serialize for Type {
 impl<'de> Deserialize<'de> for Type {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let byte = i32::deserialize(deserializer)?;
-        Type::try_from(byte)
-            .map_err(|_| D::Error::custom(format!("invalid proposal type: {}", byte)))
+        Type::try_from(byte).map_err(|_| D::Error::custom(format!("invalid proposal type: {byte}")))
     }
 }

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -220,8 +220,7 @@ impl PublicKey {
                         )
                     }),
                     Err(e) => Err(Error::signature_invalid(format!(
-                        "invalid Secp256k1 signature: {}",
-                        e
+                        "invalid Secp256k1 signature: {e}"
                     ))),
                 }
             },
@@ -380,7 +379,7 @@ impl FromStr for Algorithm {
         match s {
             "ed25519" => Ok(Algorithm::Ed25519),
             "secp256k1" => Ok(Algorithm::Secp256k1),
-            _ => Err(Error::parse(format!("invalid algorithm: {}", s))),
+            _ => Err(Error::parse(format!("invalid algorithm: {s}"))),
         }
     }
 }

--- a/tendermint/src/trust_threshold.rs
+++ b/tendermint/src/trust_threshold.rs
@@ -132,10 +132,7 @@ mod test {
     use super::*;
 
     fn to_json(num: u64, denom: u64) -> String {
-        format!(
-            "{{\"numerator\": \"{}\", \"denominator\": \"{}\"}}",
-            num, denom
-        )
+        format!("{{\"numerator\": \"{num}\", \"denominator\": \"{denom}\"}}")
     }
 
     fn from_json(num: u64, denom: u64) -> Result<TrustThresholdFraction, serde_json::Error> {

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -259,7 +259,7 @@ impl fmt::Display for Type {
             Type::Prevote => "Prevote",
             Type::Precommit => "Precommit",
         };
-        write!(f, "{}", id)
+        write!(f, "{id}")
     }
 }
 

--- a/tendermint/src/vote/power.rs
+++ b/tendermint/src/vote/power.rs
@@ -84,9 +84,9 @@ impl<'de> Deserialize<'de> for Power {
         Ok(Power(
             String::deserialize(deserializer)?
                 .parse::<i64>()
-                .map_err(|e| D::Error::custom(format!("{}", e)))?
+                .map_err(|e| D::Error::custom(format!("{e}")))?
                 .try_into()
-                .map_err(|e| D::Error::custom(format!("{}", e)))?,
+                .map_err(|e| D::Error::custom(format!("{e}")))?,
         ))
     }
 }

--- a/tendermint/src/vote/sign_vote.rs
+++ b/tendermint/src/vote/sign_vote.rs
@@ -292,7 +292,7 @@ mod tests {
                 vote_type: Type::Precommit,
                 ..Default::default()
             };
-            println!("{:?}", vt_precommit);
+            println!("{vt_precommit:?}");
             let cv_precommit = CanonicalVote::new(vt_precommit, ChainId::try_from("A").unwrap());
             let got = cv_precommit.encode_vec().unwrap();
             let want = vec![

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "tendermint-test"
 description = "Tendermint workspace tests and common utilities for testing."
 version     = "0.28.0"
-edition     = "2018"
+edition     = "2021"
 license     = "Apache-2.0"
 categories  = ["development", "test", "tools"]
 repository  = "https://github.com/informalsystems/tendermint-rs"

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -108,7 +108,7 @@ fn test_split_secret_connection() {
     const MESSAGES_2_TO_1: &[&str] = &["two", "four", "six", "eight"];
     let peer1_listener = TcpListener::bind("127.0.0.1:0").expect("to be able to bind to 127.0.0.1");
     let peer1_addr = peer1_listener.local_addr().unwrap();
-    println!("peer1 bound to {:?}", peer1_addr);
+    println!("peer1 bound to {peer1_addr:?}");
 
     let peer1 = thread::spawn(move || {
         let stream = peer1_listener
@@ -129,7 +129,7 @@ fn test_split_secret_connection() {
                 .read(&mut buf)
                 .expect("to read a message from peer 2");
             let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
-            println!("Got message from peer2: {}", msg);
+            println!("Got message from peer2: {msg}");
             assert_eq!(msg, MESSAGES_2_TO_1[msg_counter]);
         }
     });
@@ -165,7 +165,7 @@ fn test_split_secret_connection() {
             .read(&mut buf)
             .expect("to receive a message from peer 1");
         let msg = String::from_utf8_lossy(&buf[0..br]).to_string();
-        println!("Got message from peer1: {}", msg);
+        println!("Got message from peer1: {msg}");
         assert_eq!(msg, MESSAGES_1_TO_2[msg_counter]);
         write_tx
             .send(MESSAGES_2_TO_1[msg_counter].to_string())

--- a/testgen/bin/tendermint-testgen.rs
+++ b/testgen/bin/tendermint-testgen.rs
@@ -89,9 +89,9 @@ where
         cli.encode()
     };
     match res {
-        Ok(res) => println!("{}", res),
+        Ok(res) => println!("{res}"),
         Err(e) => {
-            eprintln!("Error: {}\n", e);
+            eprintln!("Error: {e}\n");
             eprintln!("Supported parameters for this command are: ");
             print_params(cli.self_usage());
             std::process::exit(1);
@@ -101,14 +101,14 @@ where
 
 fn print_params(options: &str) {
     for line in options.lines().skip(1) {
-        eprintln!("{}", line);
+        eprintln!("{line}");
     }
 }
 
 fn main() {
     let opts = CliOptions::parse_args_default_or_exit();
     if opts.usage {
-        eprintln!("{}", USAGE);
+        eprintln!("{USAGE}");
         std::process::exit(1);
     }
     match opts.command {
@@ -122,7 +122,7 @@ fn main() {
                 .split('\n')
                 .map(|s| s.split_whitespace().next().unwrap())
             {
-                eprintln!("\n{} parameters:", cmd);
+                eprintln!("\n{cmd} parameters:");
                 print_params(CliOptions::command_usage(cmd).unwrap())
             }
             std::process::exit(1);

--- a/testgen/src/tester.rs
+++ b/testgen/src/tester.rs
@@ -45,23 +45,23 @@ impl TestEnv {
     }
 
     pub fn logln(&self, msg: &str) -> Option<()> {
-        println!("{}", msg);
+        println!("{msg}");
         fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(self.full_path("log"))
             .ok()
-            .and_then(|mut file| writeln!(file, "{}", msg).ok())
+            .and_then(|mut file| writeln!(file, "{msg}").ok())
     }
 
     pub fn logln_to(&self, msg: &str, rel_path: impl AsRef<Path>) -> Option<()> {
-        println!("{}", msg);
+        println!("{msg}");
         fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(self.full_path(rel_path))
             .ok()
-            .and_then(|mut file| writeln!(file, "{}", msg).ok())
+            .and_then(|mut file| writeln!(file, "{msg}").ok())
     }
 
     /// Read a file from a path relative to the environment current dir into a string
@@ -493,12 +493,12 @@ impl Tester {
             if name.is_empty() {
                 continue;
             }
-            print(&format!("\nResults for '{}'", name));
+            print(&format!("\nResults for '{name}'"));
             let tests = self.successful_tests(name);
             if !tests.is_empty() {
                 print("  Successful tests:  ");
                 for path in tests {
-                    print(&format!("    {}", path));
+                    print(&format!("    {path}"));
                     if let Some(logs) = env.read_file(path + "/log") {
                         print(&logs)
                     }
@@ -509,7 +509,7 @@ impl Tester {
                 do_panic = true;
                 print("  Failed tests:  ");
                 for (path, message, location) in tests {
-                    print(&format!("    {}, '{}', {}", path, message, location));
+                    print(&format!("    {path}, '{message}', {location}"));
                     if let Some(logs) = env.read_file(path + "/log") {
                         print(&logs)
                     }
@@ -521,7 +521,7 @@ impl Tester {
             do_panic = true;
             print("\nUnreadable tests:  ");
             for path in tests {
-                print(&format!("  {}", path))
+                print(&format!("  {path}"))
             }
         }
         let tests = self.unparseable_tests();
@@ -529,7 +529,7 @@ impl Tester {
             do_panic = true;
             print("\nUnparseable tests:  ");
             for path in tests {
-                print(&format!("  {}", path))
+                print(&format!("  {path}"))
             }
         }
         print(&format!(

--- a/tools/abci-test/Cargo.toml
+++ b/tools/abci-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "abci-test"
 version = "0.28.0"
 authors = ["Informal Systems <hello@informal.systems>"]
-edition = "2018"
+edition = "2021"
 description = """
     abci-test provides some end-to-end integration testing between
     tendermint-abci and a full Tendermint node.

--- a/tools/abci-test/src/main.rs
+++ b/tools/abci-test/src/main.rs
@@ -78,9 +78,7 @@ async fn run_tests(client: &mut WebSocketClient) -> Result<(), Box<dyn std::erro
     raw_tx.push(b'=');
     raw_tx.extend(raw_tx_value.clone());
 
-    let _ = client
-        .broadcast_tx_async(raw_tx.clone())
-        .await?;
+    let _ = client.broadcast_tx_async(raw_tx.clone()).await?;
 
     info!("Checking for transaction events");
     let tx = tokio::time::timeout(Duration::from_secs(3), tx_subs.next())
@@ -150,8 +148,8 @@ where
     Err(Box::new(AssertionError {
         ctx: ctx.to_string(),
         what: what.to_string(),
-        expected: format!("{:?}", expected),
-        actual: format!("{:?}", actual),
+        expected: format!("{expected:?}"),
+        actual: format!("{actual:?}"),
     }))
 }
 

--- a/tools/kvstore-test/Cargo.toml
+++ b/tools/kvstore-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kvstore-test"
 version = "0.1.0"
 authors = ["Informal Systems <hello@informal.systems>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/kvstore-test/tests/light-client.rs
+++ b/tools/kvstore-test/tests/light-client.rs
@@ -34,10 +34,7 @@ struct TestEvidenceReporter;
 #[contracts::contract_trait]
 impl EvidenceReporter for TestEvidenceReporter {
     fn report(&self, evidence: Evidence, peer: PeerId) -> Result<Hash, IoError> {
-        panic!(
-            "unexpected fork detected for peer {} with evidence: {:?}",
-            peer, evidence
-        );
+        panic!("unexpected fork detected for peer {peer} with evidence: {evidence:?}");
     }
 }
 
@@ -97,15 +94,15 @@ fn forward() {
     let max_iterations: usize = 10;
 
     for i in 1..=max_iterations {
-        println!("[info ] - iteration {}/{}", i, max_iterations);
+        println!("[info ] - iteration {i}/{max_iterations}");
 
         match handle.verify_to_highest() {
             Ok(light_block) => {
                 println!("[info ] synced to block {}", light_block.height());
             },
             Err(err) => {
-                println!("[error] sync failed: {}", err);
-                panic!("failed to sync to highest: {}", err);
+                println!("[error] sync failed: {err}");
+                panic!("failed to sync to highest: {err}");
             },
         }
 
@@ -126,7 +123,7 @@ fn backward() -> Result<(), Error> {
     std::thread::sleep(Duration::from_secs(2));
 
     for i in 1..=max_iterations {
-        println!("[info ] - iteration {}/{}", i, max_iterations);
+        println!("[info ] - iteration {i}/{max_iterations}");
 
         // First we sync to the highest block to have a high enough trusted state
         let trusted_state = handle.verify_to_highest()?;

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tendermint-proto-compiler"
 version = "0.1.0"
 authors = ["Informal Systems <hello@informal.systems>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/tools/proto-compiler/src/functions.rs
+++ b/tools/proto-compiler/src/functions.rs
@@ -123,7 +123,7 @@ fn find_reference_or_commit<'a>(
     let mut try_reference = repo.resolve_reference_from_short_name(commitish);
     if try_reference.is_err() {
         // Local branch might be missing, try the remote branch
-        try_reference = repo.resolve_reference_from_short_name(&format!("origin/{}", commitish));
+        try_reference = repo.resolve_reference_from_short_name(&format!("origin/{commitish}"));
         tried_origin = true;
         if try_reference.is_err() {
             // Remote branch not found, last chance: try as a commit ID
@@ -144,7 +144,7 @@ fn find_reference_or_commit<'a>(
         if tried_origin {
             panic!("[error] => local branch names with 'origin/' prefix not supported");
         }
-        try_reference = repo.resolve_reference_from_short_name(&format!("origin/{}", commitish));
+        try_reference = repo.resolve_reference_from_short_name(&format!("origin/{commitish}"));
         reference = try_reference.unwrap();
         if reference.is_branch() {
             panic!("[error] => local branch names with 'origin/' prefix not supported");
@@ -181,7 +181,7 @@ pub fn copy_files(src_dir: &Path, target_dir: &Path) {
 
     if !errors.is_empty() {
         for e in errors {
-            println!("[error] => Error while copying compiled file: {}", e);
+            println!("[error] => Error while copying compiled file: {e}");
         }
         panic!("[error] => Aborted.");
     }
@@ -248,10 +248,10 @@ pub fn generate_tendermint_lib(prost_dir: &Path, tendermint_lib_target: &Path) {
             //{tabs} pub mod {part} {
             //{inner_content}
             //{tabs} }
-            inner_content = format!("{}pub mod {} {{\n{}\n{}}}", tabs, part, inner_content, tabs);
+            inner_content = format!("{tabs}pub mod {part} {{\n{inner_content}\n{tabs}}}");
         }
 
-        content = format!("{}\n{}\n", content, inner_content);
+        content = format!("{content}\n{inner_content}\n");
     }
 
     // Add meta

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -38,8 +38,7 @@ fn main() {
     }));
 
     println!(
-        "[info] => Fetching {} at {} into {:?}",
-        TENDERMINT_REPO, TENDERMINT_COMMITISH, tendermint_dir
+        "[info] => Fetching {TENDERMINT_REPO} at {TENDERMINT_COMMITISH} into {tendermint_dir:?}"
     );
     get_commitish(
         &PathBuf::from(&tendermint_dir),

--- a/tools/rpc-probe/Cargo.toml
+++ b/tools/rpc-probe/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "tendermint-rpc-probe"
-version = "0.28.0"
-authors = ["Informal Systems <hello@informal.systems>"]
-edition = "2018"
+name       = "tendermint-rpc-probe"
+version    = "0.28.0"
+authors    = ["Informal Systems <hello@informal.systems>"]
+edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs"

--- a/tools/rpc-probe/src/client.rs
+++ b/tools/rpc-probe/src/client.rs
@@ -102,8 +102,7 @@ impl Client {
             }
         }
         Err(Error::Internal(format!(
-            "subscription terminated before we could reach target height of {}",
-            h
+            "subscription terminated before we could reach target height of {h}"
         )))
     }
 
@@ -114,8 +113,7 @@ impl Client {
     async fn send_cmd(&mut self, cmd: DriverCommand) -> Result<()> {
         self.cmd_tx.send(cmd).map_err(|e| {
             Error::Internal(format!(
-                "WebSocket driver channel receiving end closed unexpectedly: {}",
-                e,
+                "WebSocket driver channel receiving end closed unexpectedly: {e}",
             ))
         })
     }
@@ -164,7 +162,7 @@ impl ClientDriver {
                     Ok(msg) => self.handle_incoming_msg(msg).await?,
                     Err(e) => return Err(
                         Error::WebSocket(
-                            format!("failed to read from WebSocket connection: {}", e),
+                            format!("failed to read from WebSocket connection: {e}"),
                         ),
                     ),
                 },
@@ -186,9 +184,10 @@ impl ClientDriver {
     }
 
     async fn send_msg(&mut self, msg: Message) -> Result<()> {
-        self.stream.send(msg).await.map_err(|e| {
-            Error::WebSocket(format!("failed to write to WebSocket connection: {}", e))
-        })
+        self.stream
+            .send(msg)
+            .await
+            .map_err(|e| Error::WebSocket(format!("failed to write to WebSocket connection: {e}")))
     }
 
     async fn send_json(&mut self, req: &serde_json::Value) -> Result<()> {
@@ -209,7 +208,7 @@ impl ClientDriver {
 
         let json_msg = serde_json::from_str::<serde_json::Value>(&msg)?;
         let id = json_msg.get("id").ok_or_else(|| {
-            Error::MalformedResponse(format!("incoming message has no \"id\" field: {}", msg))
+            Error::MalformedResponse(format!("incoming message has no \"id\" field: {msg}"))
         })?;
 
         // Check if we recognize this ID as a response to an earlier request
@@ -288,7 +287,7 @@ impl ClientDriver {
                     .to_string();
                 self.confirm_pending_request(method, wrapper, response_tx)
             },
-            _ => panic!("Unexpected pending command type: {:?}", pending_command),
+            _ => panic!("Unexpected pending command type: {pending_command:?}"),
         }
     }
 

--- a/tools/rpc-probe/src/common.rs
+++ b/tools/rpc-probe/src/common.rs
@@ -27,7 +27,7 @@ pub fn block(height: u64) -> PlannedInteraction {
     Request::new(
         "block",
         json!({
-            "height": format!("{}", height),
+            "height": format!("{height}"),
         }),
     )
     .into()
@@ -37,7 +37,7 @@ pub fn block_by_hash(hash: &str) -> PlannedInteraction {
     Request::new(
         "block_by_hash",
         json!({
-            "hash": format!("{}", hash),
+            "hash": format!("{hash}"),
         }),
     )
     .into()
@@ -48,8 +48,8 @@ pub fn block_search(query: &str, page: u32, per_page: u32, order_by: &str) -> Pl
         "block_search",
         json!({
             "query": query,
-            "page": format!("{}", page),
-            "per_page": format!("{}", per_page),
+            "page": format!("{page}"),
+            "per_page": format!("{per_page}"),
             "order_by": order_by,
         }),
     )
@@ -60,7 +60,7 @@ pub fn block_results(height: u64) -> PlannedInteraction {
     Request::new(
         "block_results",
         json!({
-            "height": format!("{}", height),
+            "height": format!("{height}"),
         }),
     )
     .into()
@@ -70,8 +70,8 @@ pub fn blockchain(min_height: u64, max_height: u64) -> PlannedInteraction {
     Request::new(
         "blockchain",
         json!({
-            "minHeight": format!("{}", min_height),
-            "maxHeight": format!("{}", max_height),
+            "minHeight": format!("{min_height}"),
+            "maxHeight": format!("{max_height}"),
         }),
     )
     .into()
@@ -79,7 +79,7 @@ pub fn blockchain(min_height: u64, max_height: u64) -> PlannedInteraction {
 
 pub fn broadcast_tx(method: &str, key: &str, value: &str) -> PlannedInteraction {
     Request::new(
-        format!("broadcast_tx_{}", method).as_str(),
+        format!("broadcast_tx_{method}").as_str(),
         json!({
             "tx": encode_kvpair(key, value),
         }),
@@ -91,7 +91,7 @@ pub fn commit(height: u64) -> PlannedInteraction {
     Request::new(
         "commit",
         json!({
-            "height": format!("{}", height),
+            "height": format!("{height}"),
         }),
     )
     .into()
@@ -101,7 +101,7 @@ pub fn consensus_params(height: u64) -> PlannedInteraction {
     Request::new(
         "consensus_params",
         json!({
-            "height": format!("{}", height),
+            "height": format!("{height}"),
         }),
     )
     .into()
@@ -139,8 +139,8 @@ pub fn tx_search(
         json!({
             "query": query,
             "prove": prove,
-            "page": format!("{}", page),
-            "per_page": format!("{}", per_page),
+            "page": format!("{page}"),
+            "per_page": format!("{per_page}"),
             "order_by": order_by,
         }),
     )

--- a/tools/rpc-probe/src/error.rs
+++ b/tools/rpc-probe/src/error.rs
@@ -54,16 +54,13 @@ impl From<serde_json::Error> for Error {
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
     fn from(e: tokio::sync::mpsc::error::SendError<T>) -> Self {
-        Self::Internal(format!("failed to send to channel: {}", e))
+        Self::Internal(format!("failed to send to channel: {e}"))
     }
 }
 
 impl From<tokio::task::JoinError> for Error {
     fn from(e: tokio::task::JoinError) -> Self {
-        Self::Internal(format!(
-            "failed while waiting for async task to join: {}",
-            e
-        ))
+        Self::Internal(format!("failed while waiting for async task to join: {e}"))
     }
 }
 

--- a/tools/rpc-probe/src/kvstore.rs
+++ b/tools/rpc-probe/src/kvstore.rs
@@ -26,7 +26,8 @@ pub fn quick_probe_plan(output_path: &Path, request_wait: Duration) -> Result<Pl
                     .with_min_height(10)
                     .with_name("block_at_height_10"),
                 block_results(10).with_name("block_results_at_height_10"),
-                block_by_hash("0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF").with_name("block_by_hash"),
+                block_by_hash("0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF")
+                    .with_name("block_by_hash"),
                 block_search("block.height > 1", 1, 100, "asc").with_name("block_search"),
                 blockchain(1, 10).with_name("blockchain_from_1_to_10"),
                 commit(10).with_name("commit_at_height_10"),
@@ -50,8 +51,8 @@ pub fn quick_probe_plan(output_path: &Path, request_wait: Duration) -> Result<Pl
                 (0..=5)
                     .into_iter()
                     .map(|i| {
-                        broadcast_tx("async", format!("tx{}", i).as_str(), "value")
-                            .with_name(format!("subscribe_txs_broadcast_tx_{}", i).as_str())
+                        broadcast_tx("async", format!("tx{i}").as_str(), "value")
+                            .with_name(format!("subscribe_txs_broadcast_tx_{i}").as_str())
                             .with_pre_wait(Duration::from_secs(1))
                     })
                     .collect(),

--- a/tools/rpc-probe/src/plan.rs
+++ b/tools/rpc-probe/src/plan.rs
@@ -440,7 +440,7 @@ async fn execute_subscription(
                 Ok(event_json) => {
                     write_json(
                         &config.in_path,
-                        format!("{}_{}", name, event_count).as_str(),
+                        format!("{name}_{event_count}").as_str(),
                         &event_json,
                     )
                     .await?;
@@ -450,7 +450,7 @@ async fn execute_subscription(
                     Error::Failed(_, response) => {
                         write_json(
                             &config.in_path,
-                            format!("{}_err", name).as_str(),
+                            format!("{name}_err").as_str(),
                             &response,
                         )
                         .await?;

--- a/tools/rpc-probe/src/utils.rs
+++ b/tools/rpc-probe/src/utils.rs
@@ -20,7 +20,7 @@ pub fn uuid_v4() -> String {
 }
 
 pub fn encode_kvpair(key: &str, value: &str) -> String {
-    let kvpair = format!("{}={}", key, value);
+    let kvpair = format!("{key}={value}");
     String::from_utf8(base64::encode(kvpair.as_bytes())).unwrap()
 }
 
@@ -29,7 +29,7 @@ pub fn hex_string(s: &str) -> String {
 }
 
 pub async fn write_json(base_path: &Path, name: &str, v: &serde_json::Value) -> Result<()> {
-    let path = base_path.join(format!("{}.json", name));
+    let path = base_path.join(format!("{name}.json"));
     tokio::fs::write(path, serde_json::to_string_pretty(v).unwrap()).await?;
     Ok(())
 }


### PR DESCRIPTION
Closes: #1262

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
