### PR TITLE
Derive `Hash` on `tendermint::Time` again

### DIFF
--- a/.changelog/unreleased/improvements/1278-re-add-hash-on-time.md
+++ b/.changelog/unreleased/improvements/1278-re-add-hash-on-time.md
@@ -1,0 +1,2 @@
+- Derive `Hash` on `tendermint::Time`
+  ([#1278](https://github.com/informalsystems/tendermint-rs/issues/1278))

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -34,7 +34,7 @@ use crate::{error::Error, prelude::*};
 // For memory efficiency, the inner member is `PrimitiveDateTime`, with assumed
 // UTC offset. The `assume_utc` method is used to get the operational
 // `OffsetDateTime` value.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "Timestamp", into = "Timestamp")]
 pub struct Time(PrimitiveDateTime);
 


### PR DESCRIPTION
This reintroduces #1054 after it was removed in #1203.

I believe there was no concern in having `Time` derive `Hash` so it seems fine to re-apply this change.

<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [X] Added entry in `.changelog/`
