### PR TITLE
feat: allow using http-client feature in wasm32-unknown-unknown target

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -45,7 +45,10 @@ cli = [
 http-client = [
   "futures",
   "reqwest",
+  "tokio/sync",
   "tokio/macros",
+  "tokio/time",
+  "wasmtimer/tokio",
   "tracing"
 ]
 websocket-client = [
@@ -70,6 +73,7 @@ tendermint-proto = { version = "0.40.1", path = "../proto", default-features = f
 
 async-trait = { version = "0.1", default-features = false }
 bytes = { version = "1.0", default-features = false }
+cfg-if = "1.0.0"
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 peg = { version = "0.8", default-features = false }
 pin-project = { version = "1.0.1", default-features = false }
@@ -92,9 +96,13 @@ async-tungstenite = { version = "0.24", default-features = false, features = ["t
 futures = { version = "0.3", optional = true, default-features = false }
 reqwest = { version = "0.11.20", optional = true, default-features = false, features = ["rustls-tls-native-roots"] }
 structopt = { version = "0.3", optional = true, default-features = false }
-tokio = { version = "1.0", optional = true, default-features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1.0", optional = true, default-features = false }
 tracing = { version = "0.1", optional = true, default-features = false }
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = ["fmt"] }
+
+[target."cfg(target_arch = \"wasm32\")".dependencies.wasmtimer]
+version = "0.4.1"
+optional = true
 
 [dev-dependencies]
 tendermint = { version = "0.40.1", default-features = false, path = "../tendermint", features = ["secp256k1"] }

--- a/rpc/src/client/transport/router.rs
+++ b/rpc/src/client/transport/router.rs
@@ -91,6 +91,7 @@ impl SubscriptionRouter {
 
     /// Immediately add a new subscription to the router without waiting for
     /// confirmation.
+    #[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
     pub fn add(&mut self, id: impl ToString, query: impl ToString, tx: SubscriptionTx) {
         let query = query.to_string();
         let subs_for_query = match self.subscriptions.get_mut(&query) {
@@ -105,6 +106,7 @@ impl SubscriptionRouter {
     }
 
     /// Removes all the subscriptions relating to the given query.
+    #[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
     pub fn remove_by_query(&mut self, query: impl ToString) -> usize {
         self.subscriptions
             .remove(&query.to_string())

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -18,10 +18,10 @@ type HttpStatusCode = reqwest::StatusCode;
 #[cfg(not(feature = "reqwest"))]
 type HttpStatusCode = core::num::NonZeroU16;
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
 type JoinError = flex_error::DisplayOnly<tokio::task::JoinError>;
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(any(not(feature = "tokio"), target_arch = "wasm32"))]
 type JoinError = flex_error::NoSource;
 
 #[cfg(feature = "async-tungstenite")]


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

This PR allows using the `http-client` and thus the `Client` under `wasm32-unknown-unknown` target. Previously this wasn't possible due to `rt-multi-thread` `tokio` feature being pulled (that is not supported on that target) and the `async_trait` enforcing the `Send` bound.


* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
