### PR TITLE
Bump async-tungstenite dependency to 0.20

### DIFF
--- a/.changelog/unreleased/breaking-changes/1276-tungstenite-0.18.md
+++ b/.changelog/unreleased/breaking-changes/1276-tungstenite-0.18.md
@@ -1,0 +1,3 @@
+- [`tendermint-rpc`] Bump `async-tungstenite` dependency version to 0.20,
+  re-exporting `WebSocketConfig` from `tungstenite` 0.18
+  ([\#1276](https://github.com/informalsystems/tendermint-rs/pull/1276)).

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -84,7 +84,7 @@ subtle = { version = "2", default-features = false }
 
 # Optional dependencies
 async-trait = { version = "0.1", optional = true, default-features = false }
-async-tungstenite = { version = "0.17", default-features = false, features = ["tokio-runtime", "tokio-rustls-native-certs"], optional = true }
+async-tungstenite = { version = "0.20", default-features = false, features = ["tokio-runtime", "tokio-rustls-native-certs"], optional = true }
 futures = { version = "0.3", optional = true, default-features = false }
 http = { version = "0.2", optional = true, default-features = false }
 hyper = { version = "0.14", optional = true, default-features = false, features = ["client", "http1", "http2"] }


### PR DESCRIPTION
Dependency bump. No changes needed in the code, but since we
re-export `WebSocketConfig` from tungstenite in the tendermint-rpc API, this is still a breaking change.

* [x] Added entry in `.changelog/`
