### PR TITLE
Update `async-tungstenite` to v0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "abci",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -83,7 +83,7 @@ subtle = { version = "2", default-features = false }
 semver = { version = "1.0", default-features = false }
 
 # Optional dependencies
-async-tungstenite = { version = "0.20", default-features = false, features = ["tokio-runtime", "tokio-rustls-native-certs"], optional = true }
+async-tungstenite = { version = "0.23", default-features = false, features = ["tokio-runtime", "tokio-rustls-native-certs"], optional = true }
 futures = { version = "0.3", optional = true, default-features = false }
 http = { version = "0.2", optional = true, default-features = false }
 hyper = { version = "0.14", optional = true, default-features = false, features = ["client", "http1", "http2"] }

--- a/tools/rpc-probe/Cargo.toml
+++ b/tools/rpc-probe/Cargo.toml
@@ -17,7 +17,7 @@ description = """
 all-features = true
 
 [dependencies]
-async-tungstenite = { version = "0.17", features = [ "tokio-runtime", "tokio-rustls-native-certs" ] }
+async-tungstenite = { version = "0.23", features = [ "tokio-runtime", "tokio-rustls-native-certs" ] }
 futures = "0.3"
 getrandom = "0.2"
 log = "0.4"


### PR DESCRIPTION
This in turns updates `tungstenite` to v0.20.0+, will pulls in v0.20.1, which contains a fix for this security advisory about a DoS attack:

https://github.com/informalsystems/hermes/security/dependabot/33