### PR TITLE
tendermint: allow null in `EventAttribute` kv JSON

### DIFF
--- a/.changelog/unreleased/breaking-changes/1375-allow-null-in-event-attributes.md
+++ b/.changelog/unreleased/breaking-changes/1375-allow-null-in-event-attributes.md
@@ -1,0 +1,4 @@
+- `[tendermint]` Allow null values in `key` and `value` fields of
+  `EventAttribute` when deserializing. The serialization schema for the fields
+  is changed to `Option<String>`
+  ([\#1375](https://github.com/informalsystems/tendermint-rs/issues/1375)).

--- a/tendermint/src/abci/event.rs
+++ b/tendermint/src/abci/event.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
+use crate::serializers;
 
 /// An event that occurred while processing a request.
 ///
@@ -119,8 +120,10 @@ where
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Hash)]
 pub struct EventAttribute {
     /// The event key.
+    #[serde(with = "serializers::allow_null")]
     pub key: String,
     /// The event value.
+    #[serde(with = "serializers::allow_null")]
     pub value: String,
     /// Whether Tendermint's indexer should index this event.
     ///


### PR DESCRIPTION
Fixes #1375

When deserializing `EventAttribute` values, allow null values in the key and value fields. This follows the behaviour in 0.34 RPC (where the key-value data were also base64-encoded), but technically breaks the serde schema of everything that includes ABCI event data.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
