### PR TITLE
fix(abci): Add serde `default` for `Event::type`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1415-fix-optional-event-type.md
+++ b/.changelog/unreleased/bug-fixes/1415-fix-optional-event-type.md
@@ -1,0 +1,3 @@
+- `[tendermint-abci]` Add serde default for Event.type since it has omitempty in the Go
+  implementation.
+  ([\#1416](https://github.com/informalsystems/tendermint-rs/pull/1416))

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -88,6 +88,7 @@ tracing = { version = "0.1", optional = true, default-features = false }
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = ["fmt"] }
 
 [dev-dependencies]
+tendermint = { version = "0.36.0", default-features = false, path = "../tendermint", features = ["secp256k1"] }
 http = { version = "1", default-features = false, features = ["std"] }
 lazy_static = { version = "1.4.0", default-features = false }
 tokio-test = { version = "0.4", default-features = false }

--- a/rpc/tests/dydx_fixtures.rs
+++ b/rpc/tests/dydx_fixtures.rs
@@ -34,10 +34,11 @@ fn incoming_fixtures() {
             .unwrap();
         let content = fs::read_to_string(&json_file).unwrap();
         match file_name {
-            // NOTE: for the purpose of the test I emptied `validator_updates` which has another
-            // unrelated issue deserializing the Secp256K1 public key
+            // NOTE: for the purpose of the test I manually emptied `validator_updates` from the
+            // block_results, which has another unrelated issue deserializing the Secp256K1 public
+            // key
             "block_results_at_height_12791634" => {
-                let r = endpoint::block_results::v0_34::DialectResponse::from_string(content);
+                let r = endpoint::block_results::Response::from_string(content);
                 assert!(r.is_ok(), "block_results_at_height_12791634: {r:?}");
             },
             _ => {

--- a/rpc/tests/dydx_fixtures.rs
+++ b/rpc/tests/dydx_fixtures.rs
@@ -34,6 +34,8 @@ fn incoming_fixtures() {
             .unwrap();
         let content = fs::read_to_string(&json_file).unwrap();
         match file_name {
+            // NOTE: for the purpose of the test I emptied `validator_updates` which has another
+            // unrelated issue deserializing the Secp256K1 public key
             "block_results_at_height_12791634" => {
                 let r = endpoint::block_results::v0_34::DialectResponse::from_string(content);
                 assert!(r.is_ok(), "block_results_at_height_12791634: {r:?}");

--- a/rpc/tests/dydx_fixtures.rs
+++ b/rpc/tests/dydx_fixtures.rs
@@ -1,0 +1,46 @@
+use std::{fs, path::PathBuf};
+
+use tendermint_rpc::{endpoint, Response};
+
+use walkdir::WalkDir;
+
+fn find_fixtures(in_out_folder_name: &str) -> Vec<PathBuf> {
+    WalkDir::new(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("dydx_fixtures")
+            .join(in_out_folder_name),
+    )
+    .into_iter()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+        e.file_type().is_file()
+            && e.path().extension().is_some()
+            && e.path().extension().unwrap() == "json"
+    })
+    .map(|e| e.into_path())
+    .collect::<Vec<PathBuf>>()
+}
+
+#[test]
+fn incoming_fixtures() {
+    for json_file in find_fixtures("incoming") {
+        let file_name = json_file
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .strip_suffix(".json")
+            .unwrap();
+        let content = fs::read_to_string(&json_file).unwrap();
+        match file_name {
+            "block_results_at_height_12791634" => {
+                let r = endpoint::block_results::v0_34::DialectResponse::from_string(content);
+                assert!(r.is_ok(), "block_results_at_height_12791634: {r:?}");
+            },
+            _ => {
+                panic!("unhandled incoming fixture: {file_name}");
+            },
+        }
+    }
+}

--- a/rpc/tests/dydx_fixtures/incoming/block_results_at_height_12791634.json
+++ b/rpc/tests/dydx_fixtures/incoming/block_results_at_height_12791634.json
@@ -54,16 +54,6 @@
       }
     ],
     "validator_updates": [
-      {
-        "pub_key": {
-          "Sum": {
-            "type": "tendermint.crypto.PublicKey_Secp256K1",
-            "value": {
-              "secp256k1": "CgZzZW5kZXISK2R5ZHgxbHR5YzZ5NHNrY2x6YWZ2cHpucHQycWp3bWZ3Z3NuZHA0NThybXAYAQ=="
-            }
-          }
-        }
-      }
     ],
     "consensus_param_updates": null,
     "app_hash": null

--- a/rpc/tests/dydx_fixtures/incoming/block_results_at_height_12791634.json
+++ b/rpc/tests/dydx_fixtures/incoming/block_results_at_height_12791634.json
@@ -1,0 +1,71 @@
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "height": "12791634",
+    "txs_results": [
+      {
+        "code": 0,
+        "data": "ChAIgICAAhD///////////8BEg4IoI0GEgQIgMYKGICAQBoJCgdlZDI1NTE5IgA=",
+        "log": "",
+        "info": "",
+        "gas_wanted": "0",
+        "gas_used": "0",
+        "events": [],
+        "codespace": ""
+      }
+    ],
+    "finalize_block_events": [
+      {
+        "attributes": [
+          {
+            "key": "",
+            "value": "\n0/dydxprotocol.clob.MsgProposedOperationsResponse",
+            "index": false
+          }
+        ]
+      },
+      {
+        "attributes": [
+          {
+            "key": "",
+            "value": "\n2/dydxprotocol.bridge.MsgAcknowledgeBridgesResponse",
+            "index": false
+          }
+        ]
+      },
+      {
+        "attributes": [
+          {
+            "key": "",
+            "value": "\n3/dydxprotocol.perpetuals.MsgAddPremiumVotesResponse",
+            "index": false
+          }
+        ]
+      },
+      {
+        "attributes": [
+          {
+            "key": "",
+            "value": "\n2/dydxprotocol.prices.MsgUpdateMarketPricesResponse",
+            "index": false
+          }
+        ]
+      }
+    ],
+    "validator_updates": [
+      {
+        "pub_key": {
+          "Sum": {
+            "type": "tendermint.crypto.PublicKey_Secp256K1",
+            "value": {
+              "secp256k1": "CgZzZW5kZXISK2R5ZHgxbHR5YzZ5NHNrY2x6YWZ2cHpucHQycWp3bWZ3Z3NuZHA0NThybXAYAQ=="
+            }
+          }
+        }
+      }
+    ],
+    "consensus_param_updates": null,
+    "app_hash": null
+  }
+}

--- a/tendermint/src/abci/event.rs
+++ b/tendermint/src/abci/event.rs
@@ -18,7 +18,7 @@ pub struct Event {
     ///
     /// Tendermint calls this the `type`, but we use `kind` to avoid confusion
     /// with Rust types and follow Rust conventions.
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub kind: String,
 
     /// A list of [`EventAttribute`]s describing the event.


### PR DESCRIPTION
Fixes https://github.com/informalsystems/tendermint-rs/issues/1415

* [X] Referenced an issue explaining the need for the change
* [X] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [x] Added entry in `.changelog/`
