### PR TITLE
Add `Verifier::verify_misbehaviour_header` for verifying headers coming from a misbehaviour evidence

### DIFF
--- a/.changelog/unreleased/breaking-changes/1294-verify-update-header.md
+++ b/.changelog/unreleased/breaking-changes/1294-verify-update-header.md
@@ -1,0 +1,4 @@
+- [`tendermint-light-client-verifier`] Rename `Verifier::verify`
+  to `Verifier::verify_update_header` to better describe
+  its purpose versus `Verifier::verify_misbehaviour_header`
+  ([\#1294](https://github.com/informalsystems/tendermint-rs/issues/1294))

--- a/.changelog/unreleased/features/1294-verify-misbehavior-header.md
+++ b/.changelog/unreleased/features/1294-verify-misbehavior-header.md
@@ -1,0 +1,5 @@
+- [`tendermint-light-client-verifier`] Add `Verifier::verify_misbehaviour_header`
+  for verifying headers coming from a misbehaviour evidence.
+  The verification for these headers is a bit more relaxed in order to catch FLA attacks.
+  In particular the "header in the future" check for the header should be skipped.
+  ([\#1294](https://github.com/informalsystems/tendermint-rs/issues/1294))

--- a/light-client-js/src/lib.rs
+++ b/light-client-js/src/lib.rs
@@ -32,7 +32,7 @@ pub fn verify(untrusted: JsValue, trusted: JsValue, options: JsValue, now: JsVal
     let result = deserialize_params(untrusted, trusted, options, now).map(
         |(untrusted, trusted, options, now)| {
             let verifier = ProdVerifier::default();
-            verifier.verify(
+            verifier.verify_update_header(
                 untrusted.as_untrusted_state(),
                 trusted.as_trusted_state(),
                 &options,

--- a/light-client-verifier/src/verifier.rs
+++ b/light-client-verifier/src/verifier.rs
@@ -52,7 +52,7 @@ impl From<Result<(), VerificationError>> for Verdict {
 /// - [TMBC-VAL-COMMIT.1]
 pub trait Verifier: Send + Sync {
     /// Verify a header received in a `MsgUpdateClient`.
-    fn verify(
+    fn verify_update_header(
         &self,
         untrusted: UntrustedBlockState<'_>,
         trusted: TrustedBlockState<'_>,
@@ -278,7 +278,7 @@ where
     /// `trusted.next_validators.hash() == trusted.next_validators_hash`,
     /// as typically the `trusted.next_validators` validator set comes from the relayer,
     /// and `trusted.next_validators_hash` is the hash stored on chain.
-    fn verify(
+    fn verify_update_header(
         &self,
         untrusted: UntrustedBlockState<'_>,
         trusted: TrustedBlockState<'_>,
@@ -369,7 +369,7 @@ mod tests {
             clock_drift: Default::default(),
         };
 
-        let verdict = vp.verify(
+        let verdict = vp.verify_update_header(
             light_block_2.as_untrusted_state(),
             light_block_1.as_trusted_state(),
             &opt,

--- a/light-client-verifier/src/verifier.rs
+++ b/light-client-verifier/src/verifier.rs
@@ -220,18 +220,6 @@ where
         Verdict::Success
     }
 
-    /// Validate an `UntrustedBlockState` coming from a misbehaviour evidence,
-    /// based on the given `TrustedBlockState`, `Options` and current time.
-    pub fn validate_misbehaviour_against_trusted(
-        &self,
-        untrusted: &UntrustedBlockState<'_>,
-        trusted: &TrustedBlockState<'_>,
-        options: &Options,
-        now: Time,
-    ) -> Verdict {
-        self.validate_against_trusted(untrusted, trusted, options, now)
-    }
-
     /// Check there is enough overlap between the validator sets of the trusted and untrusted
     /// blocks.
     pub fn verify_commit_against_trusted(
@@ -308,8 +296,7 @@ where
 
     /// Verify a header received in `MsgSubmitMisbehaviour`.
     /// The verification for these headers is a bit more relaxed in order to catch FLA attacks.
-    /// In particular the "header in the future" check for the header should be skipped
-    /// from `validate_against_trusted`.
+    /// In particular the "header in the future" check for the header should be skipped.
     fn verify_misbehaviour_header(
         &self,
         untrusted: UntrustedBlockState<'_>,
@@ -318,9 +305,7 @@ where
         now: Time,
     ) -> Verdict {
         ensure_verdict_success!(self.verify_validator_sets(&untrusted));
-        ensure_verdict_success!(
-            self.validate_misbehaviour_against_trusted(&untrusted, &trusted, options, now)
-        );
+        ensure_verdict_success!(self.validate_against_trusted(&untrusted, &trusted, options, now));
         ensure_verdict_success!(self.verify_commit_against_trusted(&untrusted, &trusted, options));
         ensure_verdict_success!(self.verify_commit(&untrusted));
         Verdict::Success

--- a/light-client-verifier/src/verifier.rs
+++ b/light-client-verifier/src/verifier.rs
@@ -51,8 +51,20 @@ impl From<Result<(), VerificationError>> for Verdict {
 /// - [TMBC-VAL-CONTAINS-CORR.1]
 /// - [TMBC-VAL-COMMIT.1]
 pub trait Verifier: Send + Sync {
-    /// Perform the verification.
+    /// Verify a header received in a `MsgUpdateClient`.
     fn verify(
+        &self,
+        untrusted: UntrustedBlockState<'_>,
+        trusted: TrustedBlockState<'_>,
+        options: &Options,
+        now: Time,
+    ) -> Verdict;
+
+    /// Verify a header received in `MsgSubmitMisbehaviour`.
+    /// The verification for these headers is a bit more relaxed in order to catch FLA attacks.
+    /// In particular the "header in the future" check for the header should be skipped
+    /// from `validate_against_trusted`.
+    fn verify_misbehaviour_header(
         &self,
         untrusted: UntrustedBlockState<'_>,
         trusted: TrustedBlockState<'_>,
@@ -146,9 +158,38 @@ where
         Verdict::Success
     }
 
-    /// Validate an `UntrustedBlockState`, based on the given `TrustedBlockState`, `Options` and
-    /// current time.
+    /// Validate an `UntrustedBlockState` coming from a client update,
+    /// based on the given `TrustedBlockState`, `Options` and current time.
     pub fn validate_against_trusted(
+        &self,
+        untrusted: &UntrustedBlockState<'_>,
+        trusted: &TrustedBlockState<'_>,
+        options: &Options,
+        now: Time,
+    ) -> Verdict {
+        // Ensure the header isn't from a future time
+        verdict!(self.predicates.is_header_from_past(
+            untrusted.signed_header.header.time,
+            options.clock_drift,
+            now,
+        ));
+
+        self.validate_against_trusted_no_future_check(untrusted, trusted, options, now)
+    }
+
+    /// Validate an `UntrustedBlockState` coming from a misbehaviour evidence,
+    /// based on the given `TrustedBlockState`, `Options` and current time.
+    pub fn validate_misbehaviour_against_trusted(
+        &self,
+        untrusted: &UntrustedBlockState<'_>,
+        trusted: &TrustedBlockState<'_>,
+        options: &Options,
+        now: Time,
+    ) -> Verdict {
+        self.validate_against_trusted_no_future_check(untrusted, trusted, options, now)
+    }
+
+    fn validate_against_trusted_no_future_check(
         &self,
         untrusted: &UntrustedBlockState<'_>,
         trusted: &TrustedBlockState<'_>,
@@ -159,13 +200,6 @@ where
         verdict!(self.predicates.is_within_trust_period(
             trusted.header_time,
             options.trusting_period,
-            now,
-        ));
-
-        // Ensure the header isn't from a future time
-        verdict!(self.predicates.is_header_from_past(
-            untrusted.signed_header.header.time,
-            options.clock_drift,
             now,
         ));
 
@@ -266,6 +300,26 @@ where
     ) -> Verdict {
         ensure_verdict_success!(self.verify_validator_sets(&untrusted));
         ensure_verdict_success!(self.validate_against_trusted(&untrusted, &trusted, options, now));
+        ensure_verdict_success!(self.verify_commit_against_trusted(&untrusted, &trusted, options));
+        ensure_verdict_success!(self.verify_commit(&untrusted));
+        Verdict::Success
+    }
+
+    /// Verify a header received in `MsgSubmitMisbehaviour`.
+    /// The verification for these headers is a bit more relaxed in order to catch FLA attacks.
+    /// In particular the "header in the future" check for the header should be skipped
+    /// from `validate_against_trusted`.
+    fn verify_misbehaviour_header(
+        &self,
+        untrusted: UntrustedBlockState<'_>,
+        trusted: TrustedBlockState<'_>,
+        options: &Options,
+        now: Time,
+    ) -> Verdict {
+        ensure_verdict_success!(self.verify_validator_sets(&untrusted));
+        ensure_verdict_success!(
+            self.validate_misbehaviour_against_trusted(&untrusted, &trusted, options, now)
+        );
         ensure_verdict_success!(self.verify_commit_against_trusted(&untrusted, &trusted, options));
         ensure_verdict_success!(self.verify_commit(&untrusted));
         Verdict::Success

--- a/light-client/src/light_client.rs
+++ b/light-client/src/light_client.rs
@@ -211,7 +211,7 @@ impl LightClient {
             let (current_block, status) = self.get_or_fetch_block(current_height, state)?;
 
             // Validate and verify the current block
-            let verdict = self.verifier.verify(
+            let verdict = self.verifier.verify_update_header(
                 current_block.as_untrusted_state(),
                 trusted_block.as_trusted_state(),
                 &self.options,

--- a/light-client/src/tests.rs
+++ b/light-client/src/tests.rs
@@ -169,7 +169,7 @@ pub fn verify_single(
         clock_drift,
     };
 
-    let result = verifier.verify(
+    let result = verifier.verify_update_header(
         input.as_untrusted_state(),
         trusted_block.as_trusted_state(),
         &options,


### PR DESCRIPTION
Closes: #1294


* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
