### PR TITLE
rpc: remove HTTP proxy support

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -40,7 +40,6 @@ http-client = [
   "futures",
   "http",
   "hyper",
-  "hyper-proxy",
   "hyper-rustls",
   "tokio/fs",
   "tokio/macros",
@@ -87,8 +86,7 @@ async-tungstenite = { version = "0.20", default-features = false, features = ["t
 futures = { version = "0.3", optional = true, default-features = false }
 http = { version = "0.2", optional = true, default-features = false }
 hyper = { version = "0.14", optional = true, default-features = false, features = ["client", "http1", "http2"] }
-hyper-proxy = { version = "0.9.1", optional = true, default-features = false, features = ["rustls"] }
-hyper-rustls = { version = "0.22.1", optional = true, default-features = false, features = ["rustls-native-certs", "webpki-roots", "tokio-runtime"] }
+hyper-rustls = { version = "0.24.1", optional = true, default-features = false, features = ["http1", "http2", "rustls-native-certs", "webpki-roots", "tokio-runtime"] }
 structopt = { version = "0.3", optional = true, default-features = false }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["rt-multi-thread"] }
 tracing = { version = "0.1", optional = true, default-features = false }


### PR DESCRIPTION
Closes #1342 by removing all use of hyper-proxy, and the HTTP proxy support in tendermint-rpc client which requires it.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
