### PR TITLE
rpc: Make `rpc::Client` and `SubscriptionClient` traits `?Send` under `wasm32` target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Support for Secp256k1 consensus keys has been added as an optional feature.
 - `[tendermint-rpc]` Turn non-200 HTTP response into an error
   instead of trying to parse the body as a JSON-RPC response
   ([\#1359](https://github.com/informalsystems/tendermint-rs/issues/1359))
+- `[tendermint-rpc]` Make `rpc::Client` and `SubscriptionClient` traits `?Send` under `wasm32` target.
+  ([\#1385](https://github.com/informalsystems/tendermint-rs/issues/1385))
 
 ### SECURITY
 

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -45,7 +45,8 @@ use crate::{
 /// [`SubscriptionClient`] trait.
 ///
 /// [`SubscriptionClient`]: trait.SubscriptionClient.html
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Client {
     /// `/abci_info`: get information about the ABCI application.
     async fn abci_info(&self) -> Result<abci::response::Info, Error> {

--- a/rpc/src/client/subscription.rs
+++ b/rpc/src/client/subscription.rs
@@ -19,7 +19,8 @@ use crate::{
 
 /// A client that exclusively provides [`Event`] subscription capabilities,
 /// without any other RPC method support.
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SubscriptionClient {
     /// `/subscribe`: subscribe to receive events produced by the given query.
     async fn subscribe(&self, query: Query) -> Result<Subscription, Error>;


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

Closes: https://github.com/informalsystems/tendermint-rs/issues/1385

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
