### PR TITLE
p2p: bump `chacha20poly1305` to v0.10

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -27,7 +27,7 @@ default = ["flex-error/std", "flex-error/eyre_tracer"]
 amino = ["prost-derive"]
 
 [dependencies]
-chacha20poly1305 = { version = "0.8", default-features = false, features = ["reduced-round"] }
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["reduced-round"] }
 curve25519-dalek-ng = { version = "4", default-features = false }
 ed25519-consensus = { version = "2", default-features = false }
 eyre = { version = "0.6", default-features = false }
@@ -40,7 +40,7 @@ sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 signature = { version = "2", default-features = false }
-aead = { version = "0.4.1", default-features = false }
+aead = { version = "0.5", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 # path dependencies

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use chacha20poly1305::{
-    aead::{generic_array::GenericArray, AeadInPlace, NewAead},
+    aead::{generic_array::GenericArray, AeadInPlace, KeyInit},
     ChaCha20Poly1305,
 };
 use curve25519_dalek_ng::{


### PR DESCRIPTION
Updates to the latest version of the `chacha20poly1305` crate