### PR TITLE
Fix JSON serialization of `timestamp` field for `CommitSig::BlockIdFlagAbsent`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1352-fix-absent-vote-json.md
+++ b/.changelog/unreleased/bug-fixes/1352-fix-absent-vote-json.md
@@ -1,0 +1,3 @@
+- [`tendermint`] Fix JSON serialization of timestamp field for
+  `CommitSig::BlockIdFlagAbsent` to match what is expected by CometBFT
+  ([\#1352](https://github.com/informalsystems/tendermint-rs/issues/1352))

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -12,13 +12,13 @@ use crate::{account, prelude::*, Signature, Time};
 ///
 /// From the corresponding Tendermint `Time` struct:
 ///
-///     The zero value for a Time is defined to be
-///     January 1, year 1, 00:00:00.000000000 UTC
-///     which (1) looks like a zero, or as close as you can get in a date
-///     (1-1-1 00:00:00 UTC), (2) is unlikely enough to arise in practice to
-///     be a suitable "not set" sentinel, unlike Jan 1 1970, and (3) has a
-///     non-negative year even in time zones west of UTC, unlike 1-1-0
-///     00:00:00 UTC, which would be 12-31-(-1) 19:00:00 in New York.
+/// The zero value for a Time is defined to be
+/// January 1, year 1, 00:00:00.000000000 UTC
+/// which (1) looks like a zero, or as close as you can get in a date
+/// (1-1-1 00:00:00 UTC), (2) is unlikely enough to arise in practice to
+/// be a suitable "not set" sentinel, unlike Jan 1 1970, and (3) has a
+/// non-negative year even in time zones west of UTC, unlike 1-1-0
+/// 00:00:00 UTC, which would be 12-31-(-1) 19:00:00 in New York.
 const ZERO_TIMESTAMP: Timestamp = Timestamp {
     seconds: -62135596800,
     nanos: 0,

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -187,4 +187,23 @@ tendermint_pb_modules! {
             }
         }
     }
+
+    #[test]
+    #[cfg(test)]
+    fn test_block_id_flag_absent_serialization() {
+        let absent = CommitSig::BlockIdFlagAbsent;
+        let raw_absent = RawCommitSig::from(absent);
+        let expected = r#"{"block_id_flag":1,"validator_address":"","timestamp":"0001-01-01T00:00:00Z","signature":""}"#;
+        let output = serde_json::to_string(&raw_absent).unwrap();
+        assert_eq!(expected, &output);
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn test_block_id_flag_absent_deserialization() {
+        let json = r#"{"block_id_flag":1,"validator_address":"","timestamp":"0001-01-01T00:00:00Z","signature":""}"#;
+        let raw_commit_sg = serde_json::from_str::<RawCommitSig>(json).unwrap();
+        let commit_sig = CommitSig::try_from(raw_commit_sg).unwrap();
+        assert_eq!(commit_sig, CommitSig::BlockIdFlagAbsent);
+    }
 }

--- a/tendermint/src/block/commit_sig.rs
+++ b/tendermint/src/block/commit_sig.rs
@@ -87,8 +87,6 @@ tendermint_pb_modules! {
     use num_traits::ToPrimitive;
     use pb::types::{BlockIdFlag, CommitSig as RawCommitSig};
 
-    // Todo: https://github.com/informalsystems/tendermint-rs/issues/259 - CommitSig Timestamp can be zero time
-    // Todo: https://github.com/informalsystems/tendermint-rs/issues/260 - CommitSig validator address missing in Absent vote
     impl TryFrom<RawCommitSig> for CommitSig {
         type Error = Error;
 


### PR DESCRIPTION


See #1352 for the rationale behind this fix.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
