### PR TITLE
proto: 🧪 upgrade to tonic 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v0.37.0
+
+### IMPROVEMENTS
+
+- `[tendermint-proto]` upgrades its tonic dependency to tonic@0.11.
+  ([\#1422](https://github.com/informalsystems/tendermint-rs/pull/1422))
+
 ## v0.36.0
 
 This release brings substantial performance improvements to the voting power computation within the light client, improves the handling of misformed blocks (eg. with empty `last_commit` on non-first block) when decoding them from Protobuf or RPC responses, and adds missing `serde` derives on some Protobuf definitions.

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -30,7 +30,7 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 subtle-encoding = { version = "0.5", default-features = false, features = ["hex", "base64", "alloc"] }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 flex-error = { version = "0.4.4", default-features = false }
-tonic = { version = "0.10", optional = true }
+tonic = { version = "0.11", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
this upgrades tonic from `0.10` to `0.11`. no more, no less!