### PR TITLE
rpc: use compat mode in latest_block_results()

### DIFF
--- a/.changelog/unreleased/bug-fixes/1326-compat-for-latest_block_results.md
+++ b/.changelog/unreleased/bug-fixes/1326-compat-for-latest_block_results.md
@@ -1,0 +1,3 @@
+- [tendermint-rpc]` Use compatibility mode in implementations
+  of the `Client::latest_block_results` method
+  ([\#1326](https://github.com/informalsystems/tendermint-rs/pull/1326))

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -181,6 +181,10 @@ impl Client for HttpClient {
         perform_with_compat!(self, endpoint::block_results::Request::new(height.into()))
     }
 
+    async fn latest_block_results(&self) -> Result<endpoint::block_results::Response, Error> {
+        perform_with_compat!(self, endpoint::block_results::Request::default())
+    }
+
     async fn header<H>(&self, height: H) -> Result<endpoint::header::Response, Error>
     where
         H: Into<Height> + Send,

--- a/rpc/src/client/transport/websocket.rs
+++ b/rpc/src/client/transport/websocket.rs
@@ -244,6 +244,10 @@ impl Client for WebSocketClient {
         perform_with_compat!(self, endpoint::block_results::Request::new(height.into()))
     }
 
+    async fn latest_block_results(&self) -> Result<endpoint::block_results::Response, Error> {
+        perform_with_compat!(self, endpoint::block_results::Request::default())
+    }
+
     async fn header<H>(&self, height: H) -> Result<endpoint::header::Response, Error>
     where
         H: Into<Height> + Send,


### PR DESCRIPTION
Fixes: #1325 as it applies to the implementations of `Client::latest_block_results`

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
