### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,12 +11,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache cargo bin
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,52 +21,33 @@ jobs:
   tendermint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build-all
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build-all
 
   build-light-client-wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          target: wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build-wasm-tendermint
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build-wasm-light-client
+          targets: wasm32-unknown-unknown
+      - run: cargo build-wasm-tendermint
+      - run: cargo build-wasm-light-client
 
   tools:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build-tools
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build-tools
 
   # As per https://github.com/informalsystems/tendermint-rs/issues/1014
   generated-protos-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: |
           curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
@@ -84,6 +65,4 @@ jobs:
       - name: Show the differences with checked-in files
         run: git diff -- proto/src/prost
       - name: Ensure that generated proto definitions compile
-        uses: actions-rs/cargo@v1
-        with:
-          command: build-all
+        run: cargo build-all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: |
-          curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
+          curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip
           unzip /tmp/protoc.zip -d ${HOME}/.local
           echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
           export PATH="${PATH}:${HOME}/.local/bin"
       - name: Install buf
         run: |
-          curl -sSL https://github.com/bufbuild/buf/releases/download/v1.18.0/buf-Linux-x86_64 \
+          curl -sSL https://github.com/bufbuild/buf/releases/download/v1.24.0/buf-Linux-x86_64 \
             -o /usr/local/bin/buf
           chmod +x /usr/local/bin/buf
       - name: Regenerate proto definitions

--- a/.github/workflows/no-std.yaml
+++ b/.github/workflows/no-std.yaml
@@ -9,11 +9,8 @@ jobs:
     name: Check no_std panic conflict
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - run: |
           cd tools/no-std-check
           make check-panic-conflict
@@ -24,12 +21,8 @@ jobs:
   #   name: Check no_std substrate support
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: nightly
-  #         target: wasm32-unknown-unknown
-  #         override: true
+  #     - uses: actions/checkout@v3
+  #     - uses: dtolnay/rust-toolchain@stable
   #     - run: |
   #         cd tools/no-std-check
   #         make check-substrate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Publish crates
         run: ./release.sh
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,11 +33,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: giraffate/clippy-action@v1
         with:
-          name: clippy-results
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -Dwarnings -Drust-2018-idioms
+          reporter: 'github-pr-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --all-features --all-targets -- -Dwarnings -Drust-2018-idioms
 
   clippy-tools-output:
     runs-on: ubuntu-latest
@@ -46,11 +46,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: giraffate/clippy-action@v1
         with:
-          name: clippy-tools-results
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path tools/kvstore-test/Cargo.toml --all-features --all-targets -- -Dwarnings -Drust-2018-idioms
+          reporter: 'github-pr-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --manifest-path tools/kvstore-test/Cargo.toml --all-features --all-targets -- -Dwarnings -Drust-2018-idioms
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,26 +21,18 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
 
   # This job creates the "clippy-results" GitHub Action that lists the clippy results in a nice format.
   clippy-json-output:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
-          override: true
       - uses: actions-rs/clippy-check@v1
         with:
           name: clippy-results
@@ -50,12 +42,10 @@ jobs:
   clippy-tools-output:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
-          override: true
       - uses: actions-rs/clippy-check@v1
         with:
           name: clippy-tools-results
@@ -65,14 +55,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-03-01 # regression prevents docs from building
-          override: true
-      - uses: actions-rs/cargo@v1
-        env:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly # regression prevents docs from building on stable
+      - env:
           RUSTDOCFLAGS: "--cfg docsrs"
-        with:
-          command: doc
-          args: --all-features
+        run: cargo doc --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
           LLVM_PROFILE_FILE: '%p-%m.profraw'
       - name: Install grcov
         run: |
-          curl -L https://github.com/mozilla/grcov/releases/download/v0.8.11/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+          curl -L https://github.com/mozilla/grcov/releases/download/v0.8.18/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: Run grcov
         run: |
           ./grcov . --source-dir . --binary-path ./target/debug/ --output-type lcov --output-path ./lcov.info --branch --ignore-not-existing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,9 @@ jobs:
   default-features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
 
   # TODO(shonfeder): remove duplication once GitHub addresses one of these
   #  - https://github.community/t/support-for-yaml-anchors/16128/15
@@ -37,67 +32,40 @@ jobs:
   tendermint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
-          args: -p tendermint
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test-all-features -p tendermint
 
   tendermint-rpc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
-          args: -p tendermint-rpc
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test-all-features -p tendermint-rpc
 
   tendermint-proto:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
-          args: -p tendermint-proto
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test-all-features -p tendermint-proto
 
   tendermint-light-client:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       # NOTE: We test with default features to make sure things work without "unstable".
-      - uses: actions-rs/cargo@v1
-        name: Test with default features
-        with:
-          command: test
-          args: -p tendermint-light-client
-      - uses: actions-rs/cargo@v1
-        name: Test with all features
-        with:
-          command: test-all-features
-          args: -p tendermint-light-client
+      - name: Test with default features
+        run: cargo test -p tendermint-light-client
+      - name: Test with all features
+        run: cargo test-all-features -p tendermint-light-client
 
   # From https://rustwasm.github.io/docs/wasm-bindgen/wasm-bindgen-test/continuous-integration.html#github-actions
   tendermint-light-client-js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack test --headless --chrome ./light-client-js/
@@ -106,28 +74,16 @@ jobs:
   tendermint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
-          args: -p tendermint-test
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test-all-features -p tendermint-test
 
   tendermint-testgen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
-          args: -p tendermint-testgen
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test-all-features -p tendermint-testgen
 
   kvstore-integration-stable:
     runs-on: ubuntu-latest
@@ -139,36 +95,24 @@ jobs:
           - 26657:26657
           - 26660:26660
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
-          args: --manifest-path tools/kvstore-test/Cargo.toml -- --nocapture
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test-all-features --manifest-path tools/kvstore-test/Cargo.toml -- --nocapture
         env:
           RUST_LOG: debug
 
   nightly-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2022-09-18
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        components: llvm-tools-preview
+      - run: cargo test-all-features
         env:
           RUSTFLAGS: '-Zinstrument-coverage'
           LLVM_PROFILE_FILE: '%p-%m.profraw'
       - name: Install grcov
         run: |
-          rustup component add llvm-tools-preview
           curl -L https://github.com/mozilla/grcov/releases/download/v0.8.11/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: Run grcov
         run: |

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -186,7 +186,7 @@ impl Serialize for Hash {
 pub mod allow_empty {
     use super::*;
 
-    /// Serialize [`Hash`](crate::hash::Hash) into a string.
+    /// Serialize [`Hash`](enum@crate::hash::Hash) into a string.
     pub fn serialize<S>(value: &Hash, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -194,7 +194,7 @@ pub mod allow_empty {
         value.to_string().serialize(serializer)
     }
 
-    /// Deserialize [`Hash`](crate::hash::Hash) from a string, allowing for
+    /// Deserialize [`Hash`](enum@crate::hash::Hash) from a string, allowing for
     /// empty hashes.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
     where


### PR DESCRIPTION
Update GitHub workflows to use up-to-date actions:

- Bump actions/checkout to v3
- Replace actions-rs/toolchain with dtolnay/rust-toolchain
- Replace actions-rs/audit-check with rustsec/audit-check
- Replace actions-rs/clippy-check with giraffate/clippy-action
- Update protoc, buf, and grcov to latest versions.
