### PR TITLE
tendermint: Allow misformed blocks when decoding them from Protobuf or RPC responses

### DIFF
--- a/.changelog/unreleased/improvements/1403-decode-empty-commit-in-block.md
+++ b/.changelog/unreleased/improvements/1403-decode-empty-commit-in-block.md
@@ -1,0 +1,3 @@
+- `[tendermint]` Allow misformed blocks (eg. with empty `last_commit`
+  on non-first block) when decoding them from Protobuf or RPC responses
+  ([\#1403](https://github.com/informalsystems/tendermint-rs/issues/1403))


### PR DESCRIPTION

Closes: #1403

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
