### PR TITLE
light-client-verifier: optimise validator lookup in voting_power_in

### DIFF
--- a/.changelog/unreleased/improvements/1406-optimise-voting_power_in.md
+++ b/.changelog/unreleased/improvements/1406-optimise-voting_power_in.md
@@ -1,0 +1,3 @@
+- `[light-client-verifier]` Optimise validators lookup in
+  ProvidedVotingPowerCalculator::voting_power_in method.
+  ([\#1407](https://github.com/informalsystems/tendermint-rs/pull/1407))

--- a/.changelog/unreleased/improvements/1406-optimise-voting_power_in.md
+++ b/.changelog/unreleased/improvements/1406-optimise-voting_power_in.md
@@ -1,3 +1,3 @@
 - `[light-client-verifier]` Optimise validators lookup in
-  ProvidedVotingPowerCalculator::voting_power_in method.
+  `ProvidedVotingPowerCalculator::voting_power_in` method.
   ([\#1407](https://github.com/informalsystems/tendermint-rs/pull/1407))


### PR DESCRIPTION
Rather than performing a linear search for a validator by its address, construct an index for the validator set sorted by address.  While building the index takes O(N log N) time, it cuts lookup to O(log n).

On Solana, with ~50 validators, this change causes reduction of the cost of a single lookup from 20k compute units to 700.

Furthermore, merge the index with the seen_validators map so that only a single lookup is now performed which allows us to find the validator and check whether it’s not a duplicate.

Closes: https://github.com/informalsystems/tendermint-rs/issues/1406

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
