### PR TITLE
Derive PartialEq, Eq on ProdCommitValidator

### DIFF
--- a/light-client-verifier/src/operations/commit_validator.rs
+++ b/light-client-verifier/src/operations/commit_validator.rs
@@ -65,7 +65,7 @@ pub trait CommitValidator: Send + Sync {
 }
 
 /// Production-ready implementation of a commit validator.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct ProdCommitValidator;
 
 impl CommitValidator for ProdCommitValidator {}

--- a/light-client-verifier/src/verifier.rs
+++ b/light-client-verifier/src/verifier.rs
@@ -285,6 +285,12 @@ mod tests {
         Verdict, Verifier,
     };
 
+    #[cfg(feature = "rust-crypto")]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct ProdVerifierSupportsCommonDerivedTraits {
+        verifier: ProdVerifier,
+    }
+
     #[test]
     fn test_verification_failure_on_chain_id_mismatch() {
         let now = Time::now();


### PR DESCRIPTION
Hermes needs `PartialEq` and `Eq` implemented on `ProdVerifier`. No idea why, but it's simple to add the derives
rather than fighting this downstream.

Also add test code that ensures `ProdVerifier` supports the common derived traits.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Added entry in `.changelog/`
