### PR TITLE
Prepare v0.31.0 release

### DIFF
--- a/.changelog/unreleased/breaking-changes/1290-signature-v2.md
+++ b/.changelog/unreleased/breaking-changes/1290-signature-v2.md
@@ -1,1 +1,0 @@
-* `[tendermint, tendermint-p2p]` Bump `ed25519` to v2, `k256` to v0.13, and `signature` to v2

--- a/.changelog/unreleased/improvements/1288-typedevent-trait.md
+++ b/.changelog/unreleased/improvements/1288-typedevent-trait.md
@@ -1,2 +1,0 @@
-- [`tendermint`] Adds a new `TypedEvent` for encoding structured data in ABCI events
-  ([\#1288](https://github.com/informalsystems/tendermint-rs/pull/1288)).

--- a/.changelog/unreleased/improvements/1293-buf-proto-deps.md
+++ b/.changelog/unreleased/improvements/1293-buf-proto-deps.md
@@ -1,3 +1,0 @@
-- [`tools/proto-compiler`] Parse and fetch proto dependencies as listed in the
-  `buf.lock` file
-  ([\#1293](https://github.com/informalsystems/tendermint-rs/pull/1293)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## v0.31.0
+
+Upgrade signature crate versions and add a `TypedEvent` trait for ABCI events.
+
+### BREAKING CHANGES
+
+* `[tendermint, tendermint-p2p]` Bump `ed25519` to v2, `k256` to v0.13, and `signature` to v2
+
+### IMPROVEMENTS
+
+- [`tendermint`] Adds a new `TypedEvent` for encoding structured data in ABCI events
+  ([\#1288](https://github.com/informalsystems/tendermint-rs/pull/1288)).
+- [`tools/proto-compiler`] Parse and fetch proto dependencies as listed in the
+  `buf.lock` file
+  ([\#1293](https://github.com/informalsystems/tendermint-rs/pull/1293)).
+
 ## v0.30.0
 
 This release introduces support for multiple versions of CometBFT protocols.

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-abci"
-version     = "0.30.0"
+version     = "0.31.0"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 license     = "Apache-2.0"
@@ -33,7 +33,7 @@ binary = [
 [dependencies]
 bytes = { version = "1.0", default-features = false }
 prost = { version = "0.11", default-features = false }
-tendermint-proto = { version = "0.30.0", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.31.0", default-features = false, path = "../proto" }
 tracing = { version = "0.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 structopt = { version = "0.3", optional = true, default-features = false }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-config"
-version    = "0.30.0" # Also update depending crates (rpc, light-node, ..) when bumping this.
+version    = "0.31.0" # Also update depending crates (rpc, light-node, ..) when bumping this.
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/main/tendermint"
@@ -24,7 +24,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-tendermint = { version = "0.30.0", default-features = false, features = ["rust-crypto"], path = "../tendermint" }
+tendermint = { version = "0.31.0", default-features = false, features = ["rust-crypto"], path = "../tendermint" }
 flex-error = { version = "0.4.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-light-client-js"
-version     = "0.30.0"
+version     = "0.31.0"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 license     = "Apache-2.0"
@@ -22,8 +22,8 @@ default = ["console_error_panic_hook"]
 [dependencies]
 serde = { version = "1.0", default-features = false, features = [ "derive" ] }
 serde_json = { version = "1.0", default-features = false }
-tendermint = { version = "0.30.0", default-features = false, path = "../tendermint" }
-tendermint-light-client-verifier = { version = "0.30.0", features = ["rust-crypto"], default-features = false, path = "../light-client-verifier" }
+tendermint = { version = "0.31.0", default-features = false, path = "../tendermint" }
+tendermint-light-client-verifier = { version = "0.31.0", features = ["rust-crypto"], default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }
 serde-wasm-bindgen = { version = "0.4.5", default-features = false }
 

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client-verifier"
-version    = "0.30.0"
+version    = "0.31.0"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -27,7 +27,7 @@ default = ["rust-crypto", "flex-error/std", "flex-error/eyre_tracer"]
 rust-crypto = ["tendermint/rust-crypto"]
 
 [dependencies]
-tendermint = { version = "0.30.0", path = "../tendermint", default-features = false }
+tendermint = { version = "0.31.0", path = "../tendermint", default-features = false }
 
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }
 serde = { version = "1.0.106", default-features = false }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client"
-version    = "0.30.0"
+version    = "0.31.0"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -35,9 +35,9 @@ unstable = ["rust-crypto"]
 mbt = ["rust-crypto"]
 
 [dependencies]
-tendermint = { version = "0.30.0", path = "../tendermint", default-features = false }
-tendermint-rpc = { version = "0.30.0", path = "../rpc", default-features = false }
-tendermint-light-client-verifier = { version = "0.30.0", path = "../light-client-verifier", default-features = false }
+tendermint = { version = "0.31.0", path = "../tendermint", default-features = false }
+tendermint-rpc = { version = "0.31.0", path = "../rpc", default-features = false }
+tendermint-light-client-verifier = { version = "0.31.0", path = "../light-client-verifier", default-features = false }
 
 contracts = { version = "0.6.2", default-features = false }
 crossbeam-channel = { version = "0.4.2", default-features = false }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-p2p"
-version     = "0.30.0"
+version     = "0.31.0"
 edition     = "2021"
 license     = "Apache-2.0"
 repository  = "https://github.com/informalsystems/tendermint-rs"
@@ -44,9 +44,9 @@ aead = { version = "0.4.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 # path dependencies
-tendermint = { path = "../tendermint", version = "0.30.0", default-features = false }
-tendermint-proto = { path = "../proto", version = "0.30.0", default-features = false }
-tendermint-std-ext = { path = "../std-ext", version = "0.30.0", default-features = false }
+tendermint = { path = "../tendermint", version = "0.31.0", default-features = false }
+tendermint-proto = { path = "../proto", version = "0.31.0", default-features = false }
+tendermint-std-ext = { path = "../std-ext", version = "0.31.0", default-features = false }
 
 # optional dependencies
 prost-derive = { version = "0.11", optional = true }

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-pbt-gen"
-version     = "0.30.0"
+version     = "0.31.0"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 license     = "Apache-2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-proto"
-version    = "0.30.0"
+version    = "0.31.0"
 authors    = ["Informal Systems <hello@informal.systems>"]
 edition    = "2021"
 license    = "Apache-2.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-rpc"
-version    = "0.30.0"
+version    = "0.31.0"
 edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
@@ -71,8 +71,8 @@ pin-project = { version = "1.0.1", default-features = false }
 serde = { version = "1", default-features = false, features = [ "derive" ] }
 serde_bytes = { version = "0.11", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["std"] }
-tendermint-config = { version = "0.30.0", path = "../config", default-features = false }
-tendermint = { version = "0.30.0", default-features = false, path = "../tendermint" }
+tendermint-config = { version = "0.31.0", path = "../config", default-features = false }
+tendermint = { version = "0.31.0", default-features = false, path = "../tendermint" }
 thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 uuid = { version = "0.8", default-features = false }

--- a/std-ext/Cargo.toml
+++ b/std-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-std-ext"
-version    = "0.30.0"
+version    = "0.31.0"
 edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.30.0" # Also update depending crates (rpc, light-node, etc..) when bumping this .
+version    = "0.31.0" # Also update depending crates (rpc, light-node, etc..) when bumping this .
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/main/tendermint"
@@ -44,7 +44,7 @@ serde_repr = { version = "0.1", default-features = false }
 signature = { version = "2", default-features = false, features = ["alloc"] }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
-tendermint-proto = { version = "0.30.0", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.31.0", default-features = false, path = "../proto" }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tendermint-test"
 description = "Tendermint workspace tests and common utilities for testing."
-version     = "0.30.0"
+version     = "0.31.0"
 edition     = "2021"
 license     = "Apache-2.0"
 categories  = ["development", "test", "tools"]

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-testgen"
-version     = "0.30.0"
+version     = "0.31.0"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 readme      = "README.md"
@@ -16,7 +16,7 @@ description = """
     """
 
 [dependencies]
-tendermint = { version = "0.30.0", path = "../tendermint", features = ["clock"] }
+tendermint = { version = "0.31.0", path = "../tendermint", features = ["clock"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 ed25519-consensus = { version = "2", default-features = false }

--- a/tools/abci-test/Cargo.toml
+++ b/tools/abci-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abci-test"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2021"
 description = """
@@ -14,9 +14,9 @@ description = """
 flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 futures = "0.3"
 structopt = "0.3"
-tendermint = { version = "0.30.0", path = "../../tendermint" }
-tendermint-config = { version = "0.30.0", path = "../../config" }
-tendermint-rpc = { version = "0.30.0", path = "../../rpc", features = [ "websocket-client" ] }
+tendermint = { version = "0.31.0", path = "../../tendermint" }
+tendermint-config = { version = "0.31.0", path = "../../config" }
+tendermint-rpc = { version = "0.31.0", path = "../../rpc", features = [ "websocket-client" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { version = "1.20", features = ["full"] }

--- a/tools/kvstore-test/Cargo.toml
+++ b/tools/kvstore-test/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 [dev-dependencies]
 futures = "0.3"
 sha2 = "0.10"
-tendermint = { version = "0.30.0", path = "../../tendermint" }
-tendermint-light-client = { version = "0.30.0", path = "../../light-client", features = ["unstable"] }
-tendermint-rpc = { version = "0.30.0", path = "../../rpc", features = [ "http-client", "websocket-client" ] }
+tendermint = { version = "0.31.0", path = "../../tendermint" }
+tendermint-light-client = { version = "0.31.0", path = "../../light-client", features = ["unstable"] }
+tendermint-rpc = { version = "0.31.0", path = "../../rpc", features = [ "http-client", "websocket-client" ] }
 tokio = { version = "1.0", features = [ "rt-multi-thread", "macros" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/tools/rpc-probe/Cargo.toml
+++ b/tools/rpc-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-rpc-probe"
-version    = "0.30.0"
+version    = "0.31.0"
 authors    = ["Informal Systems <hello@informal.systems>"]
 edition    = "2021"
 license    = "Apache-2.0"


### PR DESCRIPTION
Prepares an `v0.31.0` release.  This is technically a breaking change because of the signature upgrades, but should otherwise be a trivial upgrade.
