### PR TITLE
Validate construction and deserialization of `validator::Set`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1348-valset-deserialization-fixes.md
+++ b/.changelog/unreleased/bug-fixes/1348-valset-deserialization-fixes.md
@@ -1,0 +1,3 @@
+- `[tendermint]` Integer overflows are prevented when calculating the total
+  voting power value in `validator::Set`
+  ([\#1348](https://github.com/informalsystems/tendermint-rs/issues/1348)).

--- a/.changelog/unreleased/bug-fixes/1350-pubkey-serde-fixes.md
+++ b/.changelog/unreleased/bug-fixes/1350-pubkey-serde-fixes.md
@@ -1,0 +1,4 @@
+- `[tendermint-proto]` `Serialize` and `Deserialize` impls for
+  `v*::crypto::PublicKey` are corrected to match the JSON schema used by
+  other implementations
+  ([\#1350](https://github.com/informalsystems/tendermint-rs/pull/1350)).

--- a/.changelog/unreleased/improvements/1348-valset-deserialization-fixes.md
+++ b/.changelog/unreleased/improvements/1348-valset-deserialization-fixes.md
@@ -1,0 +1,9 @@
+- `[tendermint]` Improve and validate deserialization of `validator::Set`
+  ([\#1348](https://github.com/informalsystems/tendermint-rs/issues/1348)).
+  The `total_voting_power` field no longer has to be present in the format
+  processed by `Deserialize`. If it is present, it is validated against the
+  sum of the `voting_power` values of the listed validators. The sum value
+  is also checked against the protocol-defined maximum.
+- `[tendermint-proto]` In the `Deserialize` impls derived for
+  `v*::types::ValidatorSet`, the `total_voting_power` field value is retrieved
+  when present.

--- a/.changelog/unreleased/improvements/1348-valset-deserialization-fixes.md
+++ b/.changelog/unreleased/improvements/1348-valset-deserialization-fixes.md
@@ -7,3 +7,6 @@
 - `[tendermint-proto]` In the `Deserialize` impls derived for
   `v*::types::ValidatorSet`, the `total_voting_power` field value is retrieved
   when present.
+- `[tendermint-proto]` Add serialziation helper module
+  `serializers::from_str_allow_null`. Use it to allow the `proposed_priority`
+  field value of null in the deserialization of `v*::types::Validator`.

--- a/proto/src/prost/v0_34/tendermint.crypto.rs
+++ b/proto/src/prost/v0_34/tendermint.crypto.rs
@@ -56,7 +56,6 @@ pub struct ProofOps {
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
 }
 /// PublicKey defines the keys available for use with Validators
-#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublicKey {

--- a/proto/src/prost/v0_34/tendermint.types.rs
+++ b/proto/src/prost/v0_34/tendermint.types.rs
@@ -24,7 +24,8 @@ pub struct Validator {
     #[serde(alias = "power", with = "crate::serializers::from_str")]
     pub voting_power: i64,
     #[prost(int64, tag = "4")]
-    #[serde(with = "crate::serializers::from_str", default)]
+    #[serde(with = "crate::serializers::from_str_allow_null")]
+    #[serde(default)]
     pub proposer_priority: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/prost/v0_34/tendermint.types.rs
+++ b/proto/src/prost/v0_34/tendermint.types.rs
@@ -7,7 +7,8 @@ pub struct ValidatorSet {
     #[prost(message, optional, tag = "2")]
     pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag = "3")]
-    #[serde(skip)]
+    #[serde(default)]
+    #[serde(skip_serializing)]
     pub total_voting_power: i64,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]

--- a/proto/src/prost/v0_34/tendermint.types.rs
+++ b/proto/src/prost/v0_34/tendermint.types.rs
@@ -7,7 +7,7 @@ pub struct ValidatorSet {
     #[prost(message, optional, tag = "2")]
     pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag = "3")]
-    #[serde(default)]
+    #[serde(with = "crate::serializers::from_str", default)]
     #[serde(skip_serializing)]
     pub total_voting_power: i64,
 }

--- a/proto/src/prost/v0_37/tendermint.crypto.rs
+++ b/proto/src/prost/v0_37/tendermint.crypto.rs
@@ -56,7 +56,6 @@ pub struct ProofOps {
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
 }
 /// PublicKey defines the keys available for use with Validators
-#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublicKey {

--- a/proto/src/prost/v0_37/tendermint.types.rs
+++ b/proto/src/prost/v0_37/tendermint.types.rs
@@ -24,7 +24,8 @@ pub struct Validator {
     #[serde(alias = "power", with = "crate::serializers::from_str")]
     pub voting_power: i64,
     #[prost(int64, tag = "4")]
-    #[serde(with = "crate::serializers::from_str", default)]
+    #[serde(with = "crate::serializers::from_str_allow_null")]
+    #[serde(default)]
     pub proposer_priority: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/prost/v0_37/tendermint.types.rs
+++ b/proto/src/prost/v0_37/tendermint.types.rs
@@ -7,7 +7,8 @@ pub struct ValidatorSet {
     #[prost(message, optional, tag = "2")]
     pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag = "3")]
-    #[serde(skip)]
+    #[serde(default)]
+    #[serde(skip_serializing)]
     pub total_voting_power: i64,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]

--- a/proto/src/prost/v0_37/tendermint.types.rs
+++ b/proto/src/prost/v0_37/tendermint.types.rs
@@ -7,7 +7,7 @@ pub struct ValidatorSet {
     #[prost(message, optional, tag = "2")]
     pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag = "3")]
-    #[serde(default)]
+    #[serde(with = "crate::serializers::from_str", default)]
     #[serde(skip_serializing)]
     pub total_voting_power: i64,
 }

--- a/proto/src/prost/v0_38/tendermint.crypto.rs
+++ b/proto/src/prost/v0_38/tendermint.crypto.rs
@@ -56,7 +56,6 @@ pub struct ProofOps {
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
 }
 /// PublicKey defines the keys available for use with Validators
-#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublicKey {

--- a/proto/src/prost/v0_38/tendermint.types.rs
+++ b/proto/src/prost/v0_38/tendermint.types.rs
@@ -121,7 +121,8 @@ pub struct Validator {
     #[serde(alias = "power", with = "crate::serializers::from_str")]
     pub voting_power: i64,
     #[prost(int64, tag = "4")]
-    #[serde(with = "crate::serializers::from_str", default)]
+    #[serde(with = "crate::serializers::from_str_allow_null")]
+    #[serde(default)]
     pub proposer_priority: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/prost/v0_38/tendermint.types.rs
+++ b/proto/src/prost/v0_38/tendermint.types.rs
@@ -104,7 +104,8 @@ pub struct ValidatorSet {
     #[prost(message, optional, tag = "2")]
     pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag = "3")]
-    #[serde(skip)]
+    #[serde(default)]
+    #[serde(skip_serializing)]
     pub total_voting_power: i64,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]

--- a/proto/src/prost/v0_38/tendermint.types.rs
+++ b/proto/src/prost/v0_38/tendermint.types.rs
@@ -104,7 +104,7 @@ pub struct ValidatorSet {
     #[prost(message, optional, tag = "2")]
     pub proposer: ::core::option::Option<Validator>,
     #[prost(int64, tag = "3")]
-    #[serde(default)]
+    #[serde(with = "crate::serializers::from_str", default)]
     #[serde(skip_serializing)]
     pub total_voting_power: i64,
 }

--- a/proto/src/serializers.rs
+++ b/proto/src/serializers.rs
@@ -64,3 +64,5 @@ pub mod part_set_header_total;
 pub mod time_duration;
 pub mod timestamp;
 pub mod txs;
+
+mod public_key;

--- a/proto/src/serializers.rs
+++ b/proto/src/serializers.rs
@@ -57,6 +57,7 @@ pub mod allow_null;
 pub mod bytes;
 pub mod evidence;
 pub mod from_str;
+pub mod from_str_allow_null;
 pub mod nullable;
 pub mod optional;
 pub mod optional_from_str;

--- a/proto/src/serializers/from_str_allow_null.rs
+++ b/proto/src/serializers/from_str_allow_null.rs
@@ -1,0 +1,41 @@
+//! Combines [`from_str`] and [`allow_null`].
+//!
+//! Use this module to serialize and deserialize any `T` where `T` implements
+//! [`FromStr`] and [`Display`] to convert from or into a string.
+//! The serialized form is that of `Option<String>`,
+//! and a nil is deserialized to the `Default` value. For JSON, this means both
+//! quoted string values and `null` are accepted. A value is always serialized
+//! as `Some<String>`.
+//! Note that this can be used for all primitive data types.
+//!
+//! [`from_str`]: super::from_str
+//! [`allow_null`]: super::allow_null
+
+use core::fmt::Display;
+use core::str::FromStr;
+
+use serde::{de::Error as _, Deserialize, Deserializer, Serializer};
+
+use crate::prelude::*;
+
+/// Deserialize a nullable string into T
+pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr + Default,
+    <T as FromStr>::Err: Display,
+{
+    match <Option<&str>>::deserialize(deserializer)? {
+        Some(s) => s.parse::<T>().map_err(D::Error::custom),
+        None => Ok(T::default()),
+    }
+}
+
+/// Serialize from T into string
+pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Display,
+{
+    serializer.serialize_some(&value.to_string())
+}

--- a/proto/src/serializers/from_str_allow_null.rs
+++ b/proto/src/serializers/from_str_allow_null.rs
@@ -11,6 +11,7 @@
 //! [`from_str`]: super::from_str
 //! [`allow_null`]: super::allow_null
 
+use alloc::borrow::Cow;
 use core::fmt::Display;
 use core::str::FromStr;
 
@@ -25,7 +26,7 @@ where
     T: FromStr + Default,
     <T as FromStr>::Err: Display,
 {
-    match <Option<&str>>::deserialize(deserializer)? {
+    match <Option<Cow<'_, str>>>::deserialize(deserializer)? {
         Some(s) => s.parse::<T>().map_err(D::Error::custom),
         None => Ok(T::default()),
     }

--- a/proto/src/serializers/public_key.rs
+++ b/proto/src/serializers/public_key.rs
@@ -1,0 +1,71 @@
+mod v0_34 {
+    use crate::v0_34::crypto::{public_key, PublicKey};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<'de> Deserialize<'de> for PublicKey {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let sum = Option::<public_key::Sum>::deserialize(deserializer)?;
+            Ok(Self { sum })
+        }
+    }
+
+    impl Serialize for PublicKey {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.sum.serialize(serializer)
+        }
+    }
+}
+
+mod v0_37 {
+    use crate::v0_37::crypto::{public_key, PublicKey};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<'de> Deserialize<'de> for PublicKey {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let sum = Option::<public_key::Sum>::deserialize(deserializer)?;
+            Ok(Self { sum })
+        }
+    }
+
+    impl Serialize for PublicKey {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.sum.serialize(serializer)
+        }
+    }
+}
+
+mod v0_38 {
+    use crate::v0_38::crypto::{public_key, PublicKey};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<'de> Deserialize<'de> for PublicKey {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let sum = Option::<public_key::Sum>::deserialize(deserializer)?;
+            Ok(Self { sum })
+        }
+    }
+
+    impl Serialize for PublicKey {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.sum.serialize(serializer)
+        }
+    }
+}

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -16,7 +16,7 @@ define_error! {
 
         InvalidKey
             { detail: String }
-            |e| { format_args!("invalid key: {e}") },
+            |e| { format_args!("invalid key: {}", e.detail) },
 
         Length
             |_| { format_args!("length error") },

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -229,6 +229,12 @@ define_error! {
         NegativeProofIndex
             [ DisplayOnly<TryFromIntError> ]
             |_| { "negative item index in proof" },
+
+        TotalVotingPowerMismatch
+            |_| { "total voting power in validator set does not match the sum of participants' powers" },
+
+        TotalVotingPowerOverflow
+            |_| { "total voting power in validator set exceeds the allowed maximum" },
     }
 }
 

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -681,7 +681,7 @@ mod tests {
                         "type": "tendermint/PubKeyEd25519",
                         "value": "OAaNq3DX/15fGJP2MI6bujt1GRpvjwrqIevChirJsbc="
                     },
-                    "voting_power": "6148914691236516865",
+                    "voting_power": "6148914691236517205",
                     "proposer_priority": "-150"
                 },
                 {
@@ -690,7 +690,7 @@ mod tests {
                         "type": "tendermint/PubKeyEd25519",
                         "value": "+vlsKpn6ojn+UoTZl+w+fxeqm6xvUfBokTcKfcG3au4="
                     },
-                    "voting_power": "6148914691236516865",
+                    "voting_power": "6148914691236517205",
                     "proposer_priority": "50"
                 },
                 {
@@ -699,7 +699,7 @@ mod tests {
                         "type": "tendermint/PubKeyEd25519",
                         "value": "Wc790fkCDAi7LvZ4UIBAIJSNI+Rp2aU80/8l+idZ/wI="
                     },
-                    "voting_power": "6148914691236516865",
+                    "voting_power": "6148914691236517206",
                     "proposer_priority": "50"
                 }
             ],

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -1,7 +1,9 @@
 //! Tendermint validators
 
 use serde::{Deserialize, Serialize};
-use tendermint_proto::v0_37::types::SimpleValidator as RawSimpleValidator;
+use tendermint_proto::v0_38::types::{
+    SimpleValidator as RawSimpleValidator, ValidatorSet as RawValidatorSet,
+};
 use tendermint_proto::Protobuf;
 
 use crate::{
@@ -17,6 +19,7 @@ use crate::{
 
 /// Validator set contains a vector of validators
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "RawValidatorSet")]
 pub struct Set {
     validators: Vec<Info>,
     proposer: Option<Info>,

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -41,6 +41,7 @@ const TYPE_TAG: &str = r#"#[serde(tag = "type", content = "value")]"#;
 /// Predefined custom attributes for field annotations
 const QUOTED: &str = r#"#[serde(with = "crate::serializers::from_str")]"#;
 const QUOTED_WITH_DEFAULT: &str = r#"#[serde(with = "crate::serializers::from_str", default)]"#;
+const QUOTED_ALLOW_NULL: &str = r#"#[serde(with = "crate::serializers::from_str_allow_null")]"#;
 const DEFAULT: &str = r#"#[serde(default)]"#;
 const HEXSTRING: &str = r#"#[serde(with = "crate::serializers::bytes::hexstring")]"#;
 const BASE64STRING: &str = r#"#[serde(with = "crate::serializers::bytes::base64string")]"#;
@@ -197,8 +198,9 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     ), // https://github.com/tendermint/tendermint/issues/5549
     (
         ".tendermint.types.Validator.proposer_priority",
-        QUOTED_WITH_DEFAULT,
-    ), // Default is for /genesis deserialization
+        QUOTED_ALLOW_NULL,
+    ), // null occurs in some LightBlock data
+    (".tendermint.types.Validator.proposer_priority", DEFAULT), // Default is for /genesis deserialization
     (
         ".tendermint.types.ValidatorSet.total_voting_power",
         QUOTED_WITH_DEFAULT,

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -47,7 +47,7 @@ const BASE64STRING: &str = r#"#[serde(with = "crate::serializers::bytes::base64s
 const VEC_BASE64STRING: &str = r#"#[serde(with = "crate::serializers::bytes::vec_base64string")]"#;
 const OPTIONAL: &str = r#"#[serde(with = "crate::serializers::optional")]"#;
 const BYTES_SKIP_IF_EMPTY: &str = r#"#[serde(skip_serializing_if = "bytes::Bytes::is_empty")]"#;
-const SKIP: &str = "#[serde(skip)]";
+const SKIP_SERIALIZING: &str = "#[serde(skip_serializing)]";
 const RENAME_ALL_PASCALCASE: &str = r#"#[serde(rename_all = "PascalCase")]"#;
 const NULLABLEVECARRAY: &str = r#"#[serde(with = "crate::serializers::txs")]"#;
 const NULLABLE: &str = r#"#[serde(with = "crate::serializers::nullable")]"#;
@@ -199,7 +199,11 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         ".tendermint.types.Validator.proposer_priority",
         QUOTED_WITH_DEFAULT,
     ), // Default is for /genesis deserialization
-    (".tendermint.types.ValidatorSet.total_voting_power", SKIP),
+    (".tendermint.types.ValidatorSet.total_voting_power", DEFAULT),
+    (
+        ".tendermint.types.ValidatorSet.total_voting_power",
+        SKIP_SERIALIZING,
+    ),
     (".tendermint.types.BlockMeta.block_size", QUOTED),
     (".tendermint.types.BlockMeta.num_txs", QUOTED),
     (".tendermint.crypto.PublicKey.sum.ed25519", RENAME_EDPUBKEY),

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -98,7 +98,7 @@ pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.types.Commit", SERIALIZED),
     (".tendermint.types.CommitSig", SERIALIZED),
     (".tendermint.types.ValidatorSet", SERIALIZED),
-    (".tendermint.crypto.PublicKey", SERIALIZED),
+    (".tendermint.crypto.PublicKey.sum", SERIALIZED),
     (".tendermint.crypto.PublicKey.sum", TYPE_TAG),
     (".tendermint.abci.ResponseInfo", SERIALIZED),
     (".tendermint.types.CanonicalBlockID", SERIALIZED),

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -199,7 +199,10 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         ".tendermint.types.Validator.proposer_priority",
         QUOTED_WITH_DEFAULT,
     ), // Default is for /genesis deserialization
-    (".tendermint.types.ValidatorSet.total_voting_power", DEFAULT),
+    (
+        ".tendermint.types.ValidatorSet.total_voting_power",
+        QUOTED_WITH_DEFAULT,
+    ),
     (
         ".tendermint.types.ValidatorSet.total_voting_power",
         SKIP_SERIALIZING,


### PR DESCRIPTION
Closes #1348

Use the validating conversion from the protobuf struct `ValidatorSet`, which has the same schema including the now optionally deserialized `total_voting_power` field.
This is to ensure we don't blindly trust `total_voting_power` if it's
present in the serialization, and accept when it's absent.

Also ensure no integer overflows can occur while calculating the total voting power, and check the resulting power against
the protocol-defined sanity limit.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
