### PR TITLE
Bump `ed25519` => v2; `k256` => v0.13; `signature` => v2

### DIFF
--- a/.changelog/unreleased/breaking-changes/1290-signature-v2.md
+++ b/.changelog/unreleased/breaking-changes/1290-signature-v2.md
@@ -1,0 +1,1 @@
+* `[tendermint, tendermint-p2p]` Bump `ed25519` to v2, `k256` to v0.13, and `signature` to v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-03-01 # regression prevents docs from building
           override: true
       - uses: actions-rs/cargo@v1
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,3 @@ exclude = [
 [profile.release.package.tendermint-light-client-js]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
-
-# WORKAROUND for fizyk20/generic-array#133
-# Docs build is broken without this until above PR is merged/released
-[patch.crates-io.generic-array]
-git = "https://github.com/fjarri/generic-array"
-branch = "zeroize-docs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ exclude = [
 [profile.release.package.tendermint-light-client-js]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+# WORKAROUND for fizyk20/generic-array#133
+# Docs build is broken without this until above PR is merged/released
+[patch.crates-io.generic-array]
+git = "https://github.com/fjarri/generic-array"
+branch = "zeroize-docs"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 x25519-dalek = { version = "1.1", default-features = false, features = ["u64_backend"] }
 zeroize = { version = "1", default-features = false }
-signature = { version = "1", default-features = false }
+signature = { version = "2", default-features = false }
 aead = { version = "0.4.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bytes = { version = "1.2", default-features = false, features = ["serde"] }
 digest = { version = "0.10", default-features = false }
-ed25519 = { version = "1.5", default-features = false }
+ed25519 = { version = "2", default-features = false, features = ["alloc"] }
 futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.3", default-features = false }
@@ -41,7 +41,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
-signature = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["alloc"] }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.30.0", default-features = false, path = "../proto" }
@@ -50,7 +50,7 @@ zeroize = { version = "1.1", default-features = false, features = ["zeroize_deri
 flex-error = { version = "0.4.4", default-features = false }
 ed25519-consensus = { version = "2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
-k256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
+k256 = { version = "0.13", optional = true, default-features = false, features = ["alloc", "ecdsa"] }
 ripemd = { version = "0.1.3", optional = true, default-features = false }
 
 [features]
@@ -61,7 +61,7 @@ secp256k1 = ["k256", "ripemd"]
 rust-crypto = ["sha2", "ed25519-consensus"]
 
 [dev-dependencies]
-k256 = { version = "0.11", default-features = false, features = ["ecdsa"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 pretty_assertions = "1.3.0"
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 tendermint-pbt-gen = { path = "../pbt-gen", default-features = false, features = ["time"] }

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -117,7 +117,7 @@ mod key_conversions {
         fn from(pk: Secp256k1) -> Id {
             use ripemd::Ripemd160;
 
-            let sha_digest = Sha256::digest(pk.to_bytes());
+            let sha_digest = Sha256::digest(pk.to_sec1_bytes());
             let ripemd_digest = Ripemd160::digest(&sha_digest[..]);
             let mut bytes = [0u8; LENGTH];
             bytes.copy_from_slice(&ripemd_digest[..LENGTH]);

--- a/tendermint/src/crypto/default/signature.rs
+++ b/tendermint/src/crypto/default/signature.rs
@@ -283,8 +283,8 @@ mod tests {
                 _ => panic!("expected public key to be secp256k1: {:?}", public_key),
             }
             let der_sig = k256::ecdsa::Signature::from_der(sig).unwrap();
-            let sig = der_sig.as_ref();
-            let sig = Signature::try_from(sig).unwrap();
+            let sig = der_sig.to_bytes();
+            let sig = Signature::try_from(sig.as_slice()).unwrap();
             Verifier::verify(public_key, msg, &sig)
                 .unwrap_or_else(|_| panic!("signature should be valid for test vector {}", i));
         }

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -153,7 +153,7 @@ tendermint_pb_modules! {
                 #[cfg(feature = "secp256k1")]
                 PublicKey::Secp256k1(ref pk) => RawPublicKey {
                     sum: Some(Sum::Secp256k1(
-                        pk.to_bytes().to_vec(),
+                        pk.to_sec1_bytes().into(),
                     )),
                 },
             }
@@ -200,7 +200,7 @@ impl PublicKey {
         match self {
             PublicKey::Ed25519(pk) => pk.as_bytes().to_vec(),
             #[cfg(feature = "secp256k1")]
-            PublicKey::Secp256k1(pk) => pk.to_bytes().to_vec(),
+            PublicKey::Secp256k1(pk) => pk.to_sec1_bytes().into(),
         }
     }
 
@@ -215,7 +215,7 @@ impl PublicKey {
             #[cfg(feature = "secp256k1")]
             PublicKey::Secp256k1(ref pk) => {
                 let mut key_bytes = vec![0xEB, 0x5A, 0xE9, 0x87, 0x21];
-                key_bytes.extend(pk.to_bytes());
+                key_bytes.extend(pk.to_sec1_bytes().as_ref());
                 key_bytes
             },
         };
@@ -373,7 +373,7 @@ fn serialize_secp256k1_base64<S>(pk: &Secp256k1, serializer: S) -> Result<S::Ok,
 where
     S: ser::Serializer,
 {
-    String::from_utf8(base64::encode(pk.to_bytes()))
+    String::from_utf8(base64::encode(pk.to_sec1_bytes()))
         .unwrap()
         .serialize(serializer)
 }

--- a/tendermint/src/signature.rs
+++ b/tendermint/src/signature.rs
@@ -1,10 +1,9 @@
 //! Cryptographic (a.k.a. digital) signatures
 
-use core::convert::TryFrom;
-
 pub use ed25519::Signature as Ed25519Signature;
 #[cfg(feature = "secp256k1")]
 pub use k256::ecdsa::Signature as Secp256k1Signature;
+
 use tendermint_proto::Protobuf;
 
 use crate::{error::Error, prelude::*};
@@ -83,7 +82,7 @@ impl AsRef<[u8]> for Signature {
 
 impl From<Ed25519Signature> for Signature {
     fn from(sig: Ed25519Signature) -> Signature {
-        Self(sig.as_ref().to_vec())
+        Self(sig.to_vec())
     }
 }
 
@@ -96,7 +95,7 @@ impl From<ed25519_consensus::Signature> for Signature {
 
 #[cfg(feature = "secp256k1")]
 impl From<Secp256k1Signature> for Signature {
-    fn from(pk: Secp256k1Signature) -> Signature {
-        Self(pk.as_ref().to_vec())
+    fn from(sig: Secp256k1Signature) -> Signature {
+        Self(sig.to_vec())
     }
 }

--- a/tendermint/src/test.rs
+++ b/tendermint/src/test.rs
@@ -31,5 +31,7 @@ where
 
 /// Produces a dummy signature value for use as a placeholder in tests.
 pub fn dummy_signature() -> Signature {
-    Signature::from(Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap())
+    Signature::from(Ed25519Signature::from_bytes(
+        &[0; Ed25519Signature::BYTE_SIZE],
+    ))
 }

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -171,9 +171,9 @@ impl Default for Vote {
             validator_index: ValidatorIndex::try_from(0_i32).unwrap(),
             // Could have reused crate::test::dummy_signature, except that
             // this Default impl is defined outside of #[cfg(test)].
-            signature: Some(Signature::from(
-                Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap(),
-            )),
+            signature: Some(Signature::from(Ed25519Signature::from_bytes(
+                &[0; Ed25519Signature::BYTE_SIZE],
+            ))),
         }
     }
 }

--- a/tendermint/tests/alt_crypto.rs
+++ b/tendermint/tests/alt_crypto.rs
@@ -2,7 +2,7 @@
 //! for a chain environment that provides its own cryptographic API.
 #![cfg(all(feature = "secp256k1", feature = "rust-crypto"))]
 
-use ::signature::{DigestVerifier, Signature as _};
+use ::signature::DigestVerifier;
 use digest::Digest;
 
 use tendermint::crypto::signature::{self, Verifier};
@@ -23,7 +23,7 @@ impl Verifier for SubstrateSignatureVerifier {
     ) -> Result<(), signature::Error> {
         match pubkey {
             PublicKey::Secp256k1(pk) => {
-                let sig = k256::ecdsa::Signature::from_bytes(signature.as_bytes())
+                let sig = k256::ecdsa::Signature::try_from(signature.as_bytes())
                     .map_err(|_| signature::Error::MalformedSignature)?;
                 let mut hasher = sha2::Sha256::new();
                 Digest::update(&mut hasher, msg);


### PR DESCRIPTION
Closes: #1290

Bumps all of the above dependencies to their latest versions, which use the new `signature` v2 release:

https://github.com/RustCrypto/traits/pull/1211

<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
