### PR TITLE
Turn non-200 HTTP responses into an error instead of trying to parse the body as a JSON-RPC response

### DIFF
--- a/.changelog/unreleased/improvements/1359-hande-http-error.md
+++ b/.changelog/unreleased/improvements/1359-hande-http-error.md
@@ -1,0 +1,3 @@
+- `[tendermint-rpc]` Turn non-200 HTTP response into an error
+  instead of trying to parse the body as a JSON-RPC response
+  ([\#1359](https://github.com/informalsystems/tendermint-rs/issues/1359))

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -71,7 +71,7 @@ thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 uuid = { version = "0.8", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
-url = { version = "2.2", default-features = false }
+url = { version = "2.4.1", default-features = false }
 walkdir = { version = "2.3", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -12,6 +12,12 @@ type ReqwestError = flex_error::DisplayOnly<reqwest::Error>;
 #[cfg(not(feature = "reqwest"))]
 type ReqwestError = flex_error::NoSource;
 
+#[cfg(feature = "reqwest")]
+type HttpStatusCode = reqwest::StatusCode;
+
+#[cfg(not(feature = "reqwest"))]
+type HttpStatusCode = core::num::NonZeroU16;
+
 #[cfg(feature = "tokio")]
 type JoinError = flex_error::DisplayOnly<tokio::task::JoinError>;
 
@@ -77,10 +83,9 @@ define_error! {
                 format_args!("method not found: {}", e.method)
             },
 
-        #[cfg(feature = "reqwest")]
         HttpRequestFailed
             {
-                status: reqwest::StatusCode,
+                status: HttpStatusCode,
             }
             | e | {
                 format_args!("HTTP request failed with non-200 status code: {}", e.status)

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -77,6 +77,15 @@ define_error! {
                 format_args!("method not found: {}", e.method)
             },
 
+        #[cfg(feature = "reqwest")]
+        HttpRequestFailed
+            {
+                status: reqwest::StatusCode,
+            }
+            | e | {
+                format_args!("HTTP request failed with non-200 status code: {}", e.status)
+            },
+
         Parse
             {
                 reason: String


### PR DESCRIPTION
Closes: #1359

This PR checks for the status code to be 200 OK, if not it returns an error with the actual status code and the body of the response, but does not attempt to parse the response body as a JSON-RPC payload.

CometBFT will [always set the status code](https://github.com/cometbft/cometbft/blob/86c07f20f163c17a0f5b7149cbd441a242b88557/rpc/jsonrpc/server/http_server.go#L151) to 200 OK and the content type to JSON for response which were successfully handled (which does mean that the JSON-RPC response itself is successful).

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
