### PR TITLE
ci: Automate release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,8 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
-      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"  # e.g. v0.37.0-alpha.1, v0.38.0-alpha.10
-      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"   # e.g. v0.37.0-beta.1, v0.38.0-beta.10
-      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"      # e.g. v0.37.0-rc1, v0.38.0-rc10
+      - "v[0-9]+.[0-9]+.[0-9]+"             # Push events to matching v*, i.e. v0.26.0, v1.0.0
+      - "v[0-9]+.[0-9]+.[0-9]+-pre.[0-9]+"  # e.g. v0.26.0-pre.1
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+# Attempts to perform a release when a particular tag is pushed. This uses the
+# release.sh script in the root of the repository, and assumes that the
+# CRATES_TOKEN secret has been set and contains an API token with which we can
+# publish our crates to crates.io.
+#
+# If release operation fails partway through due to a temporary error (e.g. the
+# crate being published depends on the crate published just prior, but the
+# prior crate isn't yet available via crates.io), one can simply rerun this
+# workflow. The release.sh script aims to be an idempotent operation, skipping
+# the publishing of crates that have already been published.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"  # e.g. v0.37.0-alpha.1, v0.38.0-alpha.10
+      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"   # e.g. v0.37.0-beta.1, v0.38.0-beta.10
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"      # e.g. v0.37.0-rc1, v0.38.0-rc10
+
+jobs:
+  release:
+    runs-on: ubuntu
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Publish crates
+        run: ./release.sh
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+

--- a/release.sh
+++ b/release.sh
@@ -23,6 +23,16 @@ DEFAULT_CRATES="tendermint-proto tendermint-std-ext tendermint tendermint-config
 # Allows us to override the crates we want to publish.
 CRATES=${*:-${DEFAULT_CRATES}}
 
+# Additional flags to pass to the "cargo publish" operation for every crate we
+# publish.
+CARGO_PUBLISH_FLAGS=""
+
+# Allow us to specify a crates.io API token via environment variables. Mostly
+# for CI use.
+if [ -n "${CRATES_TOKEN}" ]; then
+  CARGO_PUBLISH_FLAGS="${CARGO_PUBLISH_FLAGS} --token ${CRATES_TOKEN}"
+fi
+
 get_manifest_path() {
   cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "'"${1}"'")|.manifest_path'
 }
@@ -37,7 +47,7 @@ check_version_online() {
 
 publish() {
   echo "Publishing crate $1..."
-  cargo publish --manifest-path "$(get_manifest_path "${1}")"
+  cargo publish --manifest-path "$(get_manifest_path "${1}")" ${CARGO_PUBLISH_FLAGS}
   echo ""
 }
 


### PR DESCRIPTION
Relates to #707.

This simply allows us to execute the `release.sh` script by way of pushing tags to the repository. In future we may want to consider using a more sophisticated, robust process, but for now this should work.

Allows for the publishing of crates on behalf of @bftbot.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
