### PR TITLE
Show `max_clock_drift` in error raised when header is from the future

### DIFF
--- a/.changelog/unreleased/improvements/1280-max-drift-error.md
+++ b/.changelog/unreleased/improvements/1280-max-drift-error.md
@@ -1,0 +1,3 @@
+- [tendermint-light-client] Show `max_clock_drift` in error raised when header
+  is from the future ([\#1280](https://github.com/informalsystems/tendermint-
+  rs/issues/1280))

--- a/light-client-verifier/src/errors.rs
+++ b/light-client-verifier/src/errors.rs
@@ -23,10 +23,11 @@ define_error! {
             {
                 header_time: Time,
                 now: Time,
+                max_clock_drift: Duration,
             }
             | e | {
-                format_args!("header from the future: header_time={0} now={1}",
-                    e.header_time, e.now)
+                format_args!("header from the future: header_time={0} now={1} max_clock_drift={2:?}",
+                    e.header_time, e.now, e.max_clock_drift)
             },
 
         NotEnoughTrust

--- a/light-client-verifier/src/predicates.rs
+++ b/light-client-verifier/src/predicates.rs
@@ -131,6 +131,7 @@ pub trait VerificationPredicates: Send + Sync {
             Err(VerificationError::header_from_the_future(
                 untrusted_header_time,
                 now,
+                clock_drift,
             ))
         }
     }


### PR DESCRIPTION
Closes: #1280

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
