### PR TITLE
tendermint:  relax `Block` validation rules to avoid assumptions on initial height

### DIFF
--- a/.changelog/unreleased/breaking-changes/1435-block-domain-type.md
+++ b/.changelog/unreleased/breaking-changes/1435-block-domain-type.md
@@ -1,0 +1,2 @@
+- tendermint: relax validation rules on `Block`
+  ([\#1435](https://github.com/informalsystems/tendermint-rs/issues/1435))


### PR DESCRIPTION
Fix #1435, by removing extra-validation done on the `Block` domain type.

<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
