### PR TITLE
Remove nightly-only options in rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,19 +1,6 @@
-unstable_features = true
-
-# comments
-comment_width = 110
-normalize_comments = true
-wrap_comments = true
-
 # imports
-group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
 reorder_imports = true
 
 # strings
-format_strings = false
 max_width = 100
 match_block_trailing_comma = true
-
-trailing_comma = "Vertical"
-trailing_semicolon = true


### PR DESCRIPTION
These options cannot be used on stable Rust, which we use for developing the library and on CI for checking the formatting. As such they should be removed from the `.rustfmt.toml` config, as they can otherwise be picked up by some IDEs which will automatically use the nightly `rustfmt` to honor the unstable options.