### PR TITLE
ci: 🦀 fix nightly `cargo test-all-features`

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,6 +1,6 @@
 //! tendermint-proto library gives the developer access to the Tendermint proto-defined structs.
 
-#![cfg_attr(not(any(feature = "grpc-server", feature = "grpc-client")), no_std)]
+#![cfg_attr(not(any(feature = "grpc-server")), no_std)]
 #![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant)]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
example: https://github.com/informalsystems/tendermint-rs/actions/runs/9181862633/job/25249544213?pr=1423

```
 error: unexpected `cfg` condition value: `grpc-client`
 --> proto/src/lib.rs:3:46
  |
3 | #![cfg_attr(not(any(feature = "grpc-server", feature = "grpc-client")), no_std)]
  |                                              ^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: expected values for `feature` are: `default`, `grpc`, `grpc-server`, `tonic`
  = help: consider adding `grpc-client` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

i noticed this error in ci for #1423, and #1422.