### PR TITLE
fix: bump serde-wasm-bindgen, js-sys to fix broken compile

### DIFF
--- a/.changelog/unreleased/bug-fixes/1481-bump-deps-to-fix-broken-compile.md
+++ b/.changelog/unreleased/bug-fixes/1481-bump-deps-to-fix-broken-compile.md
@@ -1,0 +1,2 @@
+- [tendermint-light-client-js] bump `serde-wasm-bindgen` to `v0.6.5` and `js-sys` to `=v0.3.70` to
+  fix compilation failure of `wasm-bindgen-test`. ([\#1481](https://github.com/informalsystems/tendermint-rs/pull/1481))

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -25,7 +25,8 @@ serde_json = { version = "1.0", default-features = false }
 tendermint = { version = "0.40.0", default-features = false, path = "../tendermint" }
 tendermint-light-client-verifier = { version = "0.40.0", features = ["rust-crypto"], default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }
-serde-wasm-bindgen = { version = "0.4.5", default-features = false }
+serde-wasm-bindgen = { version = "0.6.5", default-features = false }
+js-sys = { version = "=0.3.70", default-features = false }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
Fixes failing compilation of `wasm-bindgest-test` by bumping `serde-wasm-bindgen@v0.6.5` and `js-sys@=v0.3.70` (see compilation error at the bottom of these patch notes).

* [ ] ~Referenced an issue explaining the need for the change~
* [ ] ~Updated all relevant documentation in docs~
* [ ] ~Updated all code comments where relevant~
* [ ] ~Wrote tests~ (formerly broken compiles work now)
* [x] Added entry in `.changelog/`


<details><summary>Compilation errors seen in CI:</summary>

```
error[E0152]: found duplicate lang item `panic_impl`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-test-0.3.49/src/rt/mod.rs:321:9
    |
321 | /         fn panic_handler(panic_info: &core::panic::PanicInfo<'_>) -> ! {
322 | |             panic_handling(panic_info.to_string());
323 | |             core::arch::wasm32::unreachable();
324 | |         }
    | |_________^
    |
    = note: the lang item is first defined in crate `std` (which `js_sys` depends on)
    = note: first definition in `std` loaded from /home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib/libstd-89e63d1941b447bf.rlib
    = note: second definition in the local crate (`wasm_bindgen_test`)

For more information about this error, try `rustc --explain E0152`.
error: could not compile `wasm-bindgen-test` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Compilation of your program failed
Caused by: Compilation of your program failed
Caused by: failed to execute `cargo build`: exited with exit status: 101
  full command: cd "./light-client-js/" && "cargo" "build" "--tests" "--target" "wasm32-unknown-unknown"
```

</details>
