### PR TITLE
fix: Bump `prost` and `prost-types` to latest versions in `tendermint` crate

### DIFF
--- a/.changelog/unreleased/breaking-changes/1446-fix-prost-version.md
+++ b/.changelog/unreleased/breaking-changes/1446-fix-prost-version.md
@@ -1,4 +1,4 @@
-- `[tendermint]` Bump `prost` and `prost-types` to their latest versions in tendermint crate.
+- `[tendermint]` Bump `prost` and `prost-types` to their latest versions in the `tendermint` crate.
   This was missed in [#1444](https://github.com/informalsystems/tendermint-rs/pull/1444),
   which only updated the two dependencies in `tendermint-rpc`, leading to duplicate versions
   of both crates to be present in the dependency graph.

--- a/.changelog/unreleased/breaking-changes/1446-fix-prost-version.md
+++ b/.changelog/unreleased/breaking-changes/1446-fix-prost-version.md
@@ -1,0 +1,5 @@
+- `[tendermint]` Bump `prost` and `prost-types` to their latest versions in tendermint crate.
+  This was missed in [#1444](https://github.com/informalsystems/tendermint-rs/pull/1444),
+  which only updated the two dependencies in `tendermint-rpc`, leading to duplicate versions
+  of both crates to be present in the dependency graph.
+  ([#1446](https://github.com/informalsystems/tendermint-rs/pull/1446))

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -35,8 +35,8 @@ ed25519 = { version = "2", default-features = false, features = ["alloc"] }
 futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.3", default-features = false }
-prost = { version = "0.12", default-features = false }
-prost-types = { version = "0.12", default-features = false }
+prost = { version = "0.13", default-features = false }
+prost-types = { version = "0.13", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }


### PR DESCRIPTION
This was missed in #1444.