### PR TITLE
Update rustc option for instrument-coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
           components: llvm-tools-preview
       - run: cargo test-all-features
         env:
-          RUSTFLAGS: '-Cinstrument-coverage'
+          RUSTFLAGS: '-C instrument-coverage -C link-dead-code'
           LLVM_PROFILE_FILE: '%p-%m.profraw'
       - name: Install grcov
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
           components: llvm-tools-preview
       - run: cargo test-all-features
         env:
-          RUSTFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: '%p-%m.profraw'
       - name: Install grcov
         run: |

--- a/config/src/prelude.rs
+++ b/config/src/prelude.rs
@@ -2,7 +2,6 @@
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
 pub use alloc::{
     borrow::ToOwned,
-    boxed::Box,
     format,
     string::{String, ToString},
     vec,

--- a/light-client-verifier/src/prelude.rs
+++ b/light-client-verifier/src/prelude.rs
@@ -1,13 +1,10 @@
 // Re-export according to alloc::prelude::v1 because it is not yet stabilized
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
+#[allow(unused_imports)]
 pub use alloc::{
-    borrow::ToOwned,
     boxed::Box,
-    format,
     string::{String, ToString},
     vec,
     vec::Vec,
 };
-// will be included in 2021 edition.
-pub use core::convert::{TryFrom, TryInto};
 pub use core::prelude::v1::*;

--- a/light-client-verifier/src/prelude.rs
+++ b/light-client-verifier/src/prelude.rs
@@ -1,10 +1,10 @@
 // Re-export according to alloc::prelude::v1 because it is not yet stabilized
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
 #[allow(unused_imports)]
+pub use alloc::vec;
 pub use alloc::{
     boxed::Box,
     string::{String, ToString},
-    vec,
     vec::Vec,
 };
 pub use core::prelude::v1::*;

--- a/proto/src/prelude.rs
+++ b/proto/src/prelude.rs
@@ -2,10 +2,8 @@
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
 pub use alloc::{
     borrow::ToOwned,
-    boxed::Box,
     format,
     string::{String, ToString},
-    vec,
     vec::Vec,
 };
 pub use core::prelude::v1::*;

--- a/proto/src/prelude.rs
+++ b/proto/src/prelude.rs
@@ -1,5 +1,8 @@
 // Re-export according to alloc::prelude::v1 because it is not yet stabilized
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
+
+#[allow(unused_imports)]
+pub use alloc::vec;
 pub use alloc::{
     borrow::ToOwned,
     format,


### PR DESCRIPTION
Fix the `nightly-coverage` CI job by adjusting the flag for the nightly
rustc compiler.

Also throw in `-C link-dead-code` into the compiler flags for the
nightly-coverage CI job.
