### PR TITLE
tendermint-testgen: Add `app_hash` field to `Header`

### DIFF
--- a/.changelog/unreleased/improvements/1343-add-app-hash-field-to-testgen-header.md
+++ b/.changelog/unreleased/improvements/1343-add-app-hash-field-to-testgen-header.md
@@ -1,0 +1,3 @@
+- `[tendermint-testgen]` Add `app_hash` field to testgen `Header` and implement
+  convenient method for default `LightBlock` construction from `Header`
+  ([\#1343](https://github.com/informalsystems/tendermint-rs/issues/1343))

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -108,7 +108,9 @@ impl Handshake<AwaitingEphKey> {
         &mut self,
         remote_eph_pubkey: EphemeralPublic,
     ) -> Result<Handshake<AwaitingAuthSig>, Error> {
-        let Some(local_eph_privkey) = self.state.local_eph_privkey.take() else { return Err(Error::missing_secret()) };
+        let Some(local_eph_privkey) = self.state.local_eph_privkey.take() else {
+            return Err(Error::missing_secret());
+        };
         let local_eph_pubkey = EphemeralPublic::from(&local_eph_privkey);
 
         // Compute common shared secret.

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -206,7 +206,7 @@ pub mod allow_empty {
 }
 
 /// AppHash is usually a SHA256 hash, but in reality it can be any kind of data
-#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct AppHash(Vec<u8>);
 
 impl Protobuf<Vec<u8>> for AppHash {}

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -206,7 +206,7 @@ pub mod allow_empty {
 }
 
 /// AppHash is usually a SHA256 hash, but in reality it can be any kind of data
-#[derive(Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AppHash(Vec<u8>);
 
 impl Protobuf<Vec<u8>> for AppHash {}

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -76,16 +76,18 @@ mod app_hash_serde {
     where
         D: Deserializer<'de>,
     {
-        let app_hash = tendermint::serializers::apphash::deserialize(deserializer)?;
-        Ok(Some(app_hash))
+        tendermint::serializers::apphash::deserialize(deserializer).map(Some)
     }
 
     pub fn serialize<S>(value: &Option<AppHash>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let app_hash = value.clone().unwrap_or_default();
-        tendermint::serializers::apphash::serialize(&app_hash, serializer)
+        if value.is_none() {
+            serializer.serialize_none()
+        } else {
+            tendermint::serializers::apphash::serialize(value.as_ref().unwrap(), serializer)
+        }
     }
 }
 

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -36,8 +36,8 @@ pub struct Header {
     pub proposer: Option<usize>,
     #[options(help = "last block id hash (default: Hash::None)")]
     pub last_block_id_hash: Option<Hash>,
-    #[options(help = "last commit hash (default: AppHash(vec![])")]
-    #[serde(with = "app_hash_serde")]
+    #[options(help = "application hash (default: AppHash(vec![])")]
+    #[serde(default, with = "app_hash_serde")]
     pub app_hash: Option<AppHash>,
 }
 

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -38,6 +38,7 @@ pub struct Header {
     pub last_block_id_hash: Option<Hash>,
     #[options(help = "application hash (default: AppHash(vec![])")]
     #[serde(default, with = "app_hash_serde")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub app_hash: Option<AppHash>,
 }
 
@@ -201,11 +202,6 @@ impl Generator<block::Header> for Header {
             part_set_header: Default::default(),
         });
 
-        let app_hash = self
-            .app_hash
-            .clone()
-            .unwrap_or_default();
-
         let header = block::Header {
             // block version in Tendermint-go is hardcoded with value 11
             // so we do the same with MBT for now for compatibility
@@ -220,7 +216,7 @@ impl Generator<block::Header> for Header {
             validators_hash,
             next_validators_hash: next_valset.hash(),
             consensus_hash: validators_hash, // TODO: currently not clear how to produce a valid hash
-            app_hash,
+            app_hash: self.app_hash.clone().unwrap_or_default(),
             last_results_hash: None,
             evidence_hash: None,
             proposer_address,

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -84,10 +84,8 @@ mod app_hash_serde {
     where
         S: Serializer,
     {
-        match value {
-            Some(inner) => tendermint::serializers::apphash::serialize(inner, serializer),
-            None => serializer.serialize_none(),
-        }
+        let app_hash = value.clone().unwrap_or_default();
+        tendermint::serializers::apphash::serialize(&app_hash, serializer)
     }
 }
 

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -204,7 +204,7 @@ impl Generator<block::Header> for Header {
         let app_hash = self
             .app_hash
             .clone()
-            .unwrap_or(AppHash::from_hex_upper("").map_err(|e| SimpleError::new(e.to_string()))?);
+            .unwrap_or_default();
 
         let header = block::Header {
             // block version in Tendermint-go is hardcoded with value 11

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -171,6 +171,9 @@ impl Generator<block::Header> for Header {
             part_set_header: Default::default(),
         });
 
+        let app_hash =
+            AppHash::try_from(vec![0u8; 32]).map_err(|e| SimpleError::new(e.to_string()))?;
+
         let header = block::Header {
             // block version in Tendermint-go is hardcoded with value 11
             // so we do the same with MBT for now for compatibility
@@ -185,7 +188,7 @@ impl Generator<block::Header> for Header {
             validators_hash,
             next_validators_hash: next_valset.hash(),
             consensus_hash: validators_hash, // TODO: currently not clear how to produce a valid hash
-            app_hash: AppHash::from_hex_upper("").unwrap(),
+            app_hash,
             last_results_hash: None,
             evidence_hash: None,
             proposer_address,

--- a/testgen/src/header.rs
+++ b/testgen/src/header.rs
@@ -83,11 +83,7 @@ mod app_hash_serde {
     where
         S: Serializer,
     {
-        if value.is_none() {
-            serializer.serialize_none()
-        } else {
-            tendermint::serializers::apphash::serialize(value.as_ref().unwrap(), serializer)
-        }
+        tendermint::serializers::apphash::serialize(value.as_ref().unwrap(), serializer)
     }
 }
 

--- a/testgen/src/light_block.rs
+++ b/testgen/src/light_block.rs
@@ -95,15 +95,7 @@ impl LightBlock {
             .next_validators(&validators)
             .time(Time::from_unix_timestamp(height as i64, 0).unwrap()); // just wanted to initialize time with some value
 
-        let commit = Commit::new(header.clone(), 1);
-
-        Self {
-            header: Some(header),
-            commit: Some(commit),
-            validators: Some(validators.to_vec()),
-            next_validators: Some(validators.to_vec()),
-            provider: Some(default_peer_id()),
-        }
+        Self::new_default_with_header(header)
     }
 
     pub fn new_default_with_time_and_chain_id(chain_id: String, time: Time, height: u64) -> Self {
@@ -117,13 +109,15 @@ impl LightBlock {
             .next_validators(&validators)
             .time(time);
 
-        let commit = Commit::new(header.clone(), 1);
+        Self::new_default_with_header(header)
+    }
 
+    pub fn new_default_with_header(header: Header) -> Self {
         Self {
-            header: Some(header),
-            commit: Some(commit),
-            validators: Some(validators.to_vec()),
-            next_validators: Some(validators.to_vec()),
+            header: Some(header.clone()),
+            commit: Some(Commit::new(header.clone(), 1)),
+            validators: header.validators.clone(),
+            next_validators: header.validators,
             provider: Some(default_peer_id()),
         }
     }


### PR DESCRIPTION
Closes: #1343

Use case: https://github.com/informalsystems/hermes/pull/3566

<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
