### PR TITLE
Update to CometBFT 0.38.0 release

### DIFF
--- a/.changelog/unreleased/breaking-changes/1365-cometbft-0.38.0.md
+++ b/.changelog/unreleased/breaking-changes/1365-cometbft-0.38.0.md
@@ -1,0 +1,6 @@
+- `[tendermint-proto]` Update `v0_38` bindings to CometFBT release 0.38.0
+  ([\#1365](https://github.com/informalsystems/tendermint-rs/pull/1365)).
+- `[tendermint]` Add fields to `abci::request::ExtendVote` to represent
+  the fields added to the `abci.RequestExtendVote` protobuf message since
+  the 0.38.0-rc3 release
+  ([\#1365](https://github.com/informalsystems/tendermint-rs/pull/1365)).

--- a/proto/src/prost/v0_38/tendermint.abci.rs
+++ b/proto/src/prost/v0_38/tendermint.abci.rs
@@ -193,12 +193,26 @@ pub struct RequestProcessProposal {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestExtendVote {
-    /// the hash of the block  that this vote may be referring to
+    /// the hash of the block that this vote may be referring to
     #[prost(bytes = "bytes", tag = "1")]
     pub hash: ::prost::bytes::Bytes,
     /// the height of the extended vote
     #[prost(int64, tag = "2")]
     pub height: i64,
+    /// info of the block that this vote may be referring to
+    #[prost(message, optional, tag = "3")]
+    pub time: ::core::option::Option<crate::google::protobuf::Timestamp>,
+    #[prost(bytes = "bytes", repeated, tag = "4")]
+    pub txs: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    #[prost(message, optional, tag = "5")]
+    pub proposed_last_commit: ::core::option::Option<CommitInfo>,
+    #[prost(message, repeated, tag = "6")]
+    pub misbehavior: ::prost::alloc::vec::Vec<Misbehavior>,
+    #[prost(bytes = "bytes", tag = "7")]
+    pub next_validators_hash: ::prost::bytes::Bytes,
+    /// address of the public key of the original proposer of the block.
+    #[prost(bytes = "bytes", tag = "8")]
+    pub proposer_address: ::prost::bytes::Bytes,
 }
 /// Verify the vote extension
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/tendermint/v0_38.rs
+++ b/proto/src/tendermint/v0_38.rs
@@ -62,5 +62,5 @@ pub mod version {
 
 pub mod meta {
     pub const REPOSITORY: &str = "https://github.com/cometbft/cometbft";
-    pub const COMMITISH: &str = "v0.38.0-rc3";
+    pub const COMMITISH: &str = "v0.38.0";
 }

--- a/tendermint/src/abci/request/extend_vote.rs
+++ b/tendermint/src/abci/request/extend_vote.rs
@@ -1,10 +1,20 @@
-use crate::{block, Hash};
+use bytes::Bytes;
+
+use crate::abci::types::{CommitInfo, Misbehavior};
+use crate::prelude::*;
+use crate::{account, block, Hash, Time};
 
 #[doc = include_str!("../doc/request-extendvote.md")]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ExtendVote {
     pub hash: Hash,
     pub height: block::Height,
+    pub time: Time,
+    pub txs: Vec<Bytes>,
+    pub proposed_last_commit: Option<CommitInfo>,
+    pub misbehavior: Vec<Misbehavior>,
+    pub next_validators_hash: Hash,
+    pub proposer_address: account::Id,
 }
 
 // =============================================================================
@@ -13,6 +23,7 @@ pub struct ExtendVote {
 
 mod v0_38 {
     use super::ExtendVote;
+    use crate::{prelude::*, Error};
     use tendermint_proto::v0_38 as pb;
     use tendermint_proto::Protobuf;
 
@@ -21,17 +32,43 @@ mod v0_38 {
             Self {
                 hash: extend_vote.hash.into(),
                 height: extend_vote.height.into(),
+                time: Some(extend_vote.time.into()),
+                txs: extend_vote.txs,
+                proposed_last_commit: extend_vote.proposed_last_commit.map(Into::into),
+                misbehavior: extend_vote
+                    .misbehavior
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                next_validators_hash: extend_vote.next_validators_hash.into(),
+                proposer_address: extend_vote.proposer_address.into(),
             }
         }
     }
 
     impl TryFrom<pb::abci::RequestExtendVote> for ExtendVote {
-        type Error = crate::Error;
+        type Error = Error;
 
         fn try_from(message: pb::abci::RequestExtendVote) -> Result<Self, Self::Error> {
             Ok(Self {
                 hash: message.hash.try_into()?,
                 height: message.height.try_into()?,
+                time: message
+                    .time
+                    .ok_or_else(Error::missing_timestamp)?
+                    .try_into()?,
+                txs: message.txs,
+                proposed_last_commit: message
+                    .proposed_last_commit
+                    .map(TryInto::try_into)
+                    .transpose()?,
+                misbehavior: message
+                    .misbehavior
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+                next_validators_hash: message.next_validators_hash.try_into()?,
+                proposer_address: message.proposer_address.try_into()?,
             })
         }
     }

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -29,7 +29,7 @@ pub const TENDERMINT_VERSIONS: &[TendermintVersion] = &[
     TendermintVersion {
         repo: "https://github.com/cometbft/cometbft",
         ident: "v0_38",
-        commitish: "v0.38.0-rc3",
+        commitish: "v0.38.0",
     },
 ];
 


### PR DESCRIPTION
Since v0.38.0-rc3, there were quite a few fields added to the
`RequestExtendVote` message.
Represent them in the domain type for the request.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
