### PR TITLE
fix(tendermint): Make `FinalizeBlock::validator_updates` nullable when deserializing

### DIFF
--- a/.changelog/unreleased/improvements/1428-finalizeblock-deserialization.md
+++ b/.changelog/unreleased/improvements/1428-finalizeblock-deserialization.md
@@ -1,0 +1,1 @@
+- `[tendermint]` Fix `FinalizeBlock::validator_updates` deserialization as `nullable` ([\#1428](https://github.com/informalsystems/tendermint-rs/pull/1428))

--- a/tendermint/src/abci/response/finalize_block.rs
+++ b/tendermint/src/abci/response/finalize_block.rs
@@ -16,6 +16,7 @@ pub struct FinalizeBlock {
     pub tx_results: Vec<ExecTxResult>,
     /// A list of updates to the validator set.
     /// These will reflect the validator set at current height + 2.
+    #[serde(with = "serializers::nullable")]
     pub validator_updates: Vec<validator::Update>,
     /// Updates to the consensus params, if any.
     #[serde(default)]


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->
Fixes: #1427 
* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
