### PR TITLE
Expose the `TypedEvent` conversion trait

### DIFF
--- a/.changelog/unreleased/features/1288-typed_events.md
+++ b/.changelog/unreleased/features/1288-typed_events.md
@@ -1,0 +1,2 @@
+- Expose the `tendermint::abci::event::TypedEvent
+  ([\#1288](https://github.com/informalsystems/tendermint-rs/pull/1288))

--- a/tendermint/src/abci.rs
+++ b/tendermint/src/abci.rs
@@ -47,7 +47,7 @@ pub mod types;
 pub use crate::v0_37::abci::request::Request;
 pub use crate::v0_37::abci::response::Response;
 
-pub use event::{Event, EventAttribute, EventAttributeIndexExt};
+pub use event::{Event, EventAttribute, EventAttributeIndexExt, TypedEvent};
 
 #[doc(inline)]
 pub use self::{


### PR DESCRIPTION
This is a trivial API changes that exposes the `tendermint::abci::event::TypedEvent` marker trait.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
