### PR TITLE
Correct and optimize custom serializers for stringized values, hashes, nullable and optional fields

### DIFF
--- a/.changelog/unreleased/breaking-changes/1351-serializer-fixes.md
+++ b/.changelog/unreleased/breaking-changes/1351-serializer-fixes.md
@@ -1,0 +1,16 @@
+- Changed the serde schema produced by `serialize` functions in these
+  helper modules ([\#1351](https://github.com/informalsystems/tendermint-
+  rs/pull/1351)):
+
+  * In `tendermint-proto`:
+    - `serializers::nullable`
+    - `serializers::optional`
+  * In `tendermint`:
+    - `serializers::apphash`
+    - `serializers::hash`
+    - `serializers::option_hash`
+
+  If `serde_json` is used for serialization, the output schema does not change.
+  But since serde is a generic framework, the changes may be breaking for
+  other users. Overall, these changes should make the serialized data
+  acceptable by the corresponding deserializer agnostically of the format.

--- a/.changelog/unreleased/improvements/1351-serializer-improvements.md
+++ b/.changelog/unreleased/improvements/1351-serializer-improvements.md
@@ -1,0 +1,3 @@
+- Corrected custom serializer helpers to consistently produce the format
+  accepted by the deserializer. Improved performance of deserializers.
+  ([\#1351](https://github.com/informalsystems/tendermint-rs/pull/1351))

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -1,6 +1,11 @@
-//! Serialize and deserialize any `T` that implements [[core::str::FromStr]]
-//! and [[core::fmt::Display]] from or into string. Note this can be used for
+//! Serialize and deserialize any `T` that implements [`FromStr`]
+//! and [`Display`] to convert from or into string. Note this can be used for
 //! all primitive data types.
+
+use alloc::borrow::Cow;
+use core::fmt::Display;
+use core::str::FromStr;
+
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::prelude::*;
@@ -9,10 +14,10 @@ use crate::prelude::*;
 pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
-    T: core::str::FromStr,
-    <T as core::str::FromStr>::Err: core::fmt::Display,
+    T: FromStr,
+    <T as FromStr>::Err: Display,
 {
-    <&str>::deserialize(deserializer)?
+    <Cow<'_, str>>::deserialize(deserializer)?
         .parse::<T>()
         .map_err(D::Error::custom)
 }
@@ -21,7 +26,37 @@ where
 pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
-    T: core::fmt::Display,
+    T: Display,
 {
     value.to_string().serialize(serializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::convert::Infallible;
+    use core::str::FromStr;
+    use serde::Deserialize;
+
+    struct ParsedStr(String);
+
+    impl FromStr for ParsedStr {
+        type Err = Infallible;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            Ok(Self(s.to_owned()))
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct Foo {
+        #[serde(with = "super")]
+        msg: ParsedStr,
+    }
+
+    #[test]
+    fn can_deserialize_owned() {
+        const TEST_JSON: &str = r#"{ "msg": "\"Hello\"" }"#;
+        let v = serde_json::from_str::<Foo>(TEST_JSON).unwrap();
+        assert_eq!(v.msg.0, "\"Hello\"");
+    }
 }

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -33,6 +33,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::prelude::*;
     use core::convert::Infallible;
     use core::str::FromStr;
     use serde::Deserialize;

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -12,9 +12,9 @@ where
     T: core::str::FromStr,
     <T as core::str::FromStr>::Err: core::fmt::Display,
 {
-    String::deserialize(deserializer)?
+    <&str>::deserialize(deserializer)?
         .parse::<T>()
-        .map_err(|e| D::Error::custom(format!("{e}")))
+        .map_err(D::Error::custom)
 }
 
 /// Serialize from T into string

--- a/proto/src/serializers/nullable.rs
+++ b/proto/src/serializers/nullable.rs
@@ -17,7 +17,8 @@ where
     T: Default + PartialEq + Serialize,
 {
     if value == &T::default() {
-        return serializer.serialize_none();
+        serializer.serialize_none()
+    } else {
+        serializer.serialize_some(value)
     }
-    value.serialize(serializer)
 }

--- a/proto/src/serializers/optional.rs
+++ b/proto/src/serializers/optional.rs
@@ -1,6 +1,9 @@
 //! Serialize/deserialize `Option<T>` type where `T` has a serializer/deserializer.
-//! Use `null` if the received value equals the `Default` implementation.
-// Todo: Rename this serializer to something like "default_eq_none" to mirror its purpose better.
+//! Deserialize to `None` if the received value equals the `Default` value.
+//! Serialize `None` as `Some` with the `Default` value for `T`.
+
+// TODO: Rename this serializer to something like "default_eq_none" to mirror its purpose better.
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Deserialize `Option<T>`
@@ -19,7 +22,7 @@ where
     T: Default + Serialize,
 {
     match value {
-        Some(v) => v.serialize(serializer),
-        None => T::default().serialize(serializer),
+        Some(v) => serializer.serialize_some(v),
+        None => serializer.serialize_some(&T::default()),
     }
 }

--- a/proto/src/serializers/optional_from_str.rs
+++ b/proto/src/serializers/optional_from_str.rs
@@ -1,5 +1,6 @@
 //! De/serialize an optional type that must be converted from/to a string.
 
+use alloc::borrow::Cow;
 use core::{fmt::Display, str::FromStr};
 
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
@@ -23,7 +24,7 @@ where
     T: FromStr,
     T::Err: Display,
 {
-    let s = match Option::<&str>::deserialize(deserializer)? {
+    let s = match Option::<Cow<'_, &str>>::deserialize(deserializer)? {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/proto/src/serializers/optional_from_str.rs
+++ b/proto/src/serializers/optional_from_str.rs
@@ -23,11 +23,9 @@ where
     T: FromStr,
     T::Err: Display,
 {
-    let s = match Option::<String>::deserialize(deserializer)? {
+    let s = match Option::<&str>::deserialize(deserializer)? {
         Some(s) => s,
         None => return Ok(None),
     };
-    Ok(Some(s.parse().map_err(|e: <T as FromStr>::Err| {
-        D::Error::custom(format!("{e}"))
-    })?))
+    Ok(Some(s.parse().map_err(D::Error::custom)?))
 }

--- a/proto/src/serializers/optional_from_str.rs
+++ b/proto/src/serializers/optional_from_str.rs
@@ -30,3 +30,35 @@ where
     };
     Ok(Some(s.parse().map_err(D::Error::custom)?))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use core::convert::Infallible;
+    use core::str::FromStr;
+    use serde::Deserialize;
+
+    #[derive(Debug, PartialEq)]
+    struct ParsedStr(String);
+
+    impl FromStr for ParsedStr {
+        type Err = Infallible;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            Ok(Self(s.to_owned()))
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct Foo {
+        #[serde(with = "super")]
+        msg: Option<ParsedStr>,
+    }
+
+    #[test]
+    fn can_deserialize_owned() {
+        const TEST_JSON: &str = r#"{ "msg": "\"Hello\"" }"#;
+        let v = serde_json::from_str::<Foo>(TEST_JSON).unwrap();
+        assert_eq!(v.msg, Some(ParsedStr("\"Hello\"".into())));
+    }
+}

--- a/proto/src/serializers/optional_from_str.rs
+++ b/proto/src/serializers/optional_from_str.rs
@@ -24,7 +24,7 @@ where
     T: FromStr,
     T::Err: Display,
 {
-    let s = match Option::<Cow<'_, &str>>::deserialize(deserializer)? {
+    let s = match Option::<Cow<'_, str>>::deserialize(deserializer)? {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/tendermint/src/serializers/apphash.rs
+++ b/tendermint/src/serializers/apphash.rs
@@ -1,6 +1,6 @@
 //! AppHash serialization with validation
 
-use serde::{Deserialize, Deserializer, Serializer};
+use serde::{de, ser, Deserialize, Deserializer, Serializer};
 use subtle_encoding::hex;
 
 use crate::{prelude::*, AppHash};
@@ -10,8 +10,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<AppHash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hexstring: String = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
-    AppHash::from_hex_upper(hexstring.as_str()).map_err(serde::de::Error::custom)
+    let hexstring = Option::<&str>::deserialize(deserializer)?.unwrap_or("");
+    AppHash::from_hex_upper(hexstring).map_err(de::Error::custom)
 }
 
 /// Serialize from AppHash into hexstring
@@ -20,6 +20,7 @@ where
     S: Serializer,
 {
     let hex_bytes = hex::encode_upper(value.as_ref());
-    let hex_string = String::from_utf8(hex_bytes).map_err(serde::ser::Error::custom)?;
-    serializer.serialize_str(&hex_string)
+    let hex_string = String::from_utf8(hex_bytes).map_err(ser::Error::custom)?;
+    // Serialize as Option<String> for symmetry with deserialize
+    serializer.serialize_some(&hex_string)
 }

--- a/tendermint/src/serializers/apphash.rs
+++ b/tendermint/src/serializers/apphash.rs
@@ -1,5 +1,7 @@
 //! AppHash serialization with validation
 
+use alloc::borrow::Cow;
+
 use serde::{de, ser, Deserialize, Deserializer, Serializer};
 use subtle_encoding::hex;
 
@@ -10,8 +12,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<AppHash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hexstring = Option::<&str>::deserialize(deserializer)?.unwrap_or("");
-    AppHash::from_hex_upper(hexstring).map_err(de::Error::custom)
+    let hexstring = Option::<Cow<'_, str>>::deserialize(deserializer)?.unwrap_or(Cow::Borrowed(""));
+    AppHash::from_hex_upper(&hexstring).map_err(de::Error::custom)
 }
 
 /// Serialize from AppHash into hexstring

--- a/tendermint/src/serializers/apphash_base64.rs
+++ b/tendermint/src/serializers/apphash_base64.rs
@@ -1,6 +1,6 @@
 //! AppHash serialization with validation
 
-use serde::{Deserialize, Deserializer, Serializer};
+use serde::{de, Deserialize, Deserializer, Serializer};
 use subtle_encoding::base64;
 
 use crate::{prelude::*, AppHash};
@@ -10,9 +10,9 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<AppHash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
-    let decoded = base64::decode(s).map_err(serde::de::Error::custom)?;
-    decoded.try_into().map_err(serde::de::Error::custom)
+    let s = Option::<&str>::deserialize(deserializer)?.unwrap_or("");
+    let decoded = base64::decode(s).map_err(de::Error::custom)?;
+    decoded.try_into().map_err(de::Error::custom)
 }
 
 /// Serialize from [`AppHash`] into a base64-encoded string.

--- a/tendermint/src/serializers/apphash_base64.rs
+++ b/tendermint/src/serializers/apphash_base64.rs
@@ -1,5 +1,7 @@
 //! AppHash serialization with validation
 
+use alloc::borrow::Cow;
+
 use serde::{de, Deserialize, Deserializer, Serializer};
 use subtle_encoding::base64;
 
@@ -10,8 +12,10 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<AppHash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = Option::<&str>::deserialize(deserializer)?.unwrap_or("");
-    let decoded = base64::decode(s).map_err(de::Error::custom)?;
+    let decoded = match Option::<Cow<'_, str>>::deserialize(deserializer)? {
+        Some(s) => base64::decode(s.as_bytes()).map_err(de::Error::custom)?,
+        None => vec![],
+    };
     decoded.try_into().map_err(de::Error::custom)
 }
 

--- a/tendermint/src/serializers/hash.rs
+++ b/tendermint/src/serializers/hash.rs
@@ -1,5 +1,7 @@
 //! Hash serialization with validation
 
+use alloc::borrow::Cow;
+
 use serde::{de, ser, Deserialize, Deserializer, Serializer};
 use subtle_encoding::hex;
 
@@ -10,8 +12,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hexstring = Option::<&str>::deserialize(deserializer)?.unwrap_or("");
-    Hash::from_hex_upper(Algorithm::Sha256, hexstring).map_err(de::Error::custom)
+    let hexstring = Option::<Cow<'_, str>>::deserialize(deserializer)?.unwrap_or(Cow::Borrowed(""));
+    Hash::from_hex_upper(Algorithm::Sha256, &hexstring).map_err(de::Error::custom)
 }
 
 /// Serialize from Hash into hexstring

--- a/tendermint/src/serializers/option_hash.rs
+++ b/tendermint/src/serializers/option_hash.rs
@@ -1,5 +1,7 @@
 //! `Option<Hash>` serialization with validation
 
+use alloc::borrow::Cow;
+
 use serde::{de, Deserialize, Deserializer, Serializer};
 
 use super::hash;
@@ -11,8 +13,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Hash>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    match Option::<&str>::deserialize(deserializer)? {
-        Some(s) => Hash::from_hex_upper(Algorithm::Sha256, s)
+    match Option::<Cow<'_, str>>::deserialize(deserializer)? {
+        Some(s) => Hash::from_hex_upper(Algorithm::Sha256, &s)
             .map(Some)
             .map_err(de::Error::custom),
         None => Ok(None),

--- a/tendermint/src/serializers/option_hash.rs
+++ b/tendermint/src/serializers/option_hash.rs
@@ -1,19 +1,25 @@
 //! `Option<Hash>` serialization with validation
 
-use serde::{Deserializer, Serializer};
+use serde::{de, Deserialize, Deserializer, Serializer};
 
 use super::hash;
-use crate::Hash;
+use crate::{hash::Algorithm, Hash};
 
-/// Deserialize hexstring into `Option<Hash>`
+/// Deserialize a nullable hexstring into `Option<Hash>`.
+/// A null value is deserialized as `None`.
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Hash>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    hash::deserialize(deserializer).map(Some)
+    match Option::<&str>::deserialize(deserializer)? {
+        Some(s) => Hash::from_hex_upper(Algorithm::Sha256, s)
+            .map(Some)
+            .map_err(de::Error::custom),
+        None => Ok(None),
+    }
 }
 
-/// Serialize from `Option<Hash>` into hexstring
+/// Serialize from `Option<Hash>` into a nullable hexstring. None is serialized as null.
 pub fn serialize<S>(value: &Option<Hash>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -21,6 +27,21 @@ where
     if value.is_none() {
         serializer.serialize_none()
     } else {
-        hash::serialize(&value.unwrap(), serializer)
+        // hash::serialize serializes as Option<String>, so this is consistent
+        // with the other branch.
+        hash::serialize(value.as_ref().unwrap(), serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_round_trip() {
+        let v: Option<Hash> = None;
+        let json = serde_json::to_string(&v).unwrap();
+        let parsed: Option<Hash> = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_none());
     }
 }


### PR DESCRIPTION
The custom field serializers in `tendermint` and `tendermint-proto` have a few problems.
The modules where the deserializers expect the values to be an `Option` (i.e. nullable) do not consistently use `Serializer::serialize_some` when serializing a non-null value. This is not an issue with `serde_json`, but as the serde framework is generic, this implementation will break with other serializers, particularly for non-self-describing formats.
Deserializer functions unconditionally allocate temporary strings where they can potentially be borrowed from the deserializer, achieving zero copies from source data.

These changes correct the serde schema issues and introduce optimization by deserializing strings into `Cow`, allowing use of borrowed string values from deserializers that support it.

* [ ] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
