### PR TITLE
proto: remove `prost-types` dependency

### DIFF
--- a/.changelog/unreleased/bug-fixes/1457-remove-prost-types-dep.md
+++ b/.changelog/unreleased/bug-fixes/1457-remove-prost-types-dep.md
@@ -1,0 +1,3 @@
+- Remove dependency on `prost-types` as it is not needed anymore now that
+  [#1452](https://github.com/informalsystems/tendermint-rs/pull/1452) has landed
+  ([\#1457](https://github.com/informalsystems/tendermint-rs/pull/1457))

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -26,8 +26,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 all-features = true
 
 [dependencies]
-prost = { version = "0.13", default-features = false }
-prost-types = { version = "0.13", default-features = false }
+prost = { version = "0.13", default-features = false, features = ["derive"] }
 bytes = { version = "1.0", default-features = false, features = ["serde"]}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_bytes = { version = "0.11", default-features = false, features = ["alloc"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -36,7 +36,6 @@ futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.3", default-features = false }
 prost = { version = "0.13", default-features = false }
-prost-types = { version = "0.13", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false }


### PR DESCRIPTION
Now that #1452 has landed `prost-types` isn't used.

This removes it as a dependency.