### PR TITLE
Make `total_voting_power` optional

### DIFF
--- a/.changelog/unreleased/improvements/1340-optional-total-voting-power.md
+++ b/.changelog/unreleased/improvements/1340-optional-total-voting-power.md
@@ -1,0 +1,2 @@
+- `[tendermint]` Make the `total_voting_power` field optional in `Set`
+  ([\#1340](https://github.com/informalsystems/tendermint-rs/pull/1340)):

--- a/light-client-detector/src/evidence.rs
+++ b/light-client-detector/src/evidence.rs
@@ -41,7 +41,7 @@ pub fn make_evidence(
         conflicting_block,
         byzantine_validators,
         common_height: witness.height(),
-        total_voting_power: witness.validators.total_voting_power(),
+        total_voting_power: witness.validators.total_voting_power().unwrap_or_default(),
         timestamp: witness.time(),
     }
 }

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -20,7 +20,7 @@ use crate::{
 pub struct Set {
     validators: Vec<Info>,
     proposer: Option<Info>,
-    total_voting_power: vote::Power,
+    total_voting_power: Option<vote::Power>,
 }
 
 impl Set {
@@ -29,12 +29,14 @@ impl Set {
         Self::sort_validators(&mut validators);
 
         // Compute the total voting power
-        let total_voting_power = validators
-            .iter()
-            .map(|v| v.power.value())
-            .sum::<u64>()
-            .try_into()
-            .unwrap();
+        let total_voting_power = Some(
+            validators
+                .iter()
+                .map(|v| v.power.value())
+                .sum::<u64>()
+                .try_into()
+                .unwrap(),
+        );
 
         Set {
             validators,
@@ -77,7 +79,7 @@ impl Set {
 
     /// Get total voting power
     pub fn total_voting_power(&self) -> vote::Power {
-        self.total_voting_power
+        self.total_voting_power.unwrap()
     }
 
     /// Sort the validators according to the current Tendermint requirements
@@ -277,7 +279,7 @@ tendermint_pb_modules! {
             RawValidatorSet {
                 validators: value.validators.into_iter().map(Into::into).collect(),
                 proposer: value.proposer.map(Into::into),
-                total_voting_power: value.total_voting_power.into(),
+                total_voting_power: value.total_voting_power.unwrap().into(),
             }
         }
     }


### PR DESCRIPTION
Motivated by https://github.com/celestiaorg/celestia-core/issues/1052

I'm a Rust noob so would appreciate a thorough review and/or feedback on if this is desirable.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs (I don't see any references to `total_voting_power` in docs)
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
