### PR TITLE
export abci::event::v0_37 from abci module

### DIFF
--- a/.changelog/unreleased/bug-fixes/1476-export-v0_37-abci-events.md
+++ b/.changelog/unreleased/bug-fixes/1476-export-v0_37-abci-events.md
@@ -1,2 +1,2 @@
 - [tendermint] export `abci::event::v0_37` to construct `EventAttribute::V037` variants.
-  ([\#1479](https://github.com/informalsystems/tendermint-rs/pull/1479))
+  ([\#1479](https://github.com/informalsystems/tendermint-rs/pull/1479), ([\#1480](https://github.com/informalsystems/tendermint-rs/pull/1480))

--- a/tendermint/src/abci.rs
+++ b/tendermint/src/abci.rs
@@ -54,6 +54,7 @@ pub use crate::v0_38::abci::response::{
 };
 
 pub use event::v0_34;
+pub use event::v0_37;
 pub use event::{Event, EventAttribute, EventAttributeIndexExt, TypedEvent};
 
 #[doc(inline)]


### PR DESCRIPTION
Exporst `crate::abci::event::v0_37` from its parent module `crate::abci`. This is fixing an oversight in https://github.com/informalsystems/tendermint-rs/pull/1479 that didn't pay attention to `crate::abci::event` being private.

* [x] Referenced an issue explaining the need for the change
* ~[ ] Updated all relevant documentation in docs~
* ~[ ] Updated all code comments where relevant~
* ~[ ] Wrote tests~
* [x] Added entry in `.changelog/`
