### PR TITLE
rpc: expose `http::Builder`, `websocket::Builder` under `client`

### DIFF
--- a/.changelog/unreleased/improvements/1378-expose-rpc-client-builders.md
+++ b/.changelog/unreleased/improvements/1378-expose-rpc-client-builders.md
@@ -1,0 +1,3 @@
+- `[tendermint-rpc]` Export the `http`, `websocket`
+  modules under `client`, each with the public `Builder` type
+  ([\#1378](https://github.com/informalsystems/tendermint-rs/pull/1378)).

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -15,10 +15,10 @@ pub mod sync;
 mod transport;
 
 #[cfg(feature = "http-client")]
-pub use transport::http::{HttpClient, HttpClientUrl};
+pub use transport::http::{self, HttpClient, HttpClientUrl};
 #[cfg(feature = "websocket-client")]
 pub use transport::websocket::{
-    WebSocketClient, WebSocketClientDriver, WebSocketClientUrl, WebSocketConfig,
+    self, WebSocketClient, WebSocketClientDriver, WebSocketClientUrl, WebSocketConfig,
 };
 
 #[cfg(any(feature = "http-client", feature = "websocket-client"))]


### PR DESCRIPTION
Re-export `client::transport::{http, websocket}` (guarded by appropriate feature gates) publicly under the `client` module.
This exposes the `Builder` types defined in each of the modules as public API, with properly built documentation.

* [ ] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
