### PR TITLE
fix `from_str` serializer

### DIFF
--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -23,5 +23,5 @@ where
     S: Serializer,
     T: core::fmt::Display,
 {
-    format!("{value}").serialize(serializer)
+    value.to_string().serialize(serializer)
 }

--- a/rpc/src/response.rs
+++ b/rpc/src/response.rs
@@ -69,7 +69,6 @@ impl<R> Wrapper<R> {
         }
     }
 
-    #[cfg(test)]
     pub fn new_with_id(id: Id, result: Option<R>, error: Option<ResponseError>) -> Self {
         Self {
             jsonrpc: Version::current(),


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`

This fixes the `from_str` serialization. I discovered this while trying to serialize and deserialize the response type for `broadcast_tx_commit` while making a mock tendermint server; the `gas_wanted` field and a few others were serialized as integers, but were decoded as a string, causing an error `invalid type: integer `0`, expected a string at line 1 column 98`. `Display` formats the integer without quotes, but we wanted with quotes.

Before:
```
"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"check_tx\":{\"code\":0,\"data\":[],\"log\":\"\",\"info\":\"\",\"gas_wanted\":0,\"gas_used\":0,\"events\":[],\"codespace\":\"\",\"sender\":\"\",\"priority\":0,\"mempool_error\":\"\"},\"deliver_tx\":{\"code\":0,\"data\":[],\"log\":\"\",\"info\":\"\",\"gas_wanted\":0,\"gas_used\":0,\"events\":[],\"codespace\":\"\"},\"hash\":\"\",\"height\":\"1\"},\"error\":null}"
```

After:
```
"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"check_tx\":{\"code\":0,\"data\":null,\"log\":\"\",\"info\":\"\",\"gas_wanted\":\"0\",\"gas_used\":\"0\",\"events\":[],\"codespace\":\"\",\"sender\":\"\",\"priority\":\"0\",\"mempool_error\":\"\"},\"deliver_tx\":{\"code\":0,\"data\":null,\"log\":\"\",\"info\":\"\",\"gas_wanted\":\"0\",\"gas_used\":\"0\",\"events\":[],\"codespace\":\"\"},\"hash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"height\":\"1\"},\"error\":null}"
```

Also made `rpc::Wrapper::new_with_id` public because I'm using it externally.
