### PR TITLE
fix: strip auth info from url to avoid double authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### BUG FIXES
+
+- [tendermint-rpc] strip auth info from url to avoid double authorization header [\#1494](https://github.com/informalsystems/tendermint-rs/pull/1494)
+
 ## 0.40.1
 
 *December 24th, 2024*

--- a/rpc/src/client/transport/auth.rs
+++ b/rpc/src/client/transport/auth.rs
@@ -40,6 +40,13 @@ pub fn authorize(url: &Url) -> Option<Authorization> {
     }
 }
 
+pub fn strip_authority(url: Url) -> Url {
+    let mut stripped = url;
+    stripped.set_username("").unwrap();
+    stripped.set_password(None).unwrap();
+    stripped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,5 +69,17 @@ mod tests {
         let uri = "http://toto:tata@example.com".parse().unwrap();
         let base64 = "dG90bzp0YXRh".to_string();
         assert_eq!(authorize(&uri), Some(Authorization::Basic(base64)));
+    }
+
+    #[test]
+    fn strip_authority_absent() {
+        let uri = "http://example.com".parse().unwrap();
+        assert_eq!(strip_authority(uri), "http://example.com".parse().unwrap());
+    }
+
+    #[test]
+    fn strip_auth_username_password() {
+        let uri = "http://toto:tata@example.com".parse().unwrap();
+        assert_eq!(strip_authority(uri), "http://example.com".parse().unwrap());
     }
 }

--- a/rpc/src/client/transport/http.rs
+++ b/rpc/src/client/transport/http.rs
@@ -209,7 +209,7 @@ impl HttpClient {
 
         let mut builder = self
             .inner
-            .post(self.url.clone())
+            .post(auth::strip_authority(self.url.clone()))
             .header(header::CONTENT_TYPE, "application/json")
             .body(request_body.into_bytes());
 
@@ -503,5 +503,11 @@ mod tests {
         let req = HttpClient::build_request(&client, abci_info::Request).unwrap();
 
         assert_eq!(authorization(&req), Some("Basic dG90bzp0YXRh"));
+        let num_auth_headers = req
+            .headers()
+            .iter()
+            .filter(|h| h.0 == AUTHORIZATION)
+            .count();
+        assert_eq!(num_auth_headers, 1);
     }
 }


### PR DESCRIPTION
<!--

Thanks for filing a PR!

Before hitting the button, please check the following items.  Please note that
every non-trivial PR must reference an issue that explains the changes in the
PR.

Please also make sure you've targeted the correct branch with your PR. See the
contributing guidelines for details.

-->

Closes: #1495

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Added entry in `.changelog/`
