### PR TITLE
tendermint: ensure ValidatorIndex is ≤ i32::MAX

### DIFF
--- a/.changelog/unreleased/improvements/1411-validator-index-i32-max-limit.md
+++ b/.changelog/unreleased/improvements/1411-validator-index-i32-max-limit.md
@@ -1,0 +1,3 @@
+- `[tendermint]` Check `index ≤ i32::MAX` invariant when converting `usize`
+  into `ValidatorIndex`.
+  ([\#1411](https://github.com/informalsystems/tendermint-rs/issues/1411))

--- a/tendermint/src/vote/validator_index.rs
+++ b/tendermint/src/vote/validator_index.rs
@@ -44,9 +44,9 @@ impl TryFrom<usize> for ValidatorIndex {
     type Error = Error;
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
-        Ok(ValidatorIndex(
-            value.try_into().map_err(Error::integer_overflow)?,
-        ))
+        // Convert to i32 first to perform ≤ i32::MAX check.
+        let value = i32::try_from(value).map_err(Error::integer_overflow)?;
+        ValidatorIndex::try_from(value)
     }
 }
 
@@ -87,4 +87,12 @@ impl FromStr for ValidatorIndex {
                 .map_err(|e| Error::parse_int("validator index decode".to_string(), e))?,
         )
     }
+}
+
+#[test]
+fn test_i32_max_limit() {
+    assert!(ValidatorIndex::try_from(u32::MAX).is_err());
+    assert!(ValidatorIndex::try_from(u32::MAX as usize).is_err());
+    let value = u32::MAX.to_string();
+    assert!(ValidatorIndex::from_str(&value).is_err());
 }


### PR DESCRIPTION
During conversion from usize to ValidatorIndex first convert the value to `i32` to make sure that the value is ≤ i32::MAX.  Without that intermediate conversion, `u32::MAX as usize` is successfully converted into the index.

* [ ] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
