### PR TITLE
🔁 `PrivateKey` and `PublicKey` have `From` impls for `ed25519-consensus` types

### DIFF
--- a/.changelog/unreleased/features/1401-ed25519-consensus-from-impls.md
+++ b/.changelog/unreleased/features/1401-ed25519-consensus-from-impls.md
@@ -1,0 +1,6 @@
+- `[tendermint]` Add the following impls for `ed25519-consensus`:
+  * `From<ed25519_consensus::SigningKey` for `tendermint::PrivateKey`
+  * `From<ed25519_consensus::SigningKey>` for `tendermint::SigningKey`
+  * `From<ed25519_consensus::VerificationKey>` for `tendermint::PublicKey`
+  * `From<ed25519_consensus::VerificationKey>` for `tendermint::VerificationKey`
+  ([\#1401](https://github.com/informalsystems/tendermint-rs/pull/1401))

--- a/tendermint/src/crypto/ed25519/signing_key.rs
+++ b/tendermint/src/crypto/ed25519/signing_key.rs
@@ -7,6 +7,11 @@ use crate::Error;
 pub struct SigningKey([u8; 32]);
 
 impl SigningKey {
+    #[allow(dead_code)]
+    pub(super) fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }

--- a/tendermint/src/crypto/ed25519/signing_key.rs
+++ b/tendermint/src/crypto/ed25519/signing_key.rs
@@ -46,3 +46,10 @@ impl TryFrom<SigningKey> for ed25519_consensus::SigningKey {
         Ok(ed25519_consensus::SigningKey::from(src.0))
     }
 }
+
+#[cfg(feature = "rust-crypto")]
+impl From<ed25519_consensus::SigningKey> for SigningKey {
+    fn from(sk: ed25519_consensus::SigningKey) -> Self {
+        Self::new(sk.to_bytes())
+    }
+}

--- a/tendermint/src/crypto/ed25519/verification_key.rs
+++ b/tendermint/src/crypto/ed25519/verification_key.rs
@@ -51,3 +51,10 @@ impl TryFrom<VerificationKey> for ed25519_consensus::VerificationKey {
             .map_err(|_| Error::invalid_key("malformed Ed25519 public key".into()))
     }
 }
+
+#[cfg(feature = "rust-crypto")]
+impl From<ed25519_consensus::VerificationKey> for VerificationKey {
+    fn from(vk: ed25519_consensus::VerificationKey) -> Self {
+        Self::new(vk.to_bytes())
+    }
+}

--- a/tendermint/src/private_key.rs
+++ b/tendermint/src/private_key.rs
@@ -70,6 +70,13 @@ impl PrivateKey {
     }
 }
 
+#[cfg(feature = "rust-crypto")]
+impl From<ed25519_consensus::SigningKey> for PrivateKey {
+    fn from(sk: ed25519_consensus::SigningKey) -> Self {
+        Self::Ed25519(sk.into())
+    }
+}
+
 /// Serialize a Secp256k1 privkey as Base64
 #[cfg(feature = "secp256k1")]
 fn serialize_secp256k1_privkey<S>(signing_key: &Secp256k1, serializer: S) -> Result<S::Ok, S::Error>

--- a/tendermint/src/private_key.rs
+++ b/tendermint/src/private_key.rs
@@ -68,6 +68,12 @@ impl PrivateKey {
             PrivateKey::Secp256k1(_signing_key) => None,
         }
     }
+
+    /// From an [`ed25519_consensus::SigningKey`]
+    #[cfg(feature = "rust-crypto")]
+    pub fn from_ed25519_consensus(sk: ed25519_consensus::SigningKey) -> Self {
+        Self::Ed25519(sk.into())
+    }
 }
 
 #[cfg(feature = "rust-crypto")]

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -175,6 +175,12 @@ impl PublicKey {
         Ed25519::try_from(bytes).map(PublicKey::Ed25519).ok()
     }
 
+    /// From an [`ed25519_consensus::VerificationKey`]
+    #[cfg(feature = "rust-crypto")]
+    pub fn from_ed25519_consensus(vk: ed25519_consensus::VerificationKey) -> Self {
+        Self::from(vk)
+    }
+
     /// Get Ed25519 public key
     pub fn ed25519(self) -> Option<Ed25519> {
         #[allow(unreachable_patterns)]

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -240,6 +240,13 @@ impl From<Secp256k1> for PublicKey {
     }
 }
 
+#[cfg(feature = "rust-crypto")]
+impl From<ed25519_consensus::VerificationKey> for PublicKey {
+    fn from(vk: ed25519_consensus::VerificationKey) -> PublicKey {
+        PublicKey::Ed25519(vk.into())
+    }
+}
+
 impl PartialOrd for PublicKey {
     fn partial_cmp(&self, other: &PublicKey) -> Option<Ordering> {
         Some(self.cmp(other))


### PR DESCRIPTION
currently, when working with `tendermint::{PrivateKey, PublicKey}`, users of the `ed25519-consensus` crate must convert a `ed25519_consensus::VerificationKey` or `ed25519_consensus::SigningKey` via `TryFrom<&'_ [u8]>`. this has the unfortunate effect of requiring a bounds check, on a value that is already known to be a valid key.

```rust
tendermint::PublicKey::from_raw_ed25519(&vk.to_bytes()).expect("consensus key is valid")
```

this branch introduces some additional `From<T>` implementations, to facilitate free conversions from `ed25519-consensus` types.

* 649dd37e tendermint: `PrivateKey` is `From<ed25519_consensus::SigningKey>`
* 4f1a95a4 tendermint: `SigningKey` is `From<ed25519_consensus::SigningKey>`
* ad24ea54 tendermint: `PublicKey` is `From<ed25519_consensus::VerificationKey>`
* 8769244f tendermint: `VerificationKey` is `From<ed25519_consensus::VerificationKey>`

an internal `SigningKey::new()` constructor is also added, for the sake of consistency with `VerificationKey::new()`. this is optional, i'd be happy to back out of that change if it seems prudent.

some additional `from_ed25519_consensus` methods are provided, for cases where type inference might not suffice. these felt complimentary to existing methods like `from_raw_ed25519`, but are another optional change i'd be happy to back out of.