### PR TITLE
feat: add a way to provide a custom User-Agent

### DIFF
--- a/.changelog/unreleased/improvements/1425-add-http-client-user-agent.md
+++ b/.changelog/unreleased/improvements/1425-add-http-client-user-agent.md
@@ -1,0 +1,2 @@
+* `[tendermint-rpc]` Add a way to specify custom User-Agent for HttpClient
+  ([#1425](https://github.com/informalsystems/tendermint-rs/issues/1425))

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -61,6 +61,7 @@ pub struct Builder {
     url: HttpClientUrl,
     compat: CompatMode,
     proxy_url: Option<HttpClientUrl>,
+    user_agent : Option<String>,
     timeout: Duration,
 }
 
@@ -93,10 +94,16 @@ impl Builder {
         self
     }
 
+    /// Specify the custom User-Agent header the client.
+    pub fn user_agent(mut self, agent: String) -> Self {
+        self.user_agent = Some(agent);
+        self
+    }
+
     /// Try to create a client with the options specified for this builder.
     pub fn build(self) -> Result<HttpClient, Error> {
         let builder = reqwest::ClientBuilder::new()
-            .user_agent(USER_AGENT)
+            .user_agent(self.user_agent.unwrap_or(USER_AGENT.to_string()))
             .timeout(self.timeout);
         let inner = match self.proxy_url {
             None => builder.build().map_err(Error::http)?,
@@ -152,6 +159,7 @@ impl HttpClient {
             url,
             compat: Default::default(),
             proxy_url: None,
+            user_agent: None,
             timeout: Duration::from_secs(30),
         }
     }

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -61,7 +61,7 @@ pub struct Builder {
     url: HttpClientUrl,
     compat: CompatMode,
     proxy_url: Option<HttpClientUrl>,
-    user_agent : Option<String>,
+    user_agent: Option<String>,
     timeout: Duration,
 }
 


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

Fixes https://github.com/informalsystems/tendermint-rs/issues/1425.

Need this to be able to specify a custom User-Agent for Hermes requests.

I am unsure how to test it properly with Hermes though; if someone can give me any hint on how to compile Hermes with this version of tendermint-rpc, I'd appreciate that.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
