### PR TITLE
RPC: Provide earliest block information from /status

### DIFF
--- a/.changelog/unreleased/breaking-changes/1321-status-earliest-block.md
+++ b/.changelog/unreleased/breaking-changes/1321-status-earliest-block.md
@@ -1,0 +1,5 @@
+- [`tendermint-rpc`] Decode the earliest block data fields of the `sync_info`
+  object in `/status` response and expose them in the `SyncInfo` struct:
+  `earliest_block_hash`, `earliest_app_hash`, `earliest_block_height`,
+  `earliest_block_time`
+  ([\#1321](https://github.com/informalsystems/tendermint-rs/pull/1321)).

--- a/rpc/src/endpoint/status.rs
+++ b/rpc/src/endpoint/status.rs
@@ -41,6 +41,20 @@ impl crate::Response for Response {}
 /// Sync information
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SyncInfo {
+    /// Earliest block hash
+    #[serde(with = "tendermint::serializers::hash")]
+    pub earliest_block_hash: Hash,
+
+    /// Earliest app hash
+    #[serde(with = "tendermint::serializers::apphash")]
+    pub earliest_app_hash: AppHash,
+
+    /// Earliest block height
+    pub earliest_block_height: block::Height,
+
+    /// Earliest block time
+    pub earliest_block_time: Time,
+
     /// Latest block hash
     #[serde(with = "tendermint::serializers::hash")]
     pub latest_block_hash: Hash,

--- a/rpc/tests/kvstore_fixtures/v0_34.rs
+++ b/rpc/tests/kvstore_fixtures/v0_34.rs
@@ -710,11 +710,24 @@ fn incoming_fixtures() {
                 );
                 assert_eq!(result.node_info.version.to_string(), "0.34.21");
                 assert!(!result.sync_info.catching_up);
+                assert!(result.sync_info.earliest_app_hash.as_bytes().is_empty());
+                assert!(!result.sync_info.earliest_block_hash.is_empty());
+                assert_eq!(result.sync_info.earliest_block_height.value(), 1);
+                assert!(
+                    result
+                        .sync_info
+                        .earliest_block_time
+                        .duration_since(informal_epoch)
+                        .unwrap()
+                        .as_secs()
+                        > 0
+                );
                 assert_eq!(
                     result.sync_info.latest_app_hash.as_bytes(),
                     [6, 0, 0, 0, 0, 0, 0, 0]
                 );
                 assert!(!result.sync_info.latest_block_hash.is_empty());
+                assert_eq!(result.sync_info.latest_block_height.value(), 67);
                 assert!(
                     result
                         .sync_info

--- a/rpc/tests/kvstore_fixtures/v0_37.rs
+++ b/rpc/tests/kvstore_fixtures/v0_37.rs
@@ -709,11 +709,24 @@ fn incoming_fixtures() {
                 );
                 assert_eq!(result.node_info.version.to_string(), "0.37.0-alpha.3");
                 assert!(!result.sync_info.catching_up);
+                assert!(result.sync_info.earliest_app_hash.as_bytes().is_empty());
+                assert!(!result.sync_info.earliest_block_hash.is_empty());
+                assert_eq!(result.sync_info.earliest_block_height.value(), 1);
+                assert!(
+                    result
+                        .sync_info
+                        .earliest_block_time
+                        .duration_since(informal_epoch)
+                        .unwrap()
+                        .as_secs()
+                        > 0
+                );
                 assert_eq!(
                     result.sync_info.latest_app_hash.as_bytes(),
                     [6, 0, 0, 0, 0, 0, 0, 0]
                 );
                 assert!(!result.sync_info.latest_block_hash.is_empty());
+                assert_eq!(result.sync_info.latest_block_height.value(), 53);
                 assert!(
                     result
                         .sync_info


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->
This is a trivial addition of missing /status RPC fields, specifically the "earliest block" information.

This information is useful and tells us the range of blocks that can be queried from a node. To be used for a Cosmos block crawler/indexer project.

I deemed the change so minor as to not warrant a changelog entry.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
