### PR TITLE
rpc: Add HTTP timeout, default 30 seconds.

### DIFF
--- a/.changelog/unreleased/improvements/1379-rpc-http-timeout.md
+++ b/.changelog/unreleased/improvements/1379-rpc-http-timeout.md
@@ -1,0 +1,2 @@
+- Add request timeout for the RPC HttpClient
+  ([\#1379](https://github.com/informalsystems/tendermint-rs/issues/1379))

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -7,6 +7,7 @@ use core::{
 
 use async_trait::async_trait;
 use reqwest::{header, Proxy};
+use std::time::Duration;
 
 use tendermint::{block::Height, evidence::Evidence, Hash};
 use tendermint_config::net;
@@ -63,6 +64,7 @@ pub struct Builder {
     url: HttpClientUrl,
     compat: CompatMode,
     proxy_url: Option<HttpClientUrl>,
+    timeout: Duration,
 }
 
 impl Builder {
@@ -85,9 +87,20 @@ impl Builder {
         self
     }
 
+    /// The timeout is applied from when the request starts connecting until
+    /// the response body has finished.
+    ///
+    /// The default is 30 seconds.
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = duration;
+        self
+    }
+
     /// Try to create a client with the options specified for this builder.
     pub fn build(self) -> Result<HttpClient, Error> {
-        let builder = reqwest::ClientBuilder::new().user_agent(USER_AGENT);
+        let builder = reqwest::ClientBuilder::new()
+            .user_agent(USER_AGENT)
+            .timeout(self.timeout);
         let inner = match self.proxy_url {
             None => builder.build().map_err(Error::http)?,
             Some(proxy_url) => {
@@ -142,6 +155,7 @@ impl HttpClient {
             url,
             compat: Default::default(),
             proxy_url: None,
+            timeout: Duration::from_secs(30),
         }
     }
 


### PR DESCRIPTION
Simply introduces a HTTP timeout parameter, which is passed to reqwest.

This is highly desirable a the default behaviour is "no timeout", which can result in stalls.

Closes #1379.

<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
