### PR TITLE
Fix integration test links in rpc/README.md

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -105,7 +105,7 @@ traits.
 ## Testing
 
 The RPC types are directly tested through the [integration
-tests](./tests/integration.rs). These tests use fixtures taken from running
+tests](../tools/kvstore-test/tests/tendermint.rs). These tests use fixtures taken from running
 Tendermint nodes to ensure compatibility without needing access to a running
 node during testing. All of these fixtures were generated manually, and
 automatic regeneration of the fixtures is [on our roadmap][autogen-fixtures].
@@ -118,7 +118,7 @@ cargo test --all-features
 ```
 
 The RPC client is also indirectly tested through the [Tendermint integration
-tests](../tendermint/tests/integration.rs), which happens during
+tests](../tools/kvstore-test/tests/light-client.rs), which happens during
 [CI](../.github/workflows/test.yml). All of these tests require a running
 Tendermint node, and are therefore ignored by default. To run these tests
 locally:


### PR DESCRIPTION
Update broken links to integration test files in rpc/README.md. The previous links pointed to non-existent files (./tests/integration.rs and ../tendermint/tests/integration.rs). Updated links now correctly point to the actual integration test files in the tools/kvstore-test/tests directory.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
