### PR TITLE
light-client-verifier: 🌱 restore `verify_commit()` interface

### DIFF
--- a/.changelog/unreleased/breaking-changes/1423-verify-commit-restore.md
+++ b/.changelog/unreleased/breaking-changes/1423-verify-commit-restore.md
@@ -1,0 +1,5 @@
+- `[tendermint-light-client-verifier]` Restores the commit verification interfaces of `PredicateVerifier<P, C, V>` from `<= 0.35.0`.
+  * `verify_commit(&self. untrusted: &UntrustedBlockState<'_>)` is restored, as in <= 0.35.0.
+  * `verify_commit(&self, untrusted: &UntrustedBlockState<'_>, trusted: &TrustedBlockState<'_>,)` introduced in 0.36.0 is renamed to `verify_commit_against_trusted`.
+  The performance improvements made in the `0.36.0` release are still intact.
+  ([\#1423](https://github.com/informalsystems/tendermint-rs/pull/1423))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # CHANGELOG
 
-## v0.37.0
-
-### BREAKING CHANGES
-
-- `[tendermint-light-client-verifier]` restores the commit verification
-  interfaces of `PredicateVerifier<P, C, V>` from `<= 0.35.0`. The performance
-  improvements made in the `0.36.0` release are still intact.
-  ([\#1423](https://github.com/informalsystems/tendermint-rs/pull/1423))
-
 ## v0.36.0
 
 This release brings substantial performance improvements to the voting power computation within the light client, improves the handling of misformed blocks (eg. with empty `last_commit` on non-first block) when decoding them from Protobuf or RPC responses, and adds missing `serde` derives on some Protobuf definitions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.37.0
+
+### BREAKING CHANGES
+
+- `[tendermint-light-client-verifier]` restores the commit verification
+  interfaces of `PredicateVerifier<P, C, V>` from `<= 0.35.0`. The performance
+  improvements made in the `0.36.0` release are still intact.
+  ([\#1423](https://github.com/informalsystems/tendermint-rs/pull/1423))
+
 ## v0.36.0
 
 This release brings substantial performance improvements to the voting power computation within the light client, improves the handling of misformed blocks (eg. with empty `last_commit` on non-first block) when decoding them from Protobuf or RPC responses, and adds missing `serde` derives on some Protobuf definitions.

--- a/light-client-verifier/src/verifier.rs
+++ b/light-client-verifier/src/verifier.rs
@@ -209,10 +209,24 @@ where
         Verdict::Success
     }
 
+    /// Verify that more than 2/3 of the validators correctly committed the block.
+    ///
+    /// Use [`PredicateVerifier::verify_commit_against_trusted()`] to also verify that there is
+    /// enough overlap between validator sets.
+    pub fn verify_commit(&self, untrusted: &UntrustedBlockState<'_>) -> Verdict {
+        verdict!(self.predicates.has_sufficient_signers_overlap(
+            untrusted.signed_header,
+            untrusted.validators,
+            &self.voting_power_calculator,
+        ));
+
+        Verdict::Success
+    }
+
     /// Verify that a) there is enough overlap between the validator sets of the
     /// trusted and untrusted blocks and b) more than 2/3 of the validators
     /// correctly committed the block.
-    pub fn verify_commit(
+    pub fn verify_commit_against_trusted(
         &self,
         untrusted: &UntrustedBlockState<'_>,
         trusted: &TrustedBlockState<'_>,
@@ -288,7 +302,7 @@ where
         ensure_verdict_success!(self.verify_validator_sets(&untrusted));
         ensure_verdict_success!(self.validate_against_trusted(&untrusted, &trusted, options, now));
         ensure_verdict_success!(self.check_header_is_from_past(&untrusted, options, now));
-        ensure_verdict_success!(self.verify_commit(&untrusted, &trusted, options));
+        ensure_verdict_success!(self.verify_commit_against_trusted(&untrusted, &trusted, options));
 
         Verdict::Success
     }
@@ -305,7 +319,7 @@ where
     ) -> Verdict {
         ensure_verdict_success!(self.verify_validator_sets(&untrusted));
         ensure_verdict_success!(self.validate_against_trusted(&untrusted, &trusted, options, now));
-        ensure_verdict_success!(self.verify_commit(&untrusted, &trusted, options));
+        ensure_verdict_success!(self.verify_commit_against_trusted(&untrusted, &trusted, options));
         Verdict::Success
     }
 }


### PR DESCRIPTION
in #1410, alterations were made to the `PredicateVerifier<P, C, V>` to improve performance when verifying commits.

specifically, a call to
`verify_commit_against_trusted(untrusted, trusted, options)` will now make use of new internal interfaces that check validator signatures and signer overlap at the same time.

this is a worthwhile performance improvement, but in the process, it made changes to the public interface of `PredicateVerifier<P, C, V>` that breaks some use cases. as i understand it, there is no strict need to remove the other public interface from the verifier. those that call `verify_commit_against_trusted` can still receive a performance boost, but calling `verify_commit` on just the untrusted state should still work after those changes.

so, this commit restores `verify_commit(untrusted)`, and keeps `verify_commit_against_trusted(untrusted, trusted, options)` under its previous name.

<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.
