### PR TITLE
Prepare a patch release `v0.40.1`

### DIFF
--- a/.changelog/0.40.1/bug-fixes/1476-export-v0_37-abci-events.md
+++ b/.changelog/0.40.1/bug-fixes/1476-export-v0_37-abci-events.md
@@ -1,0 +1,2 @@
+- [tendermint] export `abci::event::v0_37` to construct `EventAttribute::V037` variants.
+  ([\#1479](https://github.com/informalsystems/tendermint-rs/pull/1479), ([\#1480](https://github.com/informalsystems/tendermint-rs/pull/1480))

--- a/.changelog/0.40.1/bug-fixes/1481-bump-deps-to-fix-broken-compile.md
+++ b/.changelog/0.40.1/bug-fixes/1481-bump-deps-to-fix-broken-compile.md
@@ -1,0 +1,2 @@
+- [tendermint-light-client-js] bump `serde-wasm-bindgen` to `v0.6.5` and `js-sys` to `=v0.3.70` to
+  fix compilation failure of `wasm-bindgen-test`. ([\#1481](https://github.com/informalsystems/tendermint-rs/pull/1481))

--- a/.changelog/0.40.1/summary.md
+++ b/.changelog/0.40.1/summary.md
@@ -1,0 +1,3 @@
+*December 24th, 2024*
+
+This is a bug fix release that address omissions in the `v0.40.0` release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 0.40.1
+
+*December 24th, 2024*
+
+This is a bug fix release that address omissions in the `v0.40.0` release.
+
+### BUG FIXES
+
+- [tendermint] export `abci::event::v0_37` to construct `EventAttribute::V037` variants.
+  ([\#1479](https://github.com/informalsystems/tendermint-rs/pull/1479), ([\#1480](https://github.com/informalsystems/tendermint-rs/pull/1480))
+- [tendermint-light-client-js] bump `serde-wasm-bindgen` to `v0.6.5` and `js-sys` to `=v0.3.70` to
+  fix compilation failure of `wasm-bindgen-test`. ([\#1481](https://github.com/informalsystems/tendermint-rs/pull/1481))
+
 ## v0.40.0
 
 *October 23rd, 2024*

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-abci"
-version     = "0.40.0"
+version     = "0.40.1"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 license     = "Apache-2.0"
@@ -33,7 +33,7 @@ binary = [
 [dependencies]
 bytes = { version = "1.0", default-features = false }
 prost = { version = "0.13", default-features = false }
-tendermint-proto = { version = "0.40.0", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.40.1", default-features = false, path = "../proto" }
 tracing = { version = "0.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 structopt = { version = "0.3", optional = true, default-features = false }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-config"
-version    = "0.40.0" # Also update depending crates (rpc, light-node, ..) when bumping this.
+version    = "0.40.1" # Also update depending crates (rpc, light-node, ..) when bumping this.
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/main/tendermint"
@@ -24,7 +24,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-tendermint = { version = "0.40.0", default-features = false, features = ["rust-crypto"], path = "../tendermint" }
+tendermint = { version = "0.40.1", default-features = false, features = ["rust-crypto"], path = "../tendermint" }
 flex-error = { version = "0.4.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/light-client-cli/Cargo.toml
+++ b/light-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client-cli"
-version    = "0.40.0"
+version    = "0.40.1"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -23,10 +23,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-tendermint = { version = "0.40.0", path = "../tendermint" }
-tendermint-rpc = { version = "0.40.0", path = "../rpc", features = ["http-client"] }
-tendermint-light-client = { version = "0.40.0", path = "../light-client" }
-tendermint-light-client-detector = { version = "0.40.0", path = "../light-client-detector" }
+tendermint = { version = "0.40.1", path = "../tendermint" }
+tendermint-rpc = { version = "0.40.1", path = "../rpc", features = ["http-client"] }
+tendermint-light-client = { version = "0.40.1", path = "../light-client" }
+tendermint-light-client-detector = { version = "0.40.1", path = "../light-client-detector" }
 
 clap = { version = "4.1.8", features = ["derive"] }
 color-eyre = "0.6.2"

--- a/light-client-detector/Cargo.toml
+++ b/light-client-detector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client-detector"
-version    = "0.40.0"
+version    = "0.40.1"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -23,10 +23,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-tendermint = { version = "0.40.0", path = "../tendermint" }
-tendermint-rpc = { version = "0.40.0", path = "../rpc", features = ["http-client"] }
-tendermint-proto = { version = "0.40.0", path = "../proto" }
-tendermint-light-client = { version = "0.40.0", path = "../light-client" }
+tendermint = { version = "0.40.1", path = "../tendermint" }
+tendermint-rpc = { version = "0.40.1", path = "../rpc", features = ["http-client"] }
+tendermint-proto = { version = "0.40.1", path = "../proto" }
+tendermint-light-client = { version = "0.40.1", path = "../light-client" }
 
 crossbeam-channel = { version = "0.5.11", default-features = false }
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }

--- a/light-client-js/Cargo.toml
+++ b/light-client-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-light-client-js"
-version     = "0.40.0"
+version     = "0.40.1"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 license     = "Apache-2.0"
@@ -22,8 +22,8 @@ default = ["console_error_panic_hook"]
 [dependencies]
 serde = { version = "1.0", default-features = false, features = [ "derive" ] }
 serde_json = { version = "1.0", default-features = false }
-tendermint = { version = "0.40.0", default-features = false, path = "../tendermint" }
-tendermint-light-client-verifier = { version = "0.40.0", features = ["rust-crypto"], default-features = false, path = "../light-client-verifier" }
+tendermint = { version = "0.40.1", default-features = false, path = "../tendermint" }
+tendermint-light-client-verifier = { version = "0.40.1", features = ["rust-crypto"], default-features = false, path = "../light-client-verifier" }
 wasm-bindgen = { version = "0.2.63", default-features = false, features = [ "serde-serialize" ] }
 serde-wasm-bindgen = { version = "0.6.5", default-features = false }
 js-sys = { version = "=0.3.70", default-features = false }

--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client-verifier"
-version    = "0.40.0"
+version    = "0.40.1"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -27,7 +27,7 @@ default = ["rust-crypto", "flex-error/std"]
 rust-crypto = ["tendermint/rust-crypto"]
 
 [dependencies]
-tendermint = { version = "0.40.0", path = "../tendermint", default-features = false }
+tendermint = { version = "0.40.1", path = "../tendermint", default-features = false }
 
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }
 serde = { version = "1.0.106", default-features = false }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-light-client"
-version    = "0.40.0"
+version    = "0.40.1"
 edition    = "2021"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -35,9 +35,9 @@ unstable = ["rust-crypto"]
 mbt = ["rust-crypto"]
 
 [dependencies]
-tendermint = { version = "0.40.0", path = "../tendermint", default-features = false }
-tendermint-rpc = { version = "0.40.0", path = "../rpc", default-features = false }
-tendermint-light-client-verifier = { version = "0.40.0", path = "../light-client-verifier", default-features = false }
+tendermint = { version = "0.40.1", path = "../tendermint", default-features = false }
+tendermint-rpc = { version = "0.40.1", path = "../rpc", default-features = false }
+tendermint-light-client-verifier = { version = "0.40.1", path = "../light-client-verifier", default-features = false }
 
 contracts = { version = "0.6.2", default-features = false }
 crossbeam-channel = { version = "0.5.11", default-features = false, features = ["std"] }
@@ -57,7 +57,7 @@ regex = { version = "1.7.3" }
 
 [dev-dependencies]
 tendermint-testgen = { path = "../testgen", default-features = false }
-tendermint-light-client-verifier = { version = "0.40.0", path = "../light-client-verifier", features = ["rust-crypto"] }
+tendermint-light-client-verifier = { version = "0.40.1", path = "../light-client-verifier", features = ["rust-crypto"] }
 
 serde_json = { version = "1.0.51", default-features = false }
 gumdrop = { version = "0.8.0", default-features = false }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-p2p"
-version     = "0.40.0"
+version     = "0.40.1"
 edition     = "2021"
 license     = "Apache-2.0"
 repository  = "https://github.com/informalsystems/tendermint-rs"
@@ -44,9 +44,9 @@ aead = { version = "0.5", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 # path dependencies
-tendermint = { path = "../tendermint", version = "0.40.0", default-features = false }
-tendermint-proto = { path = "../proto", version = "0.40.0", default-features = false }
-tendermint-std-ext = { path = "../std-ext", version = "0.40.0", default-features = false }
+tendermint = { path = "../tendermint", version = "0.40.1", default-features = false }
+tendermint-proto = { path = "../proto", version = "0.40.1", default-features = false }
+tendermint-std-ext = { path = "../std-ext", version = "0.40.1", default-features = false }
 
 # optional dependencies
 prost-derive = { version = "0.13", optional = true }

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-pbt-gen"
-version     = "0.40.0"
+version     = "0.40.1"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 license     = "Apache-2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-proto"
-version    = "0.40.0"
+version    = "0.40.1"
 authors    = ["Informal Systems <hello@informal.systems>"]
 edition    = "2021"
 license    = "Apache-2.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-rpc"
-version    = "0.40.0"
+version    = "0.40.1"
 edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
@@ -64,9 +64,9 @@ mock-client = [
 ]
 
 [dependencies]
-tendermint = { version = "0.40.0", default-features = false, path = "../tendermint" }
-tendermint-config = { version = "0.40.0", path = "../config", default-features = false }
-tendermint-proto = { version = "0.40.0", path = "../proto", default-features = false }
+tendermint = { version = "0.40.1", default-features = false, path = "../tendermint" }
+tendermint-config = { version = "0.40.1", path = "../config", default-features = false }
+tendermint-proto = { version = "0.40.1", path = "../proto", default-features = false }
 
 async-trait = { version = "0.1", default-features = false }
 bytes = { version = "1.0", default-features = false }
@@ -97,7 +97,7 @@ tracing = { version = "0.1", optional = true, default-features = false }
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = ["fmt"] }
 
 [dev-dependencies]
-tendermint = { version = "0.40.0", default-features = false, path = "../tendermint", features = ["secp256k1"] }
+tendermint = { version = "0.40.1", default-features = false, path = "../tendermint", features = ["secp256k1"] }
 http = { version = "1", default-features = false, features = ["std"] }
 lazy_static = { version = "1.4.0", default-features = false }
 tokio-test = { version = "0.4", default-features = false }

--- a/std-ext/Cargo.toml
+++ b/std-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-std-ext"
-version    = "0.40.0"
+version    = "0.40.1"
 edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.40.0" # Also update depending crates (rpc, light-node, etc..) when bumping this .
+version    = "0.40.1" # Also update depending crates (rpc, light-node, etc..) when bumping this .
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/main/tendermint"
@@ -43,7 +43,7 @@ serde_repr = { version = "0.1", default-features = false }
 signature = { version = "2", default-features = false, features = ["alloc"] }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
-tendermint-proto = { version = "0.40.0", default-features = false, path = "../proto" }
+tendermint-proto = { version = "0.40.1", default-features = false, path = "../proto" }
 time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tendermint-test"
 description = "Tendermint workspace tests and common utilities for testing."
-version     = "0.40.0"
+version     = "0.40.1"
 edition     = "2021"
 license     = "Apache-2.0"
 categories  = ["development", "test", "tools"]

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "tendermint-testgen"
-version     = "0.40.0"
+version     = "0.40.1"
 authors     = ["Informal Systems <hello@informal.systems>"]
 edition     = "2021"
 readme      = "README.md"
@@ -16,7 +16,7 @@ description = """
     """
 
 [dependencies]
-tendermint = { version = "0.40.0", path = "../tendermint", features = ["clock"] }
+tendermint = { version = "0.40.1", path = "../tendermint", features = ["clock"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 ed25519-consensus = { version = "2", default-features = false }

--- a/tools/abci-test/Cargo.toml
+++ b/tools/abci-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abci-test"
-version = "0.40.0"
+version = "0.40.1"
 authors = ["Informal Systems <hello@informal.systems>"]
 edition = "2021"
 description = """
@@ -14,9 +14,9 @@ description = """
 flex-error = { version = "0.4.4", default-features = false, features = ["std"] }
 futures = "0.3"
 structopt = "0.3"
-tendermint = { version = "0.40.0", path = "../../tendermint" }
-tendermint-config = { version = "0.40.0", path = "../../config" }
-tendermint-rpc = { version = "0.40.0", path = "../../rpc", features = [ "websocket-client" ] }
+tendermint = { version = "0.40.1", path = "../../tendermint" }
+tendermint-config = { version = "0.40.1", path = "../../config" }
+tendermint-rpc = { version = "0.40.1", path = "../../rpc", features = [ "websocket-client" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { version = "1.20", features = ["full"] }

--- a/tools/kvstore-test/Cargo.toml
+++ b/tools/kvstore-test/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 [dev-dependencies]
 futures = "0.3"
 sha2 = "0.10"
-tendermint = { version = "0.40.0", path = "../../tendermint" }
-tendermint-light-client = { version = "0.40.0", path = "../../light-client", features = ["unstable"] }
-tendermint-rpc = { version = "0.40.0", path = "../../rpc", features = [ "http-client", "websocket-client" ] }
+tendermint = { version = "0.40.1", path = "../../tendermint" }
+tendermint-light-client = { version = "0.40.1", path = "../../light-client", features = ["unstable"] }
+tendermint-rpc = { version = "0.40.1", path = "../../rpc", features = [ "http-client", "websocket-client" ] }
 tokio = { version = "1.0", features = [ "rt-multi-thread", "macros" ] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tools/rpc-probe/Cargo.toml
+++ b/tools/rpc-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint-rpc-probe"
-version    = "0.40.0"
+version    = "0.40.1"
 authors    = ["Informal Systems <hello@informal.systems>"]
 edition    = "2021"
 license    = "Apache-2.0"


### PR DESCRIPTION
This prepares a patch release. Open to make this a major one since this contains a bump in `light-client-js`. I am not sure it's necessary though. I don't understand the pin on `js-sys`. I can't see how its absence breaks `no_std`.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Added entry in `.changelog/`
