### PR TITLE
fix: use compat mode when query latest_block_results

### DIFF
--- a/.changelog/unreleased/bug-fixes/1319-use-compactmode-last-block-results.md
+++ b/.changelog/unreleased/bug-fixes/1319-use-compactmode-last-block-results.md
@@ -1,1 +1,1 @@
-- `[tendermint]` fix: use compact mode to decode response from `latest_block_results`.
+- `[tendermint]` fix: use compat mode to decode response from `latest_block_results`.

--- a/.changelog/unreleased/bug-fixes/1319-use-compactmode-last-block-results.md
+++ b/.changelog/unreleased/bug-fixes/1319-use-compactmode-last-block-results.md
@@ -1,0 +1,1 @@
+- `[tendermint]` fix: use compact mode to decode response from `latest_block_results`.

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -181,6 +181,10 @@ impl Client for HttpClient {
         perform_with_compat!(self, endpoint::block_results::Request::new(height.into()))
     }
 
+    async fn latest_block_results(&self) -> Result<endpoint::block_results::Response, Error> {
+        perform_with_compat!(self, endpoint::block_results::Request::default())
+    }
+
     async fn header<H>(&self, height: H) -> Result<endpoint::header::Response, Error>
     where
         H: Into<Height> + Send,


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [ ] Referenced an issue explaining the need for the change
* [X] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
