### PR TITLE
Avoid enabling flex-error/eyre_tracer feature

### DIFF
--- a/.changelog/unreleased/breaking-changes/eyre_tracer.md
+++ b/.changelog/unreleased/breaking-changes/eyre_tracer.md
@@ -1,0 +1,4 @@
+- Don’t enable `flex-error/eyre_tracer` feature in crates which don’t
+  use eyre directly.  If you’re using eyre, and no other crate enables
+  it, you may need to enable that explicitly.
+  ([\#1371](https://github.com/informalsystems/tendermint-rs/pull/1371))

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/application/kvstore/main.rs"
 required-features = [ "binary", "client", "kvstore-app" ]
 
 [features]
-default = ["flex-error/std", "flex-error/eyre_tracer"]
+default = ["flex-error/std"]
 client = []
 echo-app = []
 kvstore-app = []

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["rust-crypto", "flex-error/std", "flex-error/eyre_tracer"]
+default = ["rust-crypto", "flex-error/std"]
 rust-crypto = ["tendermint/rust-crypto"]
 
 [dependencies]

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["rpc-client", "flex-error/std", "flex-error/eyre_tracer"]
+default = ["rpc-client", "flex-error/std"]
 rpc-client = ["tokio", "rust-crypto", "tendermint-rpc/http-client"]
 rust-crypto = ["tendermint/rust-crypto", "tendermint-light-client-verifier/rust-crypto"]
 secp256k1 = ["tendermint/secp256k1", "tendermint-rpc/secp256k1"]

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -55,7 +55,7 @@ ripemd = { version = "0.1.3", optional = true, default-features = false }
 
 [features]
 default = ["std", "rust-crypto"]
-std = ["flex-error/std", "flex-error/eyre_tracer", "clock"]
+std = ["flex-error/std", "clock"]
 clock = ["time/std"]
 secp256k1 = ["k256", "ripemd"]
 rust-crypto = ["sha2", "ed25519-consensus"]

--- a/tools/abci-test/Cargo.toml
+++ b/tools/abci-test/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
+flex-error = { version = "0.4.4", default-features = false, features = ["std"] }
 futures = "0.3"
 structopt = "0.3"
 tendermint = { version = "0.34.0", path = "../../tendermint" }


### PR DESCRIPTION
Don’t enable flex-error/eyre_tracer feature in crates which don’t use
eyre directly.  This allows customers depend on say tendermint crate
without having to pull in eyre crate.  This is useful because eyre
uses mutable static variables (specifically HOOK variable) which is
incompatible with some blockchain runtimes.

* [n/a] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [n/a] Wrote tests
* [x] Added entry in `.changelog/`
